### PR TITLE
VEN-579 | Add berth details sub component to individual harbor page

### DIFF
--- a/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
+++ b/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
@@ -18,6 +18,7 @@ import HarborProperties from './harborProperties/HarborProperties';
 import LoadingSpinner from '../../common/spinner/LoadingSpinner';
 import { formatDimension } from '../../common/utils/format';
 import PierSelectHeader from './pierSelectHeader/PierSelectHeader';
+import BerthDetails from '../offer/berthDetails/BerthDetails';
 
 const IndividualHarborPageContainer: React.SFC = () => {
   const { id } = useParams<{ id: string }>();
@@ -100,6 +101,12 @@ const IndividualHarborPageContainer: React.SFC = () => {
               setSelectedPier(pier);
               props.setFilter('identifier', pier?.identifier);
             }}
+          />
+        )}
+        renderSubComponent={row => (
+          <BerthDetails
+            leases={row.original.leases ? row.original.leases : []}
+            comment={row.original.comment}
           />
         )}
       />

--- a/src/domain/individualHarbor/__generated__/INDIVIDUAL_HARBOR.ts
+++ b/src/domain/individualHarbor/__generated__/INDIVIDUAL_HARBOR.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BerthMooringType } from "./../../../@types/__generated__/globalTypes";
+import { BerthMooringType, LeaseStatus } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: INDIVIDUAL_HARBOR
@@ -21,10 +21,42 @@ export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties
   mooringType: BerthMooringType;
 }
 
+export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node_application_customer {
+  __typename: "ProfileNode";
+  id: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node_application {
+  __typename: "BerthApplicationNode";
+  customer: INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node_application_customer | null;
+}
+
+export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node {
+  __typename: "BerthLeaseNode";
+  application: INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node_application | null;
+  status: LeaseStatus;
+  startDate: any;
+  endDate: any;
+}
+
+export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges {
+  __typename: "BerthLeaseNodeEdge";
+  node: INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges_node | null;
+}
+
+export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases {
+  __typename: "BerthLeaseNodeConnection";
+  edges: (INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges | null)[];
+}
+
 export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
   number: number;
   berthType: INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_berthType;
+  comment: string;
+  leases: INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases | null;
 }
 
 export interface INDIVIDUAL_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges {

--- a/src/domain/individualHarbor/queries.ts
+++ b/src/domain/individualHarbor/queries.ts
@@ -37,6 +37,23 @@ export const INDIVIDUAL_HARBOR_QUERY = gql`
                         length
                         mooringType
                       }
+                      comment
+                      leases {
+                        edges {
+                          node {
+                            application {
+                              customer {
+                                id
+                                firstName
+                                lastName
+                              }
+                            }
+                            status
+                            startDate
+                            endDate
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/src/domain/offer/berthDetails/BerthDetails.tsx
+++ b/src/domain/offer/berthDetails/BerthDetails.tsx
@@ -8,6 +8,7 @@ import InternalLink from '../../../common/internalLink/InternalLink';
 import Section from '../../../common/section/Section';
 import { formatDate } from '../../../common/utils/format';
 import styles from './berthDetails.module.scss';
+import { LeaseStatus } from '../../../@types/__generated__/globalTypes';
 
 interface Lease {
   customer: {
@@ -17,17 +18,18 @@ interface Lease {
   };
   startDate: string;
   endDate: string;
+  status: string;
 }
 
 export interface BerthDetailsProps {
   leases: Lease[];
   comment: string;
-  gate: boolean | null;
-  electricity: boolean | null;
-  water: boolean | null;
-  lighting: boolean | null;
-  wasteCollection: boolean | null;
-  isAccessible: boolean | null;
+  gate?: boolean | null;
+  electricity?: boolean | null;
+  water?: boolean | null;
+  lighting?: boolean | null;
+  wasteCollection?: boolean | null;
+  isAccessible?: boolean | null;
 }
 
 const BerthDetails: React.SFC<BerthDetailsProps> = ({
@@ -42,28 +44,28 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
 }) => {
   const { t, i18n } = useTranslation();
 
-  const leasesElements = leases.map(({ startDate, endDate, customer }, i) => {
-    return (
-      <div key={i}>
-        <Text>{`${formatDate(startDate, i18n.language)} - ${formatDate(
-          endDate,
-          i18n.language
-        )}`}</Text>{' '}
-        <InternalLink to={`/customers/${customer.id}`}>
-          {customer.firstName} {customer.lastName}
-        </InternalLink>
-      </div>
-    );
-  });
+  const leasesElements = leases
+    .filter(lease => lease.status === LeaseStatus.EXPIRED)
+    .map(({ startDate, endDate, customer }, i) => {
+      return (
+        <div key={i}>
+          <Text>{`${formatDate(startDate, i18n.language)} - ${formatDate(
+            endDate,
+            i18n.language
+          )}`}</Text>{' '}
+          <InternalLink to={`/customers/${customer.id}`}>
+            {customer.firstName} {customer.lastName}
+          </InternalLink>
+        </div>
+      );
+    });
 
-  const isNotNull = (property: boolean | null): property is boolean =>
-    property !== null;
   const getColor = (property: boolean) => (property ? 'standard' : 'secondary');
 
   return (
     <div className={styles.berthDetails}>
       <div className={styles.berthProperties}>
-        {isNotNull(gate) && (
+        {gate && (
           <div className={styles.property}>
             <Icon shape="IconFence" color={getColor(gate)} outlined />
             <Text className={styles.propertyLabel} color={getColor(gate)}>
@@ -71,7 +73,7 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
             </Text>
           </div>
         )}
-        {isNotNull(electricity) && (
+        {electricity && (
           <div className={styles.property}>
             <Icon shape="IconPlug" color={getColor(electricity)} outlined />
             <Text
@@ -82,7 +84,7 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
             </Text>
           </div>
         )}
-        {isNotNull(water) && (
+        {water && (
           <div className={styles.property}>
             <Icon shape="IconWaterTap" color={getColor(water)} outlined />
             <Text className={styles.propertyLabel} color={getColor(water)}>
@@ -90,7 +92,7 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
             </Text>
           </div>
         )}
-        {isNotNull(lighting) && (
+        {lighting && (
           <div className={styles.property}>
             <Icon shape="IconStreetLight" color={getColor(lighting)} outlined />
             <Text className={styles.propertyLabel} color={getColor(lighting)}>
@@ -98,7 +100,7 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
             </Text>
           </div>
         )}
-        {isNotNull(wasteCollection) && (
+        {wasteCollection && (
           <div className={styles.property}>
             <Icon
               shape="IconTrash"
@@ -114,7 +116,7 @@ const BerthDetails: React.SFC<BerthDetailsProps> = ({
           </div>
         )}
 
-        {isNotNull(isAccessible) && (
+        {isAccessible && (
           <div className={styles.property}>
             <Icon
               shape="IconAccessibility"

--- a/src/domain/offer/utils.ts
+++ b/src/domain/offer/utils.ts
@@ -7,6 +7,7 @@ interface Lease {
     firstName: string;
     lastName: string;
   };
+  status: string;
   startDate: string;
   endDate: string;
 }
@@ -58,6 +59,7 @@ export const getOfferData = (data: OFFER_PAGE | undefined): BerthData[] => {
               {
                 startDate: edge.node.startDate,
                 endDate: edge.node.endDate,
+                status: edge.node.status,
                 customer: {
                   id: edge.node.customer.id,
                   firstName: edge.node.customer.firstName,


### PR DESCRIPTION
## Description :sparkles:

Adds BerthDetails as a subcomponent to the individual harbor page's berth table.

## Issues :bug:

### Closes :no_good_woman:

VEN-579

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
