### PR TITLE
VEN-683 | Back button issues

### DIFF
--- a/src/common/utils/__tests__/usePagination.test.tsx
+++ b/src/common/utils/__tests__/usePagination.test.tsx
@@ -144,5 +144,19 @@ describe('usePagination', () => {
 
       expect(history.location.search).toMatch(`?page=${pageIndex + 1}`);
     });
+
+    it('should not push duplicate page history entries in a row', () => {
+      const pageIndex = 2;
+      const { result } = renderHook(() => usePagination(), {
+        wrapper: getWrapper(''),
+      });
+      expect(history.length).toEqual(1);
+
+      result.current.goToPage(pageIndex);
+      expect(history.length).toEqual(2);
+
+      result.current.goToPage(pageIndex);
+      expect(history.length).toEqual(2);
+    });
   });
 });

--- a/src/common/utils/usePagination.ts
+++ b/src/common/utils/usePagination.ts
@@ -1,13 +1,12 @@
 import { useHistory } from 'react-router-dom';
 import { useCallback } from 'react';
+import { History } from 'history';
 
 const PAGE_SIZE = 10;
 
 export const usePagination = (pageSize = PAGE_SIZE) => {
   const history = useHistory();
-
-  const urlSearchParams = new URLSearchParams(history.location.search);
-  const pageParam = Number(urlSearchParams.get('page') ?? 1);
+  const pageParam = getCurrentPageParam(history);
   const pageIndex = !Number.isNaN(pageParam) ? pageParam - 1 : 0;
   const cursorIndex = pageIndex * pageSize;
   const cursor = cursorIndex > 0 ? btoa(`arrayconnection:${cursorIndex - 1}`) : undefined;
@@ -15,7 +14,17 @@ export const usePagination = (pageSize = PAGE_SIZE) => {
   const getPageCount = (connectionsCount: number | null | undefined) =>
     connectionsCount ? Math.ceil(connectionsCount / pageSize) : 1;
 
-  const goToPage = useCallback((pageIndex: number) => history.push({ search: `?page=${pageIndex + 1}` }), [history]);
+  const goToPage = useCallback(
+    (pageIndex: number) => {
+      const newPageNumber = pageIndex + 1;
+      const currentPageNumber = getCurrentPageParam(history);
+
+      if (currentPageNumber !== newPageNumber) {
+        history.push({ search: `?page=${newPageNumber}` });
+      }
+    },
+    [history]
+  );
 
   return {
     cursor,
@@ -24,4 +33,9 @@ export const usePagination = (pageSize = PAGE_SIZE) => {
     getPageCount,
     goToPage,
   };
+};
+
+const getCurrentPageParam = (history: History<History.LocationState>): number => {
+  const urlSearchParams = new URLSearchParams(history.location.search);
+  return Number(urlSearchParams.get('page') ?? 1);
 };

--- a/src/features/applicationView/ApplicationViewPageContainer.tsx
+++ b/src/features/applicationView/ApplicationViewPageContainer.tsx
@@ -87,7 +87,9 @@ const ApplicationViewPageContainer: React.FC = () => {
 
   useEffect(() => {
     // Go to the first page when search values change.
-    !customer && !loading && goToPage(0);
+    if (!customer && !loading) {
+      goToPage(0);
+    }
   }, [searchVal, searchBy, customer, loading, goToPage]);
 
   const [linkCustomer] = useMutation<UPDATE_BERTH_APPLICATION, UPDATE_BERTH_APPLICATION_VARS>(

--- a/src/features/customerList/CustomerListPageContainer.tsx
+++ b/src/features/customerList/CustomerListPageContainer.tsx
@@ -52,7 +52,7 @@ const CustomerListPageContainer: React.FC = () => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
     } else {
-      // Go to the first page when search values
+      // Go to the first page when search values change.
       goToPage(0);
     }
   }, [searchVal, searchBy, goToPage]);

--- a/src/features/customerList/CustomerListPageContainer.tsx
+++ b/src/features/customerList/CustomerListPageContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@apollo/react-hooks';
 import { useDebounce } from 'use-debounce';
@@ -45,9 +45,16 @@ const CustomerListPageContainer: React.FC = () => {
     alert(`CustomerIds: ${JSON.stringify(customerIds)} content: ${JSON.stringify(message)}`);
   };
 
+  const isInitialMount = useRef(true);
   useEffect(() => {
-    // Go to the first page when search values change.
-    goToPage(0);
+    // Prevent hook running on initial mount because it would force to first page on landing with direct url
+    // regardless of the page param
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      // Go to the first page when search values
+      goToPage(0);
+    }
   }, [searchVal, searchBy, goToPage]);
 
   const tableData = getCustomersData(data);


### PR DESCRIPTION
## Description :sparkles:
Fixes following issues
- Need to click back three times when opening application that has not been attached to customer
- Need to click back several times after you have used customer search field
- Forces to first page regardless of the url page param on customer list

### Closes :no_good_woman:
https://helsinkisolutionoffice.atlassian.net/browse/VEN-683

## Testing :alembic:
- Open application that has not been attached to customer, click back, it should take you to applications list
- Go to customer list, search with search box, click back, it should take you to previous screen
- Go to customer list, browse to third page, hit reload in browser, you should stay on third page

### Automated tests :gear:️
Added test case to `usePagination.test.tsx`