### PR TITLE
VEN-464 | add missing translation

### DIFF
--- a/src/domain/harbors/harborDetails/HarborDetails.tsx
+++ b/src/domain/harbors/harborDetails/HarborDetails.tsx
@@ -45,7 +45,6 @@ const HarborDetails: React.SFC<Props> = ({
             </ExternalLink>
             <ExternalLink href="">{t('harbors.details.portMap')}</ExternalLink>
             <ExternalLink href={serviceMapUrl}>
-              // FIXME: Missing translation
               {t('harbors.details.serviceMap')}
             </ExternalLink>
           </Section>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -51,6 +51,7 @@
       "applications": "HAKEMUKSET",
       "bills": "LASKUT",
       "comments": "HUOMIOT",
+      "serviceMap": "Palvelukartta",
       "portMap": "Satamakartta (PDF)",
       "maximumWidth": "Max leveys",
       "mooring": "Kiinnitys",


### PR DESCRIPTION
The translations for `harbors.details.serviceMap` was missing. This PR puts it back in.