### PR TITLE
VEN-579 | Add global filter to berth table in individual harbor page

### DIFF
--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -19,6 +19,7 @@ import {
   UseFiltersColumnOptions,
   UseSortByColumnOptions,
   UseFiltersInstanceProps,
+  UseGlobalFiltersOptions,
 } from 'react-table';
 
 import Checkbox from '../checkbox/Checkbox';
@@ -56,6 +57,7 @@ type Props<D extends object> = {
   renderSubComponent?: (row: Row<D>) => React.ReactNode;
   renderMainHeader?: (props: HeaderProps<D>) => React.ReactNode;
   renderEmptyStateRow?: () => React.ReactNode;
+  globalFilter?: UseGlobalFiltersOptions<D>['globalFilter'];
 } & TableOptions<D>;
 
 const EXPANDER = 'EXPANDER';
@@ -88,6 +90,7 @@ const Table = <D extends object>({
   renderSubComponent,
   renderMainHeader,
   renderEmptyStateRow,
+  globalFilter,
 }: Props<D>) => {
   const { t } = useTranslation();
 
@@ -197,6 +200,7 @@ const Table = <D extends object>({
     {
       columns: tableColumns,
       data,
+      globalFilter,
     },
     useFilters,
     useGlobalFilter,

--- a/src/common/tableTools/globalSearchTableTools/GlobalSearchTableTools.test.jsx
+++ b/src/common/tableTools/globalSearchTableTools/GlobalSearchTableTools.test.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { TextInput } from 'hds-react';
 
-import HarborsTableTools from './HarborsTableTools';
+import GlobalSearchTableTools from './GlobalSearchTableTools';
 
-describe('HarborsTableTools', () => {
+describe('GlobalSearchTableTools', () => {
   const mockProps = {
     handleGlobalFilter: jest.fn(),
   };
   const getWrapper = (props = {}) =>
-    shallow(<HarborsTableTools {...mockProps} {...props} />);
+    shallow(<GlobalSearchTableTools {...mockProps} {...props} />);
 
   beforeEach(() => {
     jest.restoreAllMocks();

--- a/src/common/tableTools/globalSearchTableTools/GlobalSearchTableTools.tsx
+++ b/src/common/tableTools/globalSearchTableTools/GlobalSearchTableTools.tsx
@@ -2,23 +2,23 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TextInput } from 'hds-react';
 
-import styles from './harborsTableTools.module.scss';
+import styles from './globalSearchTableTools.module.scss';
 
-export interface HarborsTableToolsProps {
+export interface GlobalSearchTableToolsProps {
   handleGlobalFilter(value?: string): void;
 }
 
-const HarborsTableTools: React.SFC<HarborsTableToolsProps> = ({
+const GlobalSearchTableTools: React.SFC<GlobalSearchTableToolsProps> = ({
   handleGlobalFilter,
 }) => {
   const { t } = useTranslation();
 
   return (
-    <div className={styles.harborsTableTools}>
+    <div className={styles.globalSearchTableTools}>
       <TextInput
         className={styles.filterField}
         placeholder={t('common.search')}
-        id="harborListGlobalFilter"
+        id="textSearchGlobalFilter"
         onChange={e =>
           handleGlobalFilter(
             (e.target as HTMLTextAreaElement).value || undefined
@@ -29,4 +29,4 @@ const HarborsTableTools: React.SFC<HarborsTableToolsProps> = ({
   );
 };
 
-export default HarborsTableTools;
+export default GlobalSearchTableTools;

--- a/src/common/tableTools/globalSearchTableTools/__snapshots__/GlobalSearchTableTools.test.jsx.snap
+++ b/src/common/tableTools/globalSearchTableTools/__snapshots__/GlobalSearchTableTools.test.jsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GlobalSearchTableTools renders normally 1`] = `"<div class=\\"globalSearchTableTools\\"><div class=\\"_1cealf9APZDUwwgivaltwb filterField\\"><div class=\\"_1ru3hdCZ3qhTQ_EVvRwBIh\\"><input type=\\"text\\" class=\\"_35GDyiOFLPVMWYFM4_BMWV CQwbnf7hlQrao8Za4G1Wo\\" id=\\"textSearchGlobalFilter\\" placeholder=\\"Haku\\"/></div></div></div>"`;

--- a/src/common/tableTools/globalSearchTableTools/globalSearchTableTools.module.scss
+++ b/src/common/tableTools/globalSearchTableTools/globalSearchTableTools.module.scss
@@ -1,7 +1,7 @@
 @import 'colours';
 @import 'spacings';
 
-.harborsTableTools {
+.globalSearchTableTools {
   display: flex;
   justify-content: flex-end;
   margin-bottom: units(0.5);

--- a/src/domain/harbors/HarborsList.tsx
+++ b/src/domain/harbors/HarborsList.tsx
@@ -7,7 +7,7 @@ import InternalLink from '../../common/internalLink/InternalLink';
 import styles from './harborsPage.module.scss';
 import Icon from '../../common/icons/Icon';
 import { HarborData } from './utils';
-import HarborsTableTools from './harborsTableTools/HarborsTableTools';
+import GlobalSearchTableTools from '../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
 
 export interface IconProps {
   disabled?: boolean;
@@ -116,7 +116,9 @@ const HarborsList: React.FC<HarborsPageProps> = ({ data = [] }) => {
         data={data}
         columns={columns}
         renderTableToolsTop={(_, setters) => (
-          <HarborsTableTools handleGlobalFilter={setters.setGlobalFilter} />
+          <GlobalSearchTableTools
+            handleGlobalFilter={setters.setGlobalFilter}
+          />
         )}
         renderSubComponent={row => <HarborDetails {...row.original} />}
         renderMainHeader={() => t('harbors.tableHeaders.mainHeader')}

--- a/src/domain/harbors/harborsTableTools/__snapshots__/HarborsTableTools.test.jsx.snap
+++ b/src/domain/harbors/harborsTableTools/__snapshots__/HarborsTableTools.test.jsx.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`HarborsTableTools renders normally 1`] = `"<div class=\\"harborsTableTools\\"><div class=\\"_1cealf9APZDUwwgivaltwb filterField\\"><div class=\\"_1ru3hdCZ3qhTQ_EVvRwBIh\\"><input type=\\"text\\" class=\\"_35GDyiOFLPVMWYFM4_BMWV CQwbnf7hlQrao8Za4G1Wo\\" id=\\"harborListGlobalFilter\\" placeholder=\\"Haku\\"/></div></div></div>"`;

--- a/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
+++ b/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@apollo/react-hooks';
 import { useTranslation } from 'react-i18next';
-import { UseGlobalFiltersOptions } from 'react-table';
 
 import Table, { Column } from '../../common/table/Table';
 import { INDIVIDUAL_HARBOR_QUERY } from './queries';
@@ -28,41 +27,6 @@ const IndividualHarborPageContainer: React.SFC = () => {
   );
   const { t, i18n } = useTranslation();
 
-  const includesCaseInsensitive = React.useCallback(
-    (target: string, value: string): boolean => {
-      return target
-        .toLocaleLowerCase(i18n.language)
-        .includes(value.toLocaleLowerCase(i18n.language));
-    },
-    [i18n.language]
-  );
-
-  const berthTableGlobalFilter: UseGlobalFiltersOptions<
-    Berth
-  >['globalFilter'] = React.useMemo(
-    () => (rows, _, filterValue) => {
-      return rows.filter(row => {
-        const { number, identifier, length, width, mooringType } = row.values;
-        const numberMatch = String(number) === filterValue;
-        const identifierMatch = String(identifier) === filterValue;
-        const lengthMatch = includesCaseInsensitive(length, filterValue);
-        const widthMatch = includesCaseInsensitive(width, filterValue);
-        const mooringTypeMatch = includesCaseInsensitive(
-          mooringType,
-          filterValue
-        );
-        return (
-          numberMatch ||
-          identifierMatch ||
-          lengthMatch ||
-          widthMatch ||
-          mooringTypeMatch
-        );
-      });
-    },
-    [includesCaseInsensitive]
-  );
-
   if (loading) return <LoadingSpinner isLoading={loading} />;
   if (error) return <div>Error</div>;
 
@@ -74,27 +38,31 @@ const IndividualHarborPageContainer: React.SFC = () => {
     {
       Header: t('individualHarbor.tableHeaders.number') || '',
       accessor: 'number',
+      filter: 'text',
     },
     {
       Header: t('individualHarbor.tableHeaders.identifier') || '',
       accessor: 'identifier',
-      filter: 'exactText',
+      filter: 'text',
     },
     {
       Header: t('individualHarbor.tableHeaders.length') || '',
       accessor: ({ length }) => formatDimension(length, i18n.language),
       id: 'length',
+      filter: 'text',
     },
     {
       Header: t('individualHarbor.tableHeaders.width') || '',
       accessor: ({ width }) => formatDimension(width, i18n.language),
       id: 'width',
+      filter: 'text',
     },
     {
       Header: t('individualHarbor.tableHeaders.mooring') || '',
       accessor: ({ mooringType }) =>
         t([`common.mooringTypes.${mooringType}`, mooringType]),
       id: 'mooringType',
+      filter: 'text',
     },
   ];
   const piers = getPiers(data);
@@ -129,7 +97,6 @@ const IndividualHarborPageContainer: React.SFC = () => {
           />
         )}
         styleMainHeader={false}
-        globalFilter={berthTableGlobalFilter}
         renderMainHeader={props => (
           <PierSelectHeader
             piers={piers}

--- a/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
+++ b/src/domain/individualHarbor/IndividualHarborPageContainer.tsx
@@ -18,7 +18,7 @@ import HarborProperties from './harborProperties/HarborProperties';
 import LoadingSpinner from '../../common/spinner/LoadingSpinner';
 import { formatDimension } from '../../common/utils/format';
 import PierSelectHeader from './pierSelectHeader/PierSelectHeader';
-import HarborsTableTools from '../harbors/harborsTableTools/HarborsTableTools';
+import GlobalSearchTableTools from '../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
 
 const IndividualHarborPageContainer: React.SFC = () => {
   const { id } = useParams<{ id: string }>();
@@ -124,7 +124,9 @@ const IndividualHarborPageContainer: React.SFC = () => {
         columns={columns}
         canSelectRows
         renderTableToolsTop={(_, setters) => (
-          <HarborsTableTools handleGlobalFilter={setters.setGlobalFilter} />
+          <GlobalSearchTableTools
+            handleGlobalFilter={setters.setGlobalFilter}
+          />
         )}
         styleMainHeader={false}
         globalFilter={berthTableGlobalFilter}

--- a/src/domain/individualHarbor/pierSelectHeader/PierSelectHeader.tsx
+++ b/src/domain/individualHarbor/pierSelectHeader/PierSelectHeader.tsx
@@ -9,7 +9,7 @@ import PierProperties from './pierProperties/PierProperties';
 interface PierSelectHeaderProps {
   readonly className?: string;
   readonly piers: Pier[];
-  readonly selectedPier: Pier | null;
+  readonly selectedPier?: Pier | null;
   onPierSelect(pier: Pier | null): void;
 }
 


### PR DESCRIPTION
## Description :sparkles:

Adds a search field that performs global filtering of berths in the individual harbor page's table.

Additionally refactors filtering by piers to not use component state.

## Issues :bug:

### Closes :no_good_woman:

VEN-579

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

* Go to a harbor's page.
* Type something in the search text field.
* Only the rows with at least one cell matching the written text should be shown.

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
