### PR TITLE
VEN-536 | Exact text comparison for piers filters

### DIFF
--- a/src/domain/offer/OfferPageContainer.tsx
+++ b/src/domain/offer/OfferPageContainer.tsx
@@ -56,6 +56,7 @@ const OfferPageContainer: React.FC = () => {
     {
       Header: t('offer.tableHeaders.pier') || '',
       accessor: 'pier',
+      filter: 'exactText',
     },
     {
       Header: t('offer.tableHeaders.berth') || '',


### PR DESCRIPTION
## Description :sparkles:
Exact text comparison for pier filters.

## Issues :bug:
When filtering berths by piers, filter “Pier E” includes piers “E” and “E 1”.

### Closes :no_good_woman:
[VEN-536](https://helsinkisolutionoffice.atlassian.net/browse/VEN-536): Filter berths by pier filters also by part of the filter

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to [one of the offer pages where the harbor has piers which share part of the name like "E" and "E 1"](http://localhost:3000/offer/QmVydGhBcHBsaWNhdGlvbk5vZGU6NDU=?harbor=40897)
- Click on "E" filter; it should show the results for berths only in "E" pier excluding "E 1" berths

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/76976473-aaa33b80-693c-11ea-8be4-d5933746dfbd.png)

## Additional notes :spiral_notepad:
