### PR TITLE
VEN-658 | Always display notes in customer details cards

### DIFF
--- a/src/common/applicationDetails/__tests__/ApplicationDetails.test.tsx
+++ b/src/common/applicationDetails/__tests__/ApplicationDetails.test.tsx
@@ -65,7 +65,7 @@ describe('ApplicationDetails', () => {
       applicant: privateCustomerProfile,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.render()).toMatchSnapshot();
   });
 
   it('renders normally with organization customer applicant', () => {
@@ -73,6 +73,6 @@ describe('ApplicationDetails', () => {
       applicant: organizationCustomerProfile,
     });
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.render()).toMatchSnapshot();
   });
 });

--- a/src/common/applicationDetails/__tests__/__snapshots__/ApplicationDetails.test.tsx.snap
+++ b/src/common/applicationDetails/__tests__/__snapshots__/ApplicationDetails.test.tsx.snap
@@ -1,13 +1,985 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationDetails renders normally with organization customer applicant 1`] = `
-"<div class=\\"grid cols3\\"><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HAKEMUS</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Hakemustyyppi:</span><span class=\\"value left\\">Uusi hakemus</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Vastaanotettu:</span><span class=\\"value left\\">23.10.2019 klo 12.15</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jononumero:</span><span class=\\"value left\\">245</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Status:</span><span class=\\"value left\\">Odottaa käsittelyä</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HAKEVAN YRITYKSEN TIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Liikeyritys Oy</span></div> <div class=\\"labelValuePair\\"><span class=\\"label standard\\">Y-tunnus:</span><span class=\\"value left\\">1234567-8</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">Liiketoimintaraitti 12</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">00100</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">Helsinki</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yritys</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">YHTEYSHENKILÖ</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">0504391742</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">test@example.com</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VENEEN TIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen tyyppi:</span><span class=\\"value left\\">Purjevene / moottoripursi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Rekisterinumero:</span><span class=\\"value left\\">A 12345</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen leveys:</span><span class=\\"value left\\">3,2 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen pituus:</span><span class=\\"value left\\">6,0 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen syväys:</span><span class=\\"value left\\">0,8 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen paino:</span><span class=\\"value left\\">350 kg</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Cama la Yano</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Merkki:</span><span class=\\"value left\\">Marine</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VALITUT SATAMAT</h4><section class=\\"body\\"><ul class=\\"list standard noBullets\\"><li><span class=\\"text standard span\\">Toive 
-                      1: </span><a title=\\"Eka satama\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=123\\">Eka satama</a></li><li><span class=\\"text standard span\\">Toive 
-                      2: </span><a title=\\"Kolmas satama\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=321\\">Kolmas satama</a></li></ul></section></article><article class=\\"section\\"><section class=\\"body\\"><label><span class=\\"checkbox large checked readOnly\\"><svg class=\\"check\\">check.svg</svg><input type=\\"checkbox\\" checked=\\"\\" class=\\"input\\" readonly=\\"\\"/></span><span class=\\"label readOnly\\">Tarvitsen esteettömän paikan</span></label></section></article></div></div>"
+<div
+  class="grid cols3"
+>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HAKEMUS
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Hakemustyyppi:
+          </span>
+          <span
+            class="value left"
+          >
+            Uusi hakemus
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Vastaanotettu:
+          </span>
+          <span
+            class="value left"
+          >
+            23.10.2019 klo 12.15
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jononumero:
+          </span>
+          <span
+            class="value left"
+          >
+            245
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Status:
+          </span>
+          <span
+            class="value left"
+          >
+            Odottaa käsittelyä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HAKEVAN YRITYKSEN TIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Nimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Liikeyritys Oy
+          </span>
+        </div>
+         
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Y-tunnus:
+          </span>
+          <span
+            class="value left"
+          >
+            1234567-8
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            Liiketoimintaraitti 12
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            00100
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            Helsinki
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yritys
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        YHTEYSHENKILÖ
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            0504391742
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            test@example.com
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        VENEEN TIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen tyyppi:
+          </span>
+          <span
+            class="value left"
+          >
+            Purjevene / moottoripursi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Rekisterinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            A 12345
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen leveys:
+          </span>
+          <span
+            class="value left"
+          >
+            3,2 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen pituus:
+          </span>
+          <span
+            class="value left"
+          >
+            6,0 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen syväys:
+          </span>
+          <span
+            class="value left"
+          >
+            0,8 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen paino:
+          </span>
+          <span
+            class="value left"
+          >
+            350 kg
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Nimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Cama la Yano
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Merkki:
+          </span>
+          <span
+            class="value left"
+          >
+            Marine
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        VALITUT SATAMAT
+      </h4>
+      <section
+        class="body"
+      >
+        <ul
+          class="list standard noBullets"
+        >
+          <li>
+            <span
+              class="text standard span"
+            >
+              Toive 
+                      1: 
+            </span>
+            <a
+              class="internalLink brand"
+              href="#/offer/54321?harbor=123"
+              title="Eka satama"
+            >
+              Eka satama
+            </a>
+          </li>
+          <li>
+            <span
+              class="text standard span"
+            >
+              Toive 
+                      2: 
+            </span>
+            <a
+              class="internalLink brand"
+              href="#/offer/54321?harbor=321"
+              title="Kolmas satama"
+            >
+              Kolmas satama
+            </a>
+          </li>
+        </ul>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <label>
+          <span
+            class="checkbox large checked readOnly"
+          >
+            <svg
+              class="check"
+            >
+              check.svg
+            </svg>
+            <input
+              checked=""
+              class="input"
+              readonly=""
+              type="checkbox"
+            />
+          </span>
+          <span
+            class="label readOnly"
+          >
+            Tarvitsen esteettömän paikan
+          </span>
+        </label>
+      </section>
+    </article>
+  </div>
+</div>
 `;
 
 exports[`ApplicationDetails renders normally with private customer applicant 1`] = `
-"<div class=\\"grid cols3\\"><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HAKEMUS</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Hakemustyyppi:</span><span class=\\"value left\\">Uusi hakemus</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Vastaanotettu:</span><span class=\\"value left\\">23.10.2019 klo 12.15</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jononumero:</span><span class=\\"value left\\">245</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Status:</span><span class=\\"value left\\">Odottaa käsittelyä</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HAKIJAN HENKILÖTIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">Testikatu 1</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">00100</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">Helsinki</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">0504391742</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">test@example.com</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yksityinen</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VENEEN TIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen tyyppi:</span><span class=\\"value left\\">Purjevene / moottoripursi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Rekisterinumero:</span><span class=\\"value left\\">A 12345</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen leveys:</span><span class=\\"value left\\">3,2 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen pituus:</span><span class=\\"value left\\">6,0 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen syväys:</span><span class=\\"value left\\">0,8 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen paino:</span><span class=\\"value left\\">350 kg</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Cama la Yano</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Merkki:</span><span class=\\"value left\\">Marine</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VALITUT SATAMAT</h4><section class=\\"body\\"><ul class=\\"list standard noBullets\\"><li><span class=\\"text standard span\\">Toive 
-                      1: </span><a title=\\"Eka satama\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=123\\">Eka satama</a></li><li><span class=\\"text standard span\\">Toive 
-                      2: </span><a title=\\"Kolmas satama\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=321\\">Kolmas satama</a></li></ul></section></article><article class=\\"section\\"><section class=\\"body\\"><label><span class=\\"checkbox large checked readOnly\\"><svg class=\\"check\\">check.svg</svg><input type=\\"checkbox\\" checked=\\"\\" class=\\"input\\" readonly=\\"\\"/></span><span class=\\"label readOnly\\">Tarvitsen esteettömän paikan</span></label></section></article></div></div>"
+<div
+  class="grid cols3"
+>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HAKEMUS
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Hakemustyyppi:
+          </span>
+          <span
+            class="value left"
+          >
+            Uusi hakemus
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Vastaanotettu:
+          </span>
+          <span
+            class="value left"
+          >
+            23.10.2019 klo 12.15
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jononumero:
+          </span>
+          <span
+            class="value left"
+          >
+            245
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Status:
+          </span>
+          <span
+            class="value left"
+          >
+            Odottaa käsittelyä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HAKIJAN HENKILÖTIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            Testikatu 1
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            00100
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            Helsinki
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            0504391742
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            test@example.com
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yksityinen
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        VENEEN TIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen tyyppi:
+          </span>
+          <span
+            class="value left"
+          >
+            Purjevene / moottoripursi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Rekisterinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            A 12345
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen leveys:
+          </span>
+          <span
+            class="value left"
+          >
+            3,2 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen pituus:
+          </span>
+          <span
+            class="value left"
+          >
+            6,0 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen syväys:
+          </span>
+          <span
+            class="value left"
+          >
+            0,8 m
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Veneen paino:
+          </span>
+          <span
+            class="value left"
+          >
+            350 kg
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Nimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Cama la Yano
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Merkki:
+          </span>
+          <span
+            class="value left"
+          >
+            Marine
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+  <div>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        VALITUT SATAMAT
+      </h4>
+      <section
+        class="body"
+      >
+        <ul
+          class="list standard noBullets"
+        >
+          <li>
+            <span
+              class="text standard span"
+            >
+              Toive 
+                      1: 
+            </span>
+            <a
+              class="internalLink brand"
+              href="#/offer/54321?harbor=123"
+              title="Eka satama"
+            >
+              Eka satama
+            </a>
+          </li>
+          <li>
+            <span
+              class="text standard span"
+            >
+              Toive 
+                      2: 
+            </span>
+            <a
+              class="internalLink brand"
+              href="#/offer/54321?harbor=321"
+              title="Kolmas satama"
+            >
+              Kolmas satama
+            </a>
+          </li>
+        </ul>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <label>
+          <span
+            class="checkbox large checked readOnly"
+          >
+            <svg
+              class="check"
+            >
+              check.svg
+            </svg>
+            <input
+              checked=""
+              class="input"
+              readonly=""
+              type="checkbox"
+            />
+          </span>
+          <span
+            class="label readOnly"
+          >
+            Tarvitsen esteettömän paikan
+          </span>
+        </label>
+      </section>
+    </article>
+  </div>
+</div>
 `;

--- a/src/common/customerProfileCard/__tests__/CustomerProfileCard.test.tsx
+++ b/src/common/customerProfileCard/__tests__/CustomerProfileCard.test.tsx
@@ -20,14 +20,14 @@ describe('CustomerProfileCard', () => {
         firstName: 'Testi',
         lastName: 'Käyttäjä',
       });
-      expect(wrapper.html()).toMatchSnapshot();
+      expect(wrapper.render()).toMatchSnapshot();
     });
   });
 
   describe('with a private customer profile', () => {
     it('renders normally', () => {
       const wrapper = getWrapper(privateCustomerProfile);
-      expect(wrapper.html()).toMatchSnapshot();
+      expect(wrapper.render()).toMatchSnapshot();
     });
 
     it('does not show the customer names and ssn as links if not specified', () => {
@@ -55,14 +55,14 @@ describe('CustomerProfileCard', () => {
         lastName: 'Käyttäjä',
         organization: organizationCustomerProfile.organization,
       });
-      expect(wrapper.html()).toMatchSnapshot();
+      expect(wrapper.render()).toMatchSnapshot();
     });
   });
 
   describe('with an organization customer profile', () => {
     it('renders normally', () => {
       const wrapper = getWrapper(organizationCustomerProfile);
-      expect(wrapper.html()).toMatchSnapshot();
+      expect(wrapper.render()).toMatchSnapshot();
     });
 
     it('does not show the customer names and ssn as links if not specified', () => {

--- a/src/common/customerProfileCard/__tests__/__snapshots__/CustomerProfileCard.test.tsx.snap
+++ b/src/common/customerProfileCard/__tests__/__snapshots__/CustomerProfileCard.test.tsx.snap
@@ -1,9 +1,913 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CustomerProfileCard with a private customer profile renders normally 1`] = `"<div class=\\"card\\"><div class=\\"cardHeader\\"><span class=\\"title\\">ASIAKASTIEDOT</span></div><div class=\\"cardBody\\"><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HENKILÖTIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Henkilötunnus:</span><span class=\\"value left\\">010101A1234</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">Testikatu 1</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">00100</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">Helsinki</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">0504391742</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">test@example.com</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yksityinen</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\"></span><span class=\\"value left\\">Laskutus paperisena</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Huomiot:</span><span class=\\"value left\\">Testikäyttäjä</span></div></section></article></div> </div>"`;
+exports[`CustomerProfileCard with a private customer profile renders normally 1`] = `
+<div
+  class="card"
+>
+  <div
+    class="cardHeader"
+  >
+    <span
+      class="title"
+    >
+      ASIAKASTIEDOT
+    </span>
+  </div>
+  <div
+    class="cardBody"
+  >
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HENKILÖTIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Henkilötunnus:
+          </span>
+          <span
+            class="value left"
+          >
+            010101A1234
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            Testikatu 1
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            00100
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            Helsinki
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            0504391742
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            test@example.com
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yksityinen
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          />
+          <span
+            class="value left"
+          >
+            Laskutus paperisena
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            Testikäyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+   
+</div>
+`;
 
-exports[`CustomerProfileCard with an organization customer profile renders normally 1`] = `"<div class=\\"card\\"><div class=\\"cardHeader\\"><span class=\\"title\\">ASIAKASTIEDOT</span></div><div class=\\"cardBody\\"><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">YRITYS / YHTEISÖ</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Liikeyritys Oy</span></div> <div class=\\"labelValuePair\\"><span class=\\"label standard\\">Y-tunnus:</span><span class=\\"value left\\">1234567-8</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">Liiketoimintaraitti 12</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">00100</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">Helsinki</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yritys</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">YHTEYSHENKILÖ</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Henkilötunnus:</span><span class=\\"value left\\">010101A1234</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">0504391742</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">test@example.com</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\"></span><span class=\\"value left\\">Laskutus paperisena</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Huomiot:</span><span class=\\"value left\\">Testikäyttäjä</span></div></section></article></div> </div>"`;
+exports[`CustomerProfileCard with an organization customer profile renders normally 1`] = `
+<div
+  class="card"
+>
+  <div
+    class="cardHeader"
+  >
+    <span
+      class="title"
+    >
+      ASIAKASTIEDOT
+    </span>
+  </div>
+  <div
+    class="cardBody"
+  >
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        YRITYS / YHTEISÖ
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Nimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Liikeyritys Oy
+          </span>
+        </div>
+         
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Y-tunnus:
+          </span>
+          <span
+            class="value left"
+          >
+            1234567-8
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            Liiketoimintaraitti 12
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            00100
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            Helsinki
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yritys
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        YHTEYSHENKILÖ
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Henkilötunnus:
+          </span>
+          <span
+            class="value left"
+          >
+            010101A1234
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            0504391742
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            test@example.com
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          />
+          <span
+            class="value left"
+          >
+            Laskutus paperisena
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            Testikäyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+   
+</div>
+`;
 
-exports[`CustomerProfileCard with the minimum organization customer profile fields renders normally 1`] = `"<div class=\\"card\\"><div class=\\"cardHeader\\"><span class=\\"title\\">ASIAKASTIEDOT</span></div><div class=\\"cardBody\\"><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">YRITYS / YHTEISÖ</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Liikeyritys Oy</span></div> <div class=\\"labelValuePair\\"><span class=\\"label standard\\">Y-tunnus:</span><span class=\\"value left\\">1234567-8</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">Liiketoimintaraitti 12</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">00100</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">Helsinki</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yritys</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">YHTEYSHENKILÖ</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">-</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">-</span></div></section></article></div> </div>"`;
+exports[`CustomerProfileCard with the minimum organization customer profile fields renders normally 1`] = `
+<div
+  class="card"
+>
+  <div
+    class="cardHeader"
+  >
+    <span
+      class="title"
+    >
+      ASIAKASTIEDOT
+    </span>
+  </div>
+  <div
+    class="cardBody"
+  >
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        YRITYS / YHTEISÖ
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Nimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Liikeyritys Oy
+          </span>
+        </div>
+         
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Y-tunnus:
+          </span>
+          <span
+            class="value left"
+          >
+            1234567-8
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            Liiketoimintaraitti 12
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            00100
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            Helsinki
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yritys
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        YHTEYSHENKILÖ
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+   
+</div>
+`;
 
-exports[`CustomerProfileCard with the minimum private customer profile fields renders normally 1`] = `"<div class=\\"card\\"><div class=\\"cardHeader\\"><span class=\\"title\\">ASIAKASTIEDOT</span></div><div class=\\"cardBody\\"><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HENKILÖTIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Etunimet:</span><span class=\\"value left\\">Testi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sukunimi:</span><span class=\\"value left\\">Käyttäjä</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jakeluosoite:</span><span class=\\"value left\\">-</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postinumero:</span><span class=\\"value left\\">-</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Postitoimipaikka:</span><span class=\\"value left\\">-</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Matkapuhelin:</span><span class=\\"value left\\">-</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Sähköpostiosoite:</span><span class=\\"value left\\">-</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Asiakasryhmä:</span><span class=\\"value left\\">Yksityinen</span></div></section></article></div> </div>"`;
+exports[`CustomerProfileCard with the minimum private customer profile fields renders normally 1`] = `
+<div
+  class="card"
+>
+  <div
+    class="cardHeader"
+  >
+    <span
+      class="title"
+    >
+      ASIAKASTIEDOT
+    </span>
+  </div>
+  <div
+    class="cardBody"
+  >
+    <article
+      class="section"
+    >
+      <h4
+        class="text standard h4 m title"
+      >
+        HENKILÖTIEDOT
+      </h4>
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Etunimet:
+          </span>
+          <span
+            class="value left"
+          >
+            Testi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sukunimi:
+          </span>
+          <span
+            class="value left"
+          >
+            Käyttäjä
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Jakeluosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postinumero:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Postitoimipaikka:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Matkapuhelin:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Sähköpostiosoite:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiakasryhmä:
+          </span>
+          <span
+            class="value left"
+          >
+            Yksityinen
+          </span>
+        </div>
+      </section>
+    </article>
+    <article
+      class="section"
+    >
+      <section
+        class="body"
+      >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Huomiot:
+          </span>
+          <span
+            class="value left"
+          >
+            -
+          </span>
+        </div>
+      </section>
+    </article>
+  </div>
+   
+</div>
+`;

--- a/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
+++ b/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
@@ -108,7 +108,7 @@ const OrganizationCustomerDetails: FunctionComponent<OrganizationCustomerDetails
         </Section>
       )}
       <Section>
-        <LabelValuePair label={t('customerProfile.remarks')} value={comment ?? '-'} />
+        <LabelValuePair label={t('customerProfile.remarks')} value={comment} />
       </Section>
     </>
   );

--- a/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
+++ b/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
@@ -107,11 +107,9 @@ const OrganizationCustomerDetails: FunctionComponent<OrganizationCustomerDetails
           <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />
         </Section>
       )}
-      {comment && (
-        <Section>
-          <LabelValuePair label={t('customerProfile.remarks')} value={comment} />
-        </Section>
-      )}
+      <Section>
+        <LabelValuePair label={t('customerProfile.remarks')} value={comment ?? '-'} />
+      </Section>
     </>
   );
 };

--- a/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
+++ b/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
@@ -89,7 +89,7 @@ const PrivateCustomerDetails: FunctionComponent<PrivateCustomerDetailsProps> = (
         {invoicingType && <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />}
       </Section>
       <Section>
-        <LabelValuePair label={t('customerProfile.remarks')} value={comment ?? '-'} />
+        <LabelValuePair label={t('customerProfile.remarks')} value={comment} />
       </Section>
     </>
   );

--- a/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
+++ b/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
@@ -88,11 +88,9 @@ const PrivateCustomerDetails: FunctionComponent<PrivateCustomerDetailsProps> = (
         <LabelValuePair label={t('customerProfile.customerGroup')} value={t([`common.privateCustomer`])} />
         {invoicingType && <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />}
       </Section>
-      {comment && (
-        <Section>
-          <LabelValuePair label={t('customerProfile.remarks')} value={comment} />
-        </Section>
-      )}
+      <Section>
+        <LabelValuePair label={t('customerProfile.remarks')} value={comment ?? '-'} />
+      </Section>
     </>
   );
 };

--- a/src/features/customerView/applicationsCard/ApplicationsCard.test.jsx
+++ b/src/features/customerView/applicationsCard/ApplicationsCard.test.jsx
@@ -48,6 +48,6 @@ describe('ApplicationsCard', () => {
   it('renders normally', () => {
     const wrapper = getWrapper();
 
-    expect(wrapper.html()).toMatchSnapshot();
+    expect(wrapper.render()).toMatchSnapshot();
   });
 });

--- a/src/features/customerView/applicationsCard/__snapshots__/ApplicationsCard.test.jsx.snap
+++ b/src/features/customerView/applicationsCard/__snapshots__/ApplicationsCard.test.jsx.snap
@@ -1,7 +1,360 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationsCard renders normally 1`] = `
-"<div class=\\"card applicationsCard\\"><div class=\\"cardHeader\\"><span class=\\"title\\">HAKEMUKSET</span></div><div class=\\"cardBody\\"><div class=\\"grid cols3\\"><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">HAKEMUS</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Hakemustyyppi:</span><span class=\\"value left\\">Vaihtohakemus</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Vastaanotettu:</span><span class=\\"value left\\">23.10.2019 klo 12.15</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Jononumero:</span><span class=\\"value left\\">245</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Status:</span><span class=\\"value left\\">Odottaa käsittelyä</span></div></section></article><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">NYKYINEN VENEPAIKKA</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Satama ja paikka:</span><span class=\\"value left\\">harbor pier berth</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Erityistoive:</span><span class=\\"value left\\">reason</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VENEEN TIEDOT</h4><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen tyyppi:</span><span class=\\"value left\\">Purjevene / moottoripursi</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Rekisterinumero:</span><span class=\\"value left\\">A 12345</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen leveys:</span><span class=\\"value left\\">3,2 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen pituus:</span><span class=\\"value left\\">6,0 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen syväys:</span><span class=\\"value left\\">0,8 m</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Veneen paino:</span><span class=\\"value left\\">350 kg</span></div></section></article><article class=\\"section\\"><section class=\\"body\\"><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Nimi:</span><span class=\\"value left\\">Cama la Yano</span></div><div class=\\"labelValuePair\\"><span class=\\"label standard\\">Merkki:</span><span class=\\"value left\\">Marine</span></div></section></article></div><div><article class=\\"section\\"><h4 class=\\"text standard h4 m title\\">VALITUT SATAMAT</h4><section class=\\"body\\"><ul class=\\"list standard noBullets\\"><li><span class=\\"text standard span\\">Toive 
-                      1: </span><a title=\\"first choice\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=123\\">first choice</a></li><li><span class=\\"text standard span\\">Toive 
-                      2: </span><a title=\\"second choice\\" class=\\"internalLink brand\\" href=\\"#/offer/54321?harbor=321\\">second choice</a></li></ul></section></article><article class=\\"section\\"><section class=\\"body\\"><label><span class=\\"checkbox large checked readOnly\\"><svg class=\\"check\\">check.svg</svg><input type=\\"checkbox\\" checked=\\"\\" class=\\"input\\" readonly=\\"\\"/></span><span class=\\"label readOnly\\">Tarvitsen esteettömän paikan</span></label></section></article></div></div></div> </div>"
+<div
+  class="card applicationsCard"
+>
+  <div
+    class="cardHeader"
+  >
+    <span
+      class="title"
+    >
+      HAKEMUKSET
+    </span>
+  </div>
+  <div
+    class="cardBody"
+  >
+    <div
+      class="grid cols3"
+    >
+      <div>
+        <article
+          class="section"
+        >
+          <h4
+            class="text standard h4 m title"
+          >
+            HAKEMUS
+          </h4>
+          <section
+            class="body"
+          >
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Hakemustyyppi:
+              </span>
+              <span
+                class="value left"
+              >
+                Vaihtohakemus
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Vastaanotettu:
+              </span>
+              <span
+                class="value left"
+              >
+                23.10.2019 klo 12.15
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Jononumero:
+              </span>
+              <span
+                class="value left"
+              >
+                245
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Status:
+              </span>
+              <span
+                class="value left"
+              >
+                Odottaa käsittelyä
+              </span>
+            </div>
+          </section>
+        </article>
+        <article
+          class="section"
+        >
+          <h4
+            class="text standard h4 m title"
+          >
+            NYKYINEN VENEPAIKKA
+          </h4>
+          <section
+            class="body"
+          >
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Satama ja paikka:
+              </span>
+              <span
+                class="value left"
+              >
+                harbor pier berth
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Erityistoive:
+              </span>
+              <span
+                class="value left"
+              >
+                reason
+              </span>
+            </div>
+          </section>
+        </article>
+      </div>
+      <div>
+        <article
+          class="section"
+        >
+          <h4
+            class="text standard h4 m title"
+          >
+            VENEEN TIEDOT
+          </h4>
+          <section
+            class="body"
+          >
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Veneen tyyppi:
+              </span>
+              <span
+                class="value left"
+              >
+                Purjevene / moottoripursi
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Rekisterinumero:
+              </span>
+              <span
+                class="value left"
+              >
+                A 12345
+              </span>
+            </div>
+          </section>
+        </article>
+        <article
+          class="section"
+        >
+          <section
+            class="body"
+          >
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Veneen leveys:
+              </span>
+              <span
+                class="value left"
+              >
+                3,2 m
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Veneen pituus:
+              </span>
+              <span
+                class="value left"
+              >
+                6,0 m
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Veneen syväys:
+              </span>
+              <span
+                class="value left"
+              >
+                0,8 m
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Veneen paino:
+              </span>
+              <span
+                class="value left"
+              >
+                350 kg
+              </span>
+            </div>
+          </section>
+        </article>
+        <article
+          class="section"
+        >
+          <section
+            class="body"
+          >
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Nimi:
+              </span>
+              <span
+                class="value left"
+              >
+                Cama la Yano
+              </span>
+            </div>
+            <div
+              class="labelValuePair"
+            >
+              <span
+                class="label standard"
+              >
+                Merkki:
+              </span>
+              <span
+                class="value left"
+              >
+                Marine
+              </span>
+            </div>
+          </section>
+        </article>
+      </div>
+      <div>
+        <article
+          class="section"
+        >
+          <h4
+            class="text standard h4 m title"
+          >
+            VALITUT SATAMAT
+          </h4>
+          <section
+            class="body"
+          >
+            <ul
+              class="list standard noBullets"
+            >
+              <li>
+                <span
+                  class="text standard span"
+                >
+                  Toive 
+                      1: 
+                </span>
+                <a
+                  class="internalLink brand"
+                  href="#/offer/54321?harbor=123"
+                  title="first choice"
+                >
+                  first choice
+                </a>
+              </li>
+              <li>
+                <span
+                  class="text standard span"
+                >
+                  Toive 
+                      2: 
+                </span>
+                <a
+                  class="internalLink brand"
+                  href="#/offer/54321?harbor=321"
+                  title="second choice"
+                >
+                  second choice
+                </a>
+              </li>
+            </ul>
+          </section>
+        </article>
+        <article
+          class="section"
+        >
+          <section
+            class="body"
+          >
+            <label>
+              <span
+                class="checkbox large checked readOnly"
+              >
+                <svg
+                  class="check"
+                >
+                  check.svg
+                </svg>
+                <input
+                  checked=""
+                  class="input"
+                  readonly=""
+                  type="checkbox"
+                />
+              </span>
+              <span
+                class="label readOnly"
+              >
+                Tarvitsen esteettömän paikan
+              </span>
+            </label>
+          </section>
+        </article>
+      </div>
+    </div>
+  </div>
+   
+</div>
 `;


### PR DESCRIPTION
## Description :sparkles:

Makes customer details cards always display the comment field, even if it is empty (rendered as hyphen).

Additionally updates customer details card tests to use the new enzyme renderer.

### Closes :no_good_woman:

[VEN-658](https://helsinkisolutionoffice.atlassian.net/browse/VEN-658)
