### PR TITLE
VEN-538| Single application page: searching for similar customers

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.3.0",
     "react-table": "^7.0.4",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "use-debounce": "^3.4.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/common/select/Select.tsx
+++ b/src/common/select/Select.tsx
@@ -11,10 +11,10 @@ interface Option {
 export type SelectProps = {
   labelText?: string;
   className?: string;
-  value: string | undefined;
+  value: Option['value'] | undefined;
   options: Option[];
   disabled?: boolean;
-  onChange(): void;
+  onChange: React.ChangeEventHandler<HTMLSelectElement>;
 };
 
 const Select: React.SFC<SelectProps> = ({
@@ -32,17 +32,13 @@ const Select: React.SFC<SelectProps> = ({
   ));
 
   return (
-    <label>
+    <label className={className}>
       <span className={styles.labelText}>{labelText}</span>
       <select
         value={value}
         onChange={onChange}
         disabled={disabled}
-        className={classNames(
-          styles.select,
-          { [styles.disabled]: disabled },
-          className
-        )}
+        className={classNames(styles.select, { [styles.disabled]: disabled })}
       >
         <option>-</option>
         {optionsItems}

--- a/src/common/select/Select.tsx
+++ b/src/common/select/Select.tsx
@@ -13,6 +13,7 @@ export type SelectProps = {
   className?: string;
   value: Option['value'] | undefined;
   options: Option[];
+  required?: boolean;
   disabled?: boolean;
   onChange: React.ChangeEventHandler<HTMLSelectElement>;
 };
@@ -23,6 +24,7 @@ const Select: React.SFC<SelectProps> = ({
   value,
   options,
   onChange,
+  required,
   disabled,
 }) => {
   const optionsItems = options.map(({ value, label }) => (
@@ -40,7 +42,7 @@ const Select: React.SFC<SelectProps> = ({
         disabled={disabled}
         className={classNames(styles.select, { [styles.disabled]: disabled })}
       >
-        <option>-</option>
+        {!required && <option>-</option>}
         {optionsItems}
       </select>
     </label>

--- a/src/common/select/select.module.scss
+++ b/src/common/select/select.module.scss
@@ -26,10 +26,6 @@
     display: none;
   }
 
-  &:hover {
-    border-color: #888;
-  }
-
   &:focus {
     border-color: $black;
   }

--- a/src/domain/individualApplication/IndividualApplicationPage.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPage.tsx
@@ -34,8 +34,8 @@ export enum CUSTOMER_GROUP {
 export enum SearchBy {
   FIRST_NAME = 'firstName',
   LAST_NAME = 'lastName',
-  EMAIL = 'emails_Email',
-  ADDRESS = 'addresses_Address',
+  EMAIL = 'email',
+  ADDRESS = 'address',
 }
 
 export interface CustomerData {

--- a/src/domain/individualApplication/IndividualApplicationPage.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Notification } from 'hds-react';
 
@@ -10,7 +11,9 @@ import ApplicationDetails, {
 } from '../cards/applicationDetails/ApplicationDetails';
 import CardHeader from '../../common/cardHeader/CardHeader';
 import Table, { Column } from '../../common/table/Table';
-import CustomersTableTools from './customersTableTools/CustomersTableTools';
+import CustomersTableTools, {
+  CustomersTableToolsProps,
+} from './customersTableTools/CustomersTableTools';
 import Text from '../../common/text/Text';
 import { formatDate } from '../../common/utils/format';
 import Chip from '../../common/chip/Chip';
@@ -26,6 +29,13 @@ export enum CUSTOMER_GROUP {
   INTERNAL = 'INTERNAL',
   NON_BILLABLE = 'NON_BILLABLE',
   OTHER_ORGANIZATION = 'OTHER_ORGANIZATION',
+}
+
+export enum SearchBy {
+  FIRST_NAME = 'firstName',
+  LAST_NAME = 'lastName',
+  EMAIL = 'emails_Email',
+  ADDRESS = 'addresses_Address',
 }
 
 export interface CustomerData {
@@ -45,8 +55,8 @@ export interface IndividualApplicationPageProps {
   customerInfo: CustomerInfoCardProps;
   applicationDetails: ApplicationDetailsProps;
   offerDetails: OfferCardProps | null;
+  customerTableTools: CustomersTableToolsProps<SearchBy>;
   handleLinkCustomer(customerId: string): void;
-  handleCreateCustomer(): void;
 }
 
 const IndividualApplicationPage: React.SFC<IndividualApplicationPageProps> = ({
@@ -54,8 +64,8 @@ const IndividualApplicationPage: React.SFC<IndividualApplicationPageProps> = ({
   customerInfo,
   applicationDetails,
   offerDetails,
+  customerTableTools,
   handleLinkCustomer,
-  handleCreateCustomer,
 }) => {
   const { t, i18n } = useTranslation();
   const columns: ColumnType[] = [
@@ -109,7 +119,7 @@ const IndividualApplicationPage: React.SFC<IndividualApplicationPageProps> = ({
 
   return (
     <div className={styles.individualApplicationPage}>
-      <div className={styles.pageHeader}>
+      <div className={classNames(styles.fullWidth, styles.pageHeader)}>
         <Text as="h2" size="xl" weight="normalWeight">
           {applicationDetails.berthSwitch !== null
             ? t('applications.applicationType.switchApplication')
@@ -136,21 +146,21 @@ const IndividualApplicationPage: React.SFC<IndividualApplicationPageProps> = ({
             )}
           </Notification>
           <Table
-            className={styles.customersTable}
+            className={styles.fullWidth}
             data={similarCustomersData}
             columns={columns}
             renderMainHeader={() =>
               t('individualApplication.customersTable.mainHeader')
             }
-            renderTableToolsBottom={({ selectedRows }) => {
+            renderTableToolsTop={({ selectedRows }) => {
               const onLinkCustomer = selectedRows.length
                 ? () => handleLinkCustomer(selectedRows[0].id)
                 : undefined;
 
               return (
                 <CustomersTableTools
+                  {...customerTableTools}
                   handleLinkCustomer={onLinkCustomer}
-                  handleCreateCustomer={handleCreateCustomer}
                 />
               );
             }}
@@ -167,7 +177,7 @@ const IndividualApplicationPage: React.SFC<IndividualApplicationPageProps> = ({
         <CardBody>Placeholder</CardBody>
       </Card>
       {applicationDetails && (
-        <Card className={styles.applicationDetails}>
+        <Card className={styles.fullWidth}>
           <CardHeader
             title={t('individualApplication.applicationDetails.title')}
           />

--- a/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
@@ -77,24 +77,8 @@ const IndividualCustomerPageContainer: React.SFC = () => {
   const [deleteDraftedApplication] = useDeleteBerthApplication();
   useEffect(() => {
     if (!data?.berthApplication) return;
-    let initialSearchBy: keyof BerthApplication;
 
-    switch (searchBy) {
-      case SearchBy.EMAIL:
-        initialSearchBy = 'email';
-        break;
-      case SearchBy.ADDRESS:
-        initialSearchBy = 'address';
-        break;
-      case SearchBy.FIRST_NAME:
-        initialSearchBy = 'firstName';
-        break;
-      default:
-        initialSearchBy = 'lastName';
-        break;
-    }
-
-    setSearchVal(data.berthApplication[initialSearchBy]);
+    setSearchVal(data.berthApplication[searchBy]);
   }, [data, searchBy]);
 
   useEffect(() => {

--- a/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
@@ -227,10 +227,10 @@ const IndividualCustomerPageContainer: React.SFC = () => {
         setSearchBy,
         handleCreateCustomer,
         searchByOptions: [
-          { value: SearchBy.FIRST_NAME, label: 'Etunimi' },
-          { value: SearchBy.LAST_NAME, label: 'Sukunimi' },
-          { value: SearchBy.EMAIL, label: 'Sähköposti' },
-          { value: SearchBy.ADDRESS, label: 'Osoite' },
+          { value: SearchBy.FIRST_NAME, label: t('common.firstName') },
+          { value: SearchBy.LAST_NAME, label: t('common.lastName') },
+          { value: SearchBy.EMAIL, label: t('common.email') },
+          { value: SearchBy.ADDRESS, label: t('common.address') },
         ],
       }}
       similarCustomersData={filteredCustomersData}

--- a/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
@@ -15,7 +15,6 @@ import {
 } from './queries';
 import {
   INDIVIDUAL_APPLICATION,
-  INDIVIDUAL_APPLICATION_berthApplication as BerthApplication,
   INDIVIDUAL_APPLICATIONVariables as INDIVIDUAL_APPLICATION_VARS,
 } from './__generated__/INDIVIDUAL_APPLICATION';
 import { useDeleteBerthApplication } from '../mutations/deleteBerthApplication';

--- a/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
+++ b/src/domain/individualApplication/IndividualApplicationPageContainer.tsx
@@ -99,10 +99,6 @@ const IndividualCustomerPageContainer: React.SFC = () => {
 
   useEffect(() => {
     if (!loading && !data?.berthApplication?.customer) {
-      console.log(
-        'data?.berthApplication?.customer',
-        data?.berthApplication?.customer
-      );
       !called ? fetchFilteredCustomers() : refetch();
     }
   }, [

--- a/src/domain/individualApplication/__generated__/FILTERED_CUSTOMERS.ts
+++ b/src/domain/individualApplication/__generated__/FILTERED_CUSTOMERS.ts
@@ -113,4 +113,6 @@ export interface FILTERED_CUSTOMERS {
 export interface FILTERED_CUSTOMERSVariables {
   firstName?: string | null;
   lastName?: string | null;
+  emails_Email?: string | null;
+  addresses_Address?: string | null;
 }

--- a/src/domain/individualApplication/__generated__/FILTERED_CUSTOMERS.ts
+++ b/src/domain/individualApplication/__generated__/FILTERED_CUSTOMERS.ts
@@ -113,6 +113,6 @@ export interface FILTERED_CUSTOMERS {
 export interface FILTERED_CUSTOMERSVariables {
   firstName?: string | null;
   lastName?: string | null;
-  emails_Email?: string | null;
-  addresses_Address?: string | null;
+  email?: string | null;
+  address?: string | null;
 }

--- a/src/domain/individualApplication/customersTableTools/CustomersTableTools.tsx
+++ b/src/domain/individualApplication/customersTableTools/CustomersTableTools.tsx
@@ -1,22 +1,49 @@
 import React from 'react';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Button } from 'hds-react';
+import { Button, TextInput } from 'hds-react';
 
+import Select from '../../../common/select/Select';
 import styles from './customersTableTools.module.scss';
 
-export interface CustomersTableToolsProps {
+export interface CustomersTableToolsProps<T> {
+  className?: string;
+  searchVal: string | undefined;
+  searchBy: T;
+  searchByOptions: Array<{ value: T; label: string }>;
+  setSearchVal(val: string): void;
+  setSearchBy(val: T): void;
   handleLinkCustomer?(): void;
   handleCreateCustomer(): void;
 }
 
-const CustomersTableTools: React.SFC<CustomersTableToolsProps> = ({
+const CustomersTableTools = <T extends string>({
+  className,
+  searchVal,
+  searchBy,
+  searchByOptions,
+  setSearchVal,
+  setSearchBy,
   handleLinkCustomer,
   handleCreateCustomer,
-}) => {
+}: CustomersTableToolsProps<T>) => {
   const { t } = useTranslation();
 
   return (
-    <div className={styles.customersTableTools}>
+    <div className={classNames(styles.customersTableTools, className)}>
+      <Select
+        className={styles.select}
+        onChange={e => setSearchBy(e.target.value as T)}
+        value={searchBy}
+        options={searchByOptions}
+        required
+      />
+      <TextInput
+        className={styles.searchInput}
+        id="searchSimilarCustomers"
+        value={searchVal}
+        onChange={e => setSearchVal((e.target as HTMLInputElement).value)}
+      />
       <Button disabled={!handleLinkCustomer} onClick={handleLinkCustomer}>
         {t('individualApplication.customerTableTools.linkCustomer')}
       </Button>

--- a/src/domain/individualApplication/customersTableTools/customersTableTools.module.scss
+++ b/src/domain/individualApplication/customersTableTools/customersTableTools.module.scss
@@ -1,11 +1,23 @@
 @import 'spacings';
+@import 'colours';
 
 .customersTableTools {
-  margin-top: units(0.5);
+  margin-bottom: units(0.75);
   display: flex;
   justify-content: flex-end;
 
   & > * {
     margin-left: units(0.75);
   }
+}
+
+.select {
+  width: 14em;
+}
+
+.searchInput {
+  background-color: $white;
+  margin-left: units(0.5);
+  width: 25%;
+  min-width: 12em;
 }

--- a/src/domain/individualApplication/individualApplicationPage.module.scss
+++ b/src/domain/individualApplication/individualApplicationPage.module.scss
@@ -9,14 +9,13 @@
   padding: units(2);
 }
 
-.pageHeader {
+.fullWidth {
   grid-column: 1 / -1;
-  justify-self: center;
-  display: flex;
 }
 
-.customersTable {
-  grid-column: 1 / -1;
+.pageHeader {
+  justify-self: center;
+  display: flex;
 }
 
 .berthsCell {
@@ -24,10 +23,6 @@
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-}
-
-.applicationDetails {
-  grid-column: 1 / -1;
 }
 
 .chip {

--- a/src/domain/individualApplication/queries.ts
+++ b/src/domain/individualApplication/queries.ts
@@ -4,15 +4,15 @@ export const FILTERED_CUSTOMERS_QUERY = gql`
   query FILTERED_CUSTOMERS(
     $firstName: String
     $lastName: String
-    $emails_Email: String
-    $addresses_Address: String
+    $email: String
+    $address: String
   ) {
     profiles(
       serviceType: BERTH
       firstName: $firstName
       lastName: $lastName
-      emails_Email: $emails_Email
-      addresses_Address: $addresses_Address
+      emails_Email: $email
+      addresses_Address: $address
       orderBy: "lastName"
     ) {
       edges {

--- a/src/domain/individualApplication/queries.ts
+++ b/src/domain/individualApplication/queries.ts
@@ -1,11 +1,18 @@
 import { gql } from 'apollo-boost';
 
 export const FILTERED_CUSTOMERS_QUERY = gql`
-  query FILTERED_CUSTOMERS($firstName: String, $lastName: String) {
+  query FILTERED_CUSTOMERS(
+    $firstName: String
+    $lastName: String
+    $emails_Email: String
+    $addresses_Address: String
+  ) {
     profiles(
       serviceType: BERTH
       firstName: $firstName
       lastName: $lastName
+      emails_Email: $emails_Email
+      addresses_Address: $addresses_Address
       orderBy: "lastName"
     ) {
       edges {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -22,6 +22,10 @@
     "no": "Ei",
     "search": "Haku",
     "edit": "Muokkaa",
+    "firstName": "Etunimi",
+    "lastName": "Sukunimi",
+    "email": "Sähköposti",
+    "address": "Osoite",
     "table": {
       "minimizeAll": "Pienennä kaikki",
       "all": "Kaikki",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15829,6 +15829,11 @@ use-callback-ref@^1.2.1:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.3.tgz#9f939dfb5740807bbf9dd79cdd4e99d27e827756"
   integrity sha512-DPBPh1i2adCZoIArRlTuKRy7yue7QogtEnfv0AKrWsY+GA+4EKe37zhRDouNnyWMoNQFYZZRF+2dLHsWE4YvJA==
 
+use-debounce@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-3.4.1.tgz#361a20e583c1bd4a44f8b29a26793a52a0b84d2c"
+  integrity sha512-KHZPsL+cZvOt/ZAsHTcoAK65ImXU0iG9FDeofuj9uJTdUULF6Gjws8HpK+JlIjZpZ7LTqPHZtEknc+Im4cB3AA==
+
 use-sidecar@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"


### PR DESCRIPTION
## Description :sparkles:
- Add `Select` and `TextField` for searching similar customers on the single application page
- Use the debouncing mechanism for fetching customers while typing  
- Use lazy selector for fetching similar customers to get rid of on unnecessary roundtrip if the application has a customer attached

## Issues :bug:

### Closes :no_good_woman:
[VEN-538](https://helsinkisolutionoffice.atlassian.net/browse/VEN-538): Single application page: filters for the suggested customers

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to the application page
- Click on one of the applications
- If the application doesn't have a customer, a table with suggested customers would be displayed
- Above the table, there are a search bar and a dropdown menu can be used to search for customers based on their `first name`, `last name`, `email` or `address`.

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/80194856-b19c2880-8623-11ea-9285-679903d1980a.png)

## Additional notes :spiral_notepad:
I left out the pagination to be done in another ticket since I couldn't find a non-hacky way to do it.