### PR TITLE
Change fetch policy of customerListContainer to "no-cache"

### DIFF
--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -38,6 +38,7 @@ const CustomerListContainer = () => {
 
   const { data, loading } = useQuery<CUSTOMERS, CUSTOMERS_VARS>(CUSTOMERS_QUERY, {
     variables: customersVars,
+    fetchPolicy: 'no-cache',
   });
 
   const handleSendMessage = (customerIds: string[], message: MessageFormValues) => {


### PR DESCRIPTION
## Description :sparkles:

* Change fetch policy of `customerListContainer` to `no-cache`

## Issues :bug:

### Closes :no_good_woman:

* [VEN-727](https://helsinkisolutionoffice.atlassian.net/browse/VEN-727): FE: data does not get loaded from the API when clicking "Back" button on single customer page

### Manual testing :construction_worker_man:

Check that this issue no longer occurs, check the specifics in [this comment](https://helsinkisolutionoffice.atlassian.net/browse/VEN-727?focusedCommentId=14720)

> 1. Go to the list of customers
> 2. Click on any customer to go to their single customer page
> 3. Click "Back" button in the browser
> 4. You will be back on the customers list page, but the data is not loaded
