### PR TITLE
VEN-361 | Add git commit hook for graphql codegeneration

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,5 +1,5 @@
 module.exports = {
   hooks: {
-    "pre-commit": "yarn lint"
+    "pre-commit": "yarn pre-commit"
   }
 };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
-    "pre-commit": "yarn lint && yarn codegen"
+    "pre-commit": "yarn codegen && yarn lint"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berth-reservations-admin",
-  "version": "0.1.01",
+  "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ext js,ts,tsx src",
     "ci": "CI=true yarn test --verbose --runInBand --coverage",
+    "codegen": "yarn schema:download && yarn types:generate",
     "types:generate": "apollo codegen:generate --localSchemaFile=schema.json --target=typescript --includes=\"./src/**/*.ts\" --tagName=gql",
     "schema:download": "apollo service:download --endpoint=https://venepaikka-federation.test.kuva.hel.ninja/",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "deploy-storybook": "storybook-to-ghpages",
-    "pre-commit": "yarn lint"
+    "pre-commit": "yarn lint && yarn codegen"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "berth-reservations-admin",
-  "version": "0.1.0",
+  "version": "0.1.01",
   "private": true,
   "dependencies": {
     "@apollo/react-hooks": "^3.1.2",

--- a/schema.json
+++ b/schema.json
@@ -282,6 +282,33 @@
             "deprecationReason": null
           },
           {
+            "name": "claimableProfile",
+            "description": null,
+            "args": [
+              {
+                "name": "token",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "UUID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ProfileNode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "availabilityLevels",
             "description": null,
             "args": [],
@@ -1548,13 +1575,9 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
+              "kind": "SCALAR",
+              "name": "Boolean",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -2212,9 +2235,13 @@
             "description": null,
             "args": [],
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -6664,6 +6691,33 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "deleteProfile",
+            "description": null,
+            "args": [
+              {
+                "name": "id",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "ID",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "DeleteProfile",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -7417,9 +7471,13 @@
             "name": "emailType",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "EmailType",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "EmailType",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7458,9 +7516,13 @@
             "name": "phone",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7468,9 +7530,13 @@
             "name": "phoneType",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "PhoneType",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "PhoneType",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7509,9 +7575,13 @@
             "name": "address",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7519,9 +7589,13 @@
             "name": "postalCode",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7529,9 +7603,13 @@
             "name": "city",
             "description": null,
             "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7549,9 +7627,13 @@
             "name": "addressType",
             "description": null,
             "type": {
-              "kind": "ENUM",
-              "name": "AddressType",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "AddressType",
+                "ofType": null
+              }
             },
             "defaultValue": null
           },
@@ -7700,6 +7782,29 @@
             "type": {
               "kind": "OBJECT",
               "name": "ProfileNode",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "DeleteProfile",
+        "description": null,
+        "fields": [
+          {
+            "name": "ok",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Boolean",
               "ofType": null
             },
             "isDeprecated": false,


### PR DESCRIPTION
Update apollo remote schema and generate typings during git commits to catch errors caused by changed schema.

Possible future development: I'm considering switching apollo's codegenerator to [graphql-code-generator](https://graphql-code-generator.com/) as it seems to be much more flexible.