### PR TITLE
Change format for Api-Tokens header

### DIFF
--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -43,11 +43,20 @@ const client = new ApolloClient({
         }
       );
 
+      const serializeTokens = (tokens: object) => {
+        const entries = Object.entries(tokens);
+        const serializedTokens = entries.map(
+          ([key, value]) => `${key}=${value}`
+        );
+        const result = serializedTokens.join(';');
+        return result;
+      };
+
       const apiTokens = res.data;
 
       operation.setContext({
         headers: {
-          'Api-Tokens': JSON.stringify(apiTokens),
+          'Api-Tokens': serializeTokens(apiTokens),
         },
       });
     } catch (e) {

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -43,11 +43,16 @@ const client = new ApolloClient({
         }
       );
 
+      // token format: "key value;key value"
       const serializeTokens = (tokens: object) => {
-        const entries = Object.entries(tokens);
+        const entries = Object.entries(tokens); // object to array of tuples
+
+        // tuples to strings
         const serializedTokens = entries.map(
-          ([key, value]) => `${key}=${value}`
+          ([key, value]) => `${key} ${value}`
         );
+
+        // concatenate strings
         const result = serializedTokens.join(';');
         return result;
       };


### PR DESCRIPTION
Change Api-Tokens header format to match this: https://github.com/City-of-Helsinki/berth-federation-gateway/pull/5/.

After further consideration I'm not sure whether this change is a good idea. Keeping this PR in draft state for now.

Deserialize with:
```
const deserializeTokens = (payload: string) => {
  const serializedTokens = payload.split(';');
  const entries = serializedTokens.reduce((acc, tokenString) => {
    const [key, value] = tokenString.split(' ');
    acc[key] = value;
    return acc;
  }, {});
  return entries;
};
```