### PR TITLE
Revert "remove duplicate yarn install step"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,14 @@ COPY package*.json *yarn* ./
 
 # Install npm depepndencies
 ENV PATH /app/node_modules/.bin:$PATH
+# RUN yarn && yarn cache clean --force
 
 USER root
 
 RUN apt-install.sh build-essential
+
+USER appuser
+RUN yarn && yarn cache clean --force
 
 USER root
 RUN apt-install.sh build-essential && \


### PR DESCRIPTION
This reverts commit 1ec5b771b51e1060c854da580916e56df9475b80.

I'm not sure why this is necessary, but the docker image doesn't build without these seemingly duplicate additions.