### PR TITLE
VEN-596 | Customers page: search field for the table

### DIFF
--- a/src/domain/customers/CustomerListComponent.tsx
+++ b/src/domain/customers/CustomerListComponent.tsx
@@ -7,6 +7,14 @@ import InternalLink from '../../common/internalLink/InternalLink';
 import CustomerDetails from './customerDetails/CustomerDetails';
 import { OrganizationType } from '../../@types/__generated__/globalTypes';
 import Pagination, { PaginationProps } from '../../common/pagination/Pagination';
+import TableTools, { TableToolsProps } from './tableTools/TableTools';
+
+export enum SearchBy {
+  FIRST_NAME = 'firstName',
+  LAST_NAME = 'lastName',
+  EMAIL = 'email',
+  ADDRESS = 'address',
+}
 
 export interface TableData {
   address?: string;
@@ -28,9 +36,10 @@ export interface CustomerListComponentProps {
   loading: boolean;
   data: TableData[];
   pagination: PaginationProps;
+  tableTools: TableToolsProps<SearchBy>;
 }
 
-const CustomerListComponent = ({ loading, data, pagination }: CustomerListComponentProps) => {
+const CustomerListComponent = ({ loading, data, pagination, tableTools }: CustomerListComponentProps) => {
   const { t } = useTranslation();
   const columns: ColumnType[] = [
     {
@@ -94,6 +103,7 @@ const CustomerListComponent = ({ loading, data, pagination }: CustomerListCompon
         );
       }}
       renderMainHeader={() => t('customers.tableHeaders.mainHeader')}
+      renderTableToolsTop={() => <TableTools {...tableTools} />}
       renderEmptyStateRow={() => t('common.notification.noData.description')}
       renderTableToolsBottom={() => <Pagination {...pagination} />}
       canSelectRows

--- a/src/domain/customers/CustomerPageContainer.tsx
+++ b/src/domain/customers/CustomerPageContainer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Notification } from 'hds-react';
-import { useLazyQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/react-hooks';
 import { useDebounce } from 'use-debounce';
 
 import { CUSTOMER_QUERY } from './queries';
@@ -34,18 +34,9 @@ const CustomersPageContainer: React.FC = () => {
     [searchBy]: prevSearchBy === searchBy ? debouncedSearchVal : searchVal,
   };
 
-  const [fetchFilteredCustomers, { data, error, called, loading }] = useLazyQuery<CUSTOMERS, CUSTOMERS_VARS>(
-    CUSTOMER_QUERY,
-    {
-      variables: filteredCustomersVars,
-    }
-  );
-
-  useEffect(() => {
-    if (!loading && !called) {
-      fetchFilteredCustomers();
-    }
-  }, [loading, called, fetchFilteredCustomers]);
+  const { data, error, loading } = useQuery<CUSTOMERS, CUSTOMERS_VARS>(CUSTOMER_QUERY, {
+    variables: filteredCustomersVars,
+  });
 
   useEffect(() => {
     // Go to the first page when search values change.

--- a/src/domain/customers/CustomerPageContainer.tsx
+++ b/src/domain/customers/CustomerPageContainer.tsx
@@ -75,9 +75,7 @@ const CustomersPageContainer: React.FC = () => {
           searchVal,
           searchBy,
           setSearchVal,
-          setSearchBy: (searchBy) => {
-            setSearchBy(searchBy);
-          },
+          setSearchBy,
           searchByOptions: [
             { value: SearchBy.FIRST_NAME, label: t('common.firstName') },
             { value: SearchBy.LAST_NAME, label: t('common.lastName') },

--- a/src/domain/customers/CustomerPageContainer.tsx
+++ b/src/domain/customers/CustomerPageContainer.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Notification } from 'hds-react';
-import { useQuery } from '@apollo/react-hooks';
+import { useLazyQuery } from '@apollo/react-hooks';
+import { useDebounce } from 'use-debounce';
 
 import { CUSTOMER_QUERY } from './queries';
 import { getCustomersData } from './utils';
@@ -9,15 +10,47 @@ import { CUSTOMERS, CUSTOMERSVariables as CUSTOMERS_VARS } from './__generated__
 import CustomerList from './CustomerListComponent';
 import CustomersPage from './CustomersPage';
 import { usePagination } from '../../common/utils/usePagination';
+import { SearchBy } from '../individualApplication/IndividualApplicationPage';
+import { usePrevious } from '../../common/utils/usePrevious';
 
 const CustomersPageContainer: React.FC = () => {
   const { t } = useTranslation();
 
+  const [searchBy, setSearchBy] = useState<SearchBy>(SearchBy.LAST_NAME);
+  const [searchVal, setSearchVal] = useState<string>('');
+
   const { cursor, pageSize, pageIndex, getPageCount, goToPage } = usePagination();
 
-  const { loading, error, data } = useQuery<CUSTOMERS, CUSTOMERS_VARS>(CUSTOMER_QUERY, {
-    variables: { after: cursor, first: pageSize },
+  const [debouncedSearchVal] = useDebounce(searchVal, 500, {
+    equalityFn: (prev, next) => prev === next,
+    leading: true,
   });
+
+  const prevSearchBy = usePrevious(searchBy);
+
+  const filteredCustomersVars = {
+    first: pageSize,
+    after: cursor,
+    [searchBy]: prevSearchBy === searchBy ? debouncedSearchVal : searchVal,
+  };
+
+  const [fetchFilteredCustomers, { data, error, called, loading }] = useLazyQuery<CUSTOMERS, CUSTOMERS_VARS>(
+    CUSTOMER_QUERY,
+    {
+      variables: filteredCustomersVars,
+    }
+  );
+
+  useEffect(() => {
+    if (!loading && !called) {
+      fetchFilteredCustomers();
+    }
+  }, [loading, called, fetchFilteredCustomers]);
+
+  useEffect(() => {
+    // Go to the first page when search values change.
+    goToPage(0);
+  }, [searchVal, searchBy, goToPage]);
 
   if (error)
     return (
@@ -37,6 +70,20 @@ const CustomersPageContainer: React.FC = () => {
           forcePage: pageIndex,
           pageCount: getPageCount(data?.profiles?.count),
           onPageChange: ({ selected }) => goToPage(selected),
+        }}
+        tableTools={{
+          searchVal,
+          searchBy,
+          setSearchVal,
+          setSearchBy: (searchBy) => {
+            setSearchBy(searchBy);
+          },
+          searchByOptions: [
+            { value: SearchBy.FIRST_NAME, label: t('common.firstName') },
+            { value: SearchBy.LAST_NAME, label: t('common.lastName') },
+            { value: SearchBy.EMAIL, label: t('common.email') },
+            { value: SearchBy.ADDRESS, label: t('common.address') },
+          ],
         }}
       />
     </CustomersPage>

--- a/src/domain/customers/__generated__/CUSTOMERS.ts
+++ b/src/domain/customers/__generated__/CUSTOMERS.ts
@@ -85,6 +85,10 @@ export interface CUSTOMERS {
 }
 
 export interface CUSTOMERSVariables {
-  after?: string | null;
   first: number;
+  after?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  email?: string | null;
+  address?: string | null;
 }

--- a/src/domain/customers/queries.ts
+++ b/src/domain/customers/queries.ts
@@ -1,8 +1,24 @@
 import { gql } from 'apollo-boost';
 
 export const CUSTOMER_QUERY = gql`
-  query CUSTOMERS($after: String, $first: Int!) {
-    profiles(serviceType: BERTH, first: $first, after: $after) {
+  query CUSTOMERS(
+    $first: Int!
+    $after: String
+    $firstName: String
+    $lastName: String
+    $email: String
+    $address: String
+  ) {
+    profiles(
+      first: $first
+      after: $after
+      serviceType: BERTH
+      firstName: $firstName
+      lastName: $lastName
+      emails_Email: $email
+      addresses_Address: $address
+      orderBy: "lastName"
+    ) {
       count
       edges {
         node {

--- a/src/domain/customers/tableTools/TableTools.tsx
+++ b/src/domain/customers/tableTools/TableTools.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import classNames from 'classnames';
+import { TextInput } from 'hds-react';
+
+import Select from '../../../common/select/Select';
+import styles from './tableTools.module.scss';
+
+export interface TableToolsProps<T> {
+  className?: string;
+  searchVal: string | undefined;
+  searchBy: T;
+  searchByOptions: Array<{ value: T; label: string }>;
+  setSearchVal(val: string): void;
+  setSearchBy(val: T): void;
+}
+
+const TableTools = <T extends string>({
+  className,
+  searchVal,
+  searchBy,
+  searchByOptions,
+  setSearchVal,
+  setSearchBy,
+}: TableToolsProps<T>) => {
+  return (
+    <div className={classNames(styles.tableTools, className)}>
+      <Select
+        className={styles.select}
+        onChange={(e) => setSearchBy(e.target.value as T)}
+        value={searchBy}
+        options={searchByOptions}
+        required
+      />
+      <TextInput
+        className={styles.searchInput}
+        id="searchSimilarCustomers"
+        value={searchVal}
+        onChange={(e) => setSearchVal((e.target as HTMLInputElement).value)}
+      />
+    </div>
+  );
+};
+
+export default TableTools;

--- a/src/domain/customers/tableTools/tableTools.module.scss
+++ b/src/domain/customers/tableTools/tableTools.module.scss
@@ -1,0 +1,23 @@
+@import 'spacings';
+@import 'colours';
+
+.tableTools {
+  margin-bottom: units(0.75);
+  display: flex;
+  justify-content: flex-end;
+
+  & > * {
+    margin-left: units(0.75);
+  }
+}
+
+.select {
+  width: 14em;
+}
+
+.searchInput {
+  background-color: $white;
+  margin-left: units(0.5);
+  width: 25%;
+  min-width: 12em;
+}


### PR DESCRIPTION
## Description :sparkles:

Add search field for customer list

Search by:

* first name
* last name
* address
* email

## Issues :bug:

### Closes :no_good_woman:

[VEN-596](https://helsinkisolutionoffice.atlassian.net/browse/VEN-596) | Customers page: search field for the table

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

Nada. 👎

### Manual testing :construction_worker_man:

Open the customer list
1. Test that data is filtered by first name, last name, address and email correctly
2. Test that the filtered data works with pagination

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:

Sorting works only for the current page. This is also the case for the reference, the single application page.
