### PR TITLE
Sticky table headers

### DIFF
--- a/src/assets/styles/_z-index.scss
+++ b/src/assets/styles/_z-index.scss
@@ -1,0 +1,12 @@
+$z-index: (
+  table-header  : 1,
+  dropdown      : 2,
+);
+
+@function z-index($key) {
+  @return map-get($z-index, $key);
+}
+
+@mixin z-index($key) {
+  z-index: z-index($key);
+}

--- a/src/common/dropdown/dropdown.module.scss
+++ b/src/common/dropdown/dropdown.module.scss
@@ -1,5 +1,6 @@
 @import 'colours';
 @import 'spacings';
+@import 'z-index';
 
 .dropdown {
   cursor: pointer;
@@ -13,5 +14,5 @@
   color: $black;
   margin-top: units(1);
   min-width: 100%;
-  z-index: 1;
+  z-index: z-index(dropdown);
 }

--- a/src/common/table/table.module.scss
+++ b/src/common/table/table.module.scss
@@ -8,7 +8,6 @@ $transition-duration: 300ms;
 
 .tableWrapper {
   display: block;
-  overflow-x: scroll;
 }
 
 .table {
@@ -42,6 +41,10 @@ $transition-duration: 300ms;
     border-bottom: solid 2px $gray-500;
     margin-bottom: $rows-spacing;
     padding: units(0.5) 0;
+    position: sticky;
+    top: units(3);
+    background-color: $gray-50;
+    z-index: 1;
   }
 
   .mainHeader {
@@ -53,6 +56,7 @@ $transition-duration: 300ms;
     letter-spacing: 0.03em;
     margin: 0;
     padding: 0;
+    top: 0;
 
     & .tableCell {
       margin: 0;

--- a/src/common/table/table.module.scss
+++ b/src/common/table/table.module.scss
@@ -1,5 +1,6 @@
 @import 'colours';
 @import 'spacings';
+@import 'z-index';
 
 $rows-spacing: units(0.25);
 $cell-padding-vertical: units(0.5);
@@ -44,7 +45,7 @@ $transition-duration: 300ms;
     position: sticky;
     top: units(3);
     background-color: $gray-50;
-    z-index: 1;
+    z-index: z-index(table-header);
   }
 
   .mainHeader {
@@ -98,7 +99,7 @@ $transition-duration: 300ms;
     margin-bottom: $rows-spacing;
 
     &.isSelected {
-      box-shadow: inset 0px 0px 0px 1px $blue-500;
+      box-shadow: inset 0 0 0 1px $blue-500;
     }
   }
 


### PR DESCRIPTION
## Description :sparkles:

Made table headers stick to the top of the view when scrolling down

## Issues :bug:

### Closes :no_good_woman:

Implements [VEN-516: Sticky table headers](https://helsinkisolutionoffice.atlassian.net/browse/VEN-516)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

Check the following views that have tables:
* Berths (Venepaikat)
* Single berth
* Applications (Hakemukset)
* Customers (Asiakkaat)

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
