### PR TITLE
VEN-471 | Refetch the query after linking a customer

### DIFF
--- a/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
@@ -63,7 +63,16 @@ const IndividualCustomerPageContainer: React.SFC = () => {
   const [linkCustomer, { error: linkCustomerErr }] = useMutation<
     UPDATE_BERTH_APPLICATION,
     UPDATE_BERTH_APPLICATION_VARS
-  >(UPDATE_BERTH_APPLICATION_MUTATION);
+  >(UPDATE_BERTH_APPLICATION_MUTATION, {
+    refetchQueries: [
+      {
+        query: INDIVIDUAL_APPLICATION_QUERY,
+        variables: {
+          id,
+        },
+      },
+    ],
+  });
 
   // TODO: handle errors
   const [createNewCustomer, { error: newCustomerErr }] = useMutation<


### PR DESCRIPTION
## Description :sparkles:
On the single application page, after clicking a customer to an application, it re-fetches the data for the page in question and hides the table of suggested customers.

## Issues :bug:
After linking a customer to a table, you had to refresh the page manually to see the changes.

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- From the sidebar, go to `Hakamukset` 
- Click on one of the applications
- From the table, select a customer, then click on `Liitä valittuun`
- Wait until the submission is done, then the table should disappear and the name on `ASIAKASTIEDOT` should show a link to the linked customer's page

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/76852998-2c1f9e80-6855-11ea-8dce-5950e24cbf09.png)

![image](https://user-images.githubusercontent.com/23040926/76853286-a819e680-6855-11ea-9c0a-19e27549b4fa.png)

## Additional notes :spiral_notepad:
