### PR TITLE
VEN-473 | Disable table filters for empty results

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -1447,6 +1447,16 @@
                   "ofType": null
                 },
                 "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": null
               }
             ],
             "type": {
@@ -1648,6 +1658,16 @@
                 "type": {
                   "kind": "SCALAR",
                   "name": "Boolean",
+                  "ofType": null
+                },
+                "defaultValue": null
+              },
+              {
+                "name": "orderBy",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
                   "ofType": null
                 },
                 "defaultValue": null

--- a/src/assets/styles/_colours.scss
+++ b/src/assets/styles/_colours.scss
@@ -2,6 +2,7 @@ $white: var(--hds-ui-color-white);
 $black: var(--hds-ui-color-black);
 
 $blue-100: var(--hds-theme-color-primary-extra-light);
+$blue-300: var(--hds-theme-color-primary-light);
 $blue-500: var(--hds-theme-color-primary);
 $blue-900: var(--hds-theme-color-primary-dark);
 

--- a/src/domain/offer/OfferPageContainer.tsx
+++ b/src/domain/offer/OfferPageContainer.tsx
@@ -125,6 +125,7 @@ const OfferPageContainer: React.FC = () => {
             activeFilters={props.state.filters.map(filter => filter.value)}
             filters={piersIdentifiers}
             handleSetFilter={filter => props.setFilter('pier', filter)}
+            filterPrefix={t('offer.tableHeaders.pierFilterBtn')}
           />
         )}
         renderTableToolsTop={state => {

--- a/src/domain/offer/tableHeader/TableHeader.test.jsx
+++ b/src/domain/offer/tableHeader/TableHeader.test.jsx
@@ -5,7 +5,21 @@ import TableHeader from './TableHeader';
 
 describe('TableHeader', () => {
   const handleSetFilter = jest.fn();
-  const initialProps = { filters: ['A', 'B'], handleSetFilter };
+  const initialProps = {
+    filters: [
+      {
+        label: 'A',
+        value: 'A',
+        enabled: true,
+      },
+      {
+        label: 'B',
+        value: 'B',
+        enabled: true,
+      },
+    ],
+    handleSetFilter,
+  };
 
   const getWrapper = (props = {}) =>
     shallow(<TableHeader {...initialProps} {...props} />);
@@ -31,16 +45,43 @@ describe('TableHeader', () => {
   });
 
   it("should call handleSetFilters with the filter's value when a filter button is clicked", () => {
-    const filters = ['foo', 'bar'];
-    const fooFilter = filters[0];
-
+    const filters = [
+      {
+        label: 'Foo',
+        value: 'Foo',
+        enabled: true,
+      },
+      {
+        label: 'Bar',
+        value: 'Bar',
+        enabled: true,
+      },
+    ];
+    const fooFilterValue = filters[0].value;
     const buttons = getWrapper({ filters }).find('button');
     const firstFilterBtn = buttons
-      .findWhere(node => node.text().includes(fooFilter))
+      .findWhere(node => node.text().includes(fooFilterValue))
       .first();
 
     firstFilterBtn.simulate('click');
 
-    expect(handleSetFilter).toHaveBeenNthCalledWith(1, fooFilter);
+    expect(handleSetFilter).toHaveBeenNthCalledWith(1, fooFilterValue);
+  });
+
+  it('filter button should be disabled for disabled filters', () => {
+    const filters = [
+      {
+        label: 'Foo',
+        value: 'Foo',
+        enabled: false,
+      },
+    ];
+    const filterValue = filters[0].value;
+    const buttons = getWrapper({ filters }).find('button');
+    const filterBtn = buttons
+      .findWhere(node => node.text().includes(filterValue))
+      .first();
+
+    expect(filterBtn.prop('disabled')).toBe(true);
   });
 });

--- a/src/domain/offer/tableHeader/TableHeader.tsx
+++ b/src/domain/offer/tableHeader/TableHeader.tsx
@@ -19,7 +19,7 @@ export interface TableHeaderProps {
 const TableHeader: React.SFC<TableHeaderProps> = ({
   activeFilters, // Note: this filters might include other active filters from the table
   filters,
-  filterPrefix,
+  filterPrefix = '',
   handleSetFilter,
 }) => {
   const { t } = useTranslation();

--- a/src/domain/offer/tableHeader/TableHeader.tsx
+++ b/src/domain/offer/tableHeader/TableHeader.tsx
@@ -4,15 +4,22 @@ import { useTranslation } from 'react-i18next';
 
 import styles from './tableHeader.module.scss';
 
+interface Tab {
+  label: string;
+  value: string;
+  enabled: boolean;
+}
 export interface TableHeaderProps {
   activeFilters?: string[];
-  filters: string[];
+  filters: Tab[];
+  filterPrefix?: string;
   handleSetFilter(filter?: string): void;
 }
 
 const TableHeader: React.SFC<TableHeaderProps> = ({
   activeFilters, // Note: this filters might include other active filters from the table
   filters,
+  filterPrefix,
   handleSetFilter,
 }) => {
   const { t } = useTranslation();
@@ -21,17 +28,19 @@ const TableHeader: React.SFC<TableHeaderProps> = ({
     <button
       key={i}
       className={classNames(styles.filterBtn, {
-        [styles.active]: activeFilters?.includes(filter),
+        [styles.active]: activeFilters?.includes(filter.label),
+        [styles.disabled]: !filter.enabled,
       })}
-      onClick={() => handleSetFilter(filter)}
+      disabled={!filter.enabled}
+      onClick={() => handleSetFilter(filter.label)}
     >
-      {t('offer.tableHeaders.pierFilterBtn', { pier: filter })}
+      {`${filterPrefix} ${filter.label}`}
     </button>
   ));
 
   const noActiveFilter =
-    filters.filter(filterVal => activeFilters?.includes(filterVal)).length ===
-    0;
+    filters.filter(filterVal => activeFilters?.includes(filterVal.label))
+      .length === 0;
 
   return (
     <>
@@ -41,7 +50,7 @@ const TableHeader: React.SFC<TableHeaderProps> = ({
         })}
         onClick={() => handleSetFilter()}
       >
-        {t('offer.tableHeaders.all')}
+        {t('common.table.all')}
       </button>
       {filtersButtons}
     </>

--- a/src/domain/offer/tableHeader/__snapshots__/TableHeader.test.jsx.snap
+++ b/src/domain/offer/tableHeader/__snapshots__/TableHeader.test.jsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHeader renders normally 1`] = `"<button class=\\"filterBtn active\\">Kaikki</button><button class=\\"filterBtn\\">Laituri A</button><button class=\\"filterBtn\\">Laituri B</button>"`;
+exports[`TableHeader renders normally 1`] = `"<button class=\\"filterBtn active\\">Kaikki</button><button class=\\"filterBtn\\"> A</button><button class=\\"filterBtn\\"> B</button>"`;

--- a/src/domain/offer/tableHeader/tableHeader.module.scss
+++ b/src/domain/offer/tableHeader/tableHeader.module.scss
@@ -26,6 +26,11 @@
     }
   }
 
+  &.disabled {
+    color: $blue-300;
+    pointer-events: none;
+  }
+
   &:hover {
     color: $active-color;
   }

--- a/src/domain/offer/utils.ts
+++ b/src/domain/offer/utils.ts
@@ -90,16 +90,26 @@ export const getOfferData = (data: OFFER_PAGE | undefined): BerthData[] => {
   return allBerths;
 };
 
+interface PierTab {
+  label: string;
+  value: string;
+  enabled: boolean;
+}
+
 export const getAllPiersIdentifiers = (
   data: OFFER_PAGE | undefined
-): string[] => {
+): PierTab[] => {
   const piers = data?.harborByServicemapId?.properties?.piers?.edges ?? [];
 
-  return piers.reduce<string[]>((acc, pier) => {
-    const identifier = pier?.node?.properties?.identifier;
+  return piers.reduce<PierTab[]>((acc, pier) => {
+    if (!pier?.node?.properties) return acc;
 
-    if (!identifier || (identifier && acc.includes(identifier))) return acc;
+    const pierTab = {
+      label: pier.node.properties.identifier,
+      value: pier.node.properties.identifier,
+      enabled: !!pier.node.properties?.berths.edges.length,
+    };
 
-    return [...acc, identifier];
+    return [...acc, pierTab];
   }, []);
 };

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -19,7 +19,8 @@
   },
   "common": {
     "table": {
-      "minimizeAll": "Pienennä kaikki"
+      "minimizeAll": "Pienennä kaikki",
+      "all": "Kaikki"
     },
     "sidebar": {
       "harbors": "Venepaikat",
@@ -163,8 +164,7 @@
   },
   "offer": {
     "tableHeaders": {
-      "all": "Kaikki",
-      "pierFilterBtn": "Laituri {{pier}}",
+      "pierFilterBtn": "Laituri",
       "harbor": "Satama",
       "pier": "Laituri",
       "berth": "Paikka",


### PR DESCRIPTION
## Description :sparkles:
Disable pier tabs (filters) for the piers that don't have suitable berths

## Issues :bug:

### Closes :no_good_woman:
[VEN-473](https://helsinkisolutionoffice.atlassian.net/browse/VEN-473) Berth details on the Offer page

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go the applications page `Hakemukset` from the sidebar
- Expand the application's row
- Select one of the choices under `VALITUT SATAMAT`, then it goes to the offer page
- On the offer page: the table has similar filters on the header for piers
- if a [pier has no matched results](https://venepaikka-admin.test.kuva.hel.ninja/offer/QmVydGhBcHBsaWNhdGlvbk5vZGU6NTU=?harbor=42225) the filter is disabled

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/76946034-16b97b80-690c-11ea-9ecc-19b31c42d616.png)

## Additional notes :spiral_notepad:
