### PR TITLE
VEN-415 | use fonts from Helsinki Design System

### DIFF
--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -1,12 +1,15 @@
+@import '~hds-core/lib/helsinki.css';
 @import 'normalize';
 @import 'boxSizing';
 @import 'colours';
 
-body {
-  margin: 0;
-  font-family: HelsinkiGrotesk, Helvetica, Arial, 'MS Gothic', Meiryo, Osaka;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+@font-face {
+  font-family: 'HelsinkiGrotesk';
+  src: url('https://makasiini.hel.ninja/delivery/HelsinkiGrotesk/7c46f288e8133b87e6b12b45dac71865.woff');
+}
+
+html * {
+  font-family: var(--hds-theme-primary-font), Arial;
 }
 
 code {


### PR DESCRIPTION
![Screenshot from 2020-01-28 13-01-28](https://user-images.githubusercontent.com/3033037/73258550-99587100-41ce-11ea-917a-447cf3a92b5c.png)

As far as I understand the fonts are served as files with a .woff extension. I can't seem find the fonts anywhere in hds-core. My current approach is to navigate to https://city-of-helsinki.github.io/helsinki-design-system/storybook and copy the font url from there.

Umm, is this the right approach?