### PR TITLE
VEN-540 | Show customer language in application and customer views

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -27,6 +27,12 @@ export enum ApplicationStatus {
   PENDING = "PENDING",
 }
 
+export enum BerthApplicationLanguage {
+  EN = "EN",
+  FI = "FI",
+  SV = "SV",
+}
+
 export enum BerthMooringType {
   DINGHY_PLACE = "DINGHY_PLACE",
   NO_STERN_TO_MOORING = "NO_STERN_TO_MOORING",
@@ -53,6 +59,12 @@ export enum InvoicingType {
   DIGITAL_INVOICE = "DIGITAL_INVOICE",
   ONLINE_PAYMENT = "ONLINE_PAYMENT",
   PAPER_INVOICE = "PAPER_INVOICE",
+}
+
+export enum Language {
+  ENGLISH = "ENGLISH",
+  FINNISH = "FINNISH",
+  SWEDISH = "SWEDISH",
 }
 
 export enum LeaseStatus {

--- a/src/common/customerProfileCard/CustomerProfileCard.stories.tsx
+++ b/src/common/customerProfileCard/CustomerProfileCard.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { boolean, withKnobs } from '@storybook/addon-knobs';
 
 import CustomerProfileCard from './CustomerProfileCard';
-import { InvoicingType, OrganizationType } from '../../@types/__generated__/globalTypes';
+import { InvoicingType, Language, OrganizationType } from '../../@types/__generated__/globalTypes';
 
 export default {
   component: CustomerProfileCard,
@@ -41,6 +41,7 @@ const baseCustomerProps = {
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
   Aenean malesuada id est ut pellentesque.
   Vivamus quis maximus sem. Ut auctor vestibulum mattis.`,
+  language: Language.FINNISH,
 };
 
 export const privateCustomer = () => (

--- a/src/common/customerProfileCard/__tests__/CustomerProfileCard.test.tsx
+++ b/src/common/customerProfileCard/__tests__/CustomerProfileCard.test.tsx
@@ -19,6 +19,7 @@ describe('CustomerProfileCard', () => {
       const wrapper = getWrapper({
         firstName: 'Testi',
         lastName: 'Käyttäjä',
+        language: null,
       });
       expect(wrapper.render()).toMatchSnapshot();
     });
@@ -54,6 +55,7 @@ describe('CustomerProfileCard', () => {
         firstName: 'Testi',
         lastName: 'Käyttäjä',
         organization: organizationCustomerProfile.organization,
+        language: null,
       });
       expect(wrapper.render()).toMatchSnapshot();
     });

--- a/src/common/customerProfileCard/__tests__/__snapshots__/CustomerProfileCard.test.tsx.snap
+++ b/src/common/customerProfileCard/__tests__/__snapshots__/CustomerProfileCard.test.tsx.snap
@@ -182,6 +182,20 @@ exports[`CustomerProfileCard with a private customer profile renders normally 1`
         >
           <span
             class="label standard"
+          >
+            Asiointikieli:
+          </span>
+          <span
+            class="value left"
+          >
+            Suomi
+          </span>
+        </div>
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
           />
           <span
             class="value left"
@@ -445,6 +459,20 @@ exports[`CustomerProfileCard with an organization customer profile renders norma
       <section
         class="body"
       >
+        <div
+          class="labelValuePair"
+        >
+          <span
+            class="label standard"
+          >
+            Asiointikieli:
+          </span>
+          <span
+            class="value left"
+          >
+            Suomi
+          </span>
+        </div>
         <div
           class="labelValuePair"
         >

--- a/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
+++ b/src/common/organizationCustomerDetails/OrganizationCustomerDetails.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import Section from '../section/Section';
 import LabelValuePair from '../labelValuePair/LabelValuePair';
 import InternalLink from '../internalLink/InternalLink';
-import { InvoicingType, OrganizationType } from '../../@types/__generated__/globalTypes';
+import { InvoicingType, Language, OrganizationType } from '../../@types/__generated__/globalTypes';
 
 export interface OrganizationCustomerDetailsProps {
   title?: string;
@@ -28,6 +28,7 @@ export interface OrganizationCustomerDetailsProps {
   } | null;
   primaryEmail?: string | null;
   primaryPhone?: string | null;
+  language: Language | null;
   showCustomerNameAsLink?: boolean;
   ssn?: string;
 }
@@ -42,6 +43,7 @@ const OrganizationCustomerDetails = ({
   organization,
   primaryEmail,
   primaryPhone,
+  language,
   showCustomerNameAsLink = false,
   ssn,
 }: OrganizationCustomerDetailsProps) => {
@@ -102,9 +104,12 @@ const OrganizationCustomerDetails = ({
         <LabelValuePair label={t('customerProfile.phone')} value={primaryPhone} />
         <LabelValuePair label={t('customerProfile.email')} value={primaryEmail} />
       </Section>
-      {invoicingType && (
+      {(language || invoicingType) && (
         <Section>
-          <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />
+          {language && (
+            <LabelValuePair label={t('customerProfile.language')} value={t([`common.languages.${language}`])} />
+          )}
+          {invoicingType && <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />}
         </Section>
       )}
       <Section>

--- a/src/common/organizationCustomerDetails/__fixtures__/mockData.ts
+++ b/src/common/organizationCustomerDetails/__fixtures__/mockData.ts
@@ -1,4 +1,4 @@
-import { InvoicingType, OrganizationType } from '../../../@types/__generated__/globalTypes';
+import { InvoicingType, Language, OrganizationType } from '../../../@types/__generated__/globalTypes';
 
 export const organizationCustomerProfile = {
   comment: 'Testikäyttäjä',
@@ -21,5 +21,6 @@ export const organizationCustomerProfile = {
   },
   primaryEmail: 'test@example.com',
   primaryPhone: '0504391742',
+  language: Language.FINNISH,
   ssn: '010101A1234',
 };

--- a/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
+++ b/src/common/privateCustomerDetails/PrivateCustomerDetails.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import Section from '../section/Section';
 import LabelValuePair from '../labelValuePair/LabelValuePair';
 import InternalLink from '../internalLink/InternalLink';
-import { InvoicingType } from '../../@types/__generated__/globalTypes';
+import { InvoicingType, Language } from '../../@types/__generated__/globalTypes';
 
 export interface PrivateCustomerDetailsProps {
   title?: string;
@@ -20,6 +20,7 @@ export interface PrivateCustomerDetailsProps {
   } | null;
   primaryEmail?: string | null;
   primaryPhone?: string | null;
+  language: Language | null;
   showCustomerNameAsLink?: boolean;
   ssn?: string;
 }
@@ -34,6 +35,7 @@ const PrivateCustomerDetails = ({
   primaryAddress,
   primaryEmail,
   primaryPhone,
+  language,
   showCustomerNameAsLink = false,
   ssn,
 }: PrivateCustomerDetailsProps) => {
@@ -86,6 +88,9 @@ const PrivateCustomerDetails = ({
       </Section>
       <Section>
         <LabelValuePair label={t('customerProfile.customerGroup')} value={t([`common.privateCustomer`])} />
+        {language && (
+          <LabelValuePair label={t('customerProfile.language')} value={t([`common.languages.${language}`])} />
+        )}
         {invoicingType && <LabelValuePair value={t([`common.invoicingTypes.${invoicingType}`])} />}
       </Section>
       <Section>

--- a/src/common/privateCustomerDetails/__fixtures__/mockData.ts
+++ b/src/common/privateCustomerDetails/__fixtures__/mockData.ts
@@ -1,4 +1,4 @@
-import { InvoicingType } from '../../../@types/__generated__/globalTypes';
+import { InvoicingType, Language } from '../../../@types/__generated__/globalTypes';
 
 export const privateCustomerProfile = {
   comment: 'Testikäyttäjä',
@@ -13,5 +13,6 @@ export const privateCustomerProfile = {
   },
   primaryEmail: 'test@example.com',
   primaryPhone: '0504391742',
+  language: Language.FINNISH,
   ssn: '010101A1234',
 };

--- a/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
+++ b/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { InvoicingType, OrganizationType, ApplicationStatus, BerthMooringType, ProductServiceType, AdditionalProductType, PriceUnits, PeriodType } from "./../../../@types/__generated__/globalTypes";
+import { BerthApplicationLanguage, InvoicingType, OrganizationType, Language, ApplicationStatus, BerthMooringType, ProductServiceType, AdditionalProductType, PriceUnits, PeriodType } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: INDIVIDUAL_APPLICATION
@@ -47,6 +47,7 @@ export interface INDIVIDUAL_APPLICATION_berthApplication_customer {
   primaryAddress: INDIVIDUAL_APPLICATION_berthApplication_customer_primaryAddress | null;
   primaryEmail: INDIVIDUAL_APPLICATION_berthApplication_customer_primaryEmail | null;
   primaryPhone: INDIVIDUAL_APPLICATION_berthApplication_customer_primaryPhone | null;
+  language: Language | null;
 }
 
 export interface INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_reason {
@@ -162,6 +163,7 @@ export interface INDIVIDUAL_APPLICATION_berthApplication {
   email: string;
   businessId: string;
   companyName: string;
+  language: BerthApplicationLanguage;
   customer: INDIVIDUAL_APPLICATION_berthApplication_customer | null;
   berthSwitch: INDIVIDUAL_APPLICATION_berthApplication_berthSwitch | null;
   createdAt: any;

--- a/src/features/applicationView/queries.ts
+++ b/src/features/applicationView/queries.ts
@@ -85,6 +85,7 @@ export const INDIVIDUAL_APPLICATION_QUERY = gql`
       email
       businessId
       companyName
+      language
       customer {
         comment
         firstName
@@ -110,6 +111,7 @@ export const INDIVIDUAL_APPLICATION_QUERY = gql`
         primaryPhone {
           phone
         }
+        language
       }
       berthSwitch {
         berthNumber

--- a/src/features/applicationView/utils.ts
+++ b/src/features/applicationView/utils.ts
@@ -6,6 +6,7 @@ import {
 } from './__generated__/INDIVIDUAL_APPLICATION';
 import { CustomerProfileCardProps } from '../../common/customerProfileCard/CustomerProfileCard';
 import { CustomerData } from './ApplicationView';
+import { BerthApplicationLanguage, Language } from '../../@types/__generated__/globalTypes';
 import { FILTERED_CUSTOMERS } from './__generated__/FILTERED_CUSTOMERS';
 
 export const getCustomerProfile = (profile: CUSTOMER_PROFILE): CustomerProfileCardProps => {
@@ -17,6 +18,7 @@ export const getCustomerProfile = (profile: CUSTOMER_PROFILE): CustomerProfileCa
     primaryPhone: profile.primaryPhone?.phone,
     primaryEmail: profile.primaryEmail?.email,
     ssn: '-', // TODO
+    language: profile.language,
     showCustomerNameAsLink: true,
   };
 };
@@ -37,6 +39,19 @@ interface BerthSwitch {
   reason: string | null;
 }
 
+const mapBerthApplicationLanguageToLanguage = (berthApplicationLanguage: BerthApplicationLanguage): Language | null => {
+  switch (berthApplicationLanguage) {
+    case BerthApplicationLanguage.FI:
+      return Language.FINNISH;
+    case BerthApplicationLanguage.SV:
+      return Language.SWEDISH;
+    case BerthApplicationLanguage.EN:
+      return Language.ENGLISH;
+    default:
+      return null;
+  }
+};
+
 const getApplicantDetails = (berthApplication: BERTH_APPLICATION): CustomerProfileCardProps => {
   const {
     firstName,
@@ -48,6 +63,7 @@ const getApplicantDetails = (berthApplication: BERTH_APPLICATION): CustomerProfi
     email,
     businessId,
     companyName,
+    language,
   } = berthApplication;
 
   return {
@@ -60,6 +76,7 @@ const getApplicantDetails = (berthApplication: BERTH_APPLICATION): CustomerProfi
     },
     primaryPhone: phoneNumber,
     primaryEmail: email,
+    language: mapBerthApplicationLanguageToLanguage(language),
     ...(businessId && {
       organization: {
         businessId,

--- a/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
+++ b/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { InvoicingType, OrganizationType, BoatCertificateType, LeaseStatus, ApplicationStatus } from "./../../../@types/__generated__/globalTypes";
+import { InvoicingType, OrganizationType, Language, BoatCertificateType, LeaseStatus, ApplicationStatus } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: INDIVIDUAL_CUSTOMER
@@ -221,6 +221,7 @@ export interface INDIVIDUAL_CUSTOMER_profile {
   primaryAddress: INDIVIDUAL_CUSTOMER_profile_primaryAddress | null;
   primaryEmail: INDIVIDUAL_CUSTOMER_profile_primaryEmail | null;
   primaryPhone: INDIVIDUAL_CUSTOMER_profile_primaryPhone | null;
+  language: Language | null;
   boats: INDIVIDUAL_CUSTOMER_profile_boats | null;
   berthLeases: INDIVIDUAL_CUSTOMER_profile_berthLeases | null;
   berthApplications: INDIVIDUAL_CUSTOMER_profile_berthApplications | null;

--- a/src/features/customerView/queries.ts
+++ b/src/features/customerView/queries.ts
@@ -27,6 +27,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
       primaryPhone {
         phone
       }
+      language
       boats {
         edges {
           node {

--- a/src/features/customerView/utils.ts
+++ b/src/features/customerView/utils.ts
@@ -15,6 +15,7 @@ export const getCustomerProfile = (profile: CUSTOMER_PROFILE): CustomerProfileCa
       primaryAddress: profile.primaryAddress,
       primaryPhone: profile.primaryPhone?.phone,
       primaryEmail: profile.primaryEmail?.email,
+      language: profile.language,
       ssn: '-', // TODO
     },
     ...(profile.organization && {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -80,6 +80,11 @@
       "MONTH": "1 kk",
       "YEAR": "Vuosi"
     },
+    "languages": {
+      "FINNISH": "Suomi",
+      "SWEDISH": "Ruotsi",
+      "ENGLISH": "Englanti"
+    },
     "terminology": {
       "address": "Osoite",
       "applications": "Hakemukset",
@@ -519,6 +524,7 @@
     "phone": "Matkapuhelin",
     "email": "Sähköpostiosoite",
     "customerGroup": "Asiakasryhmä",
+    "language": "Asiointikieli",
     "remarks": "Huomiot"
   },
   "harborCard": {


### PR DESCRIPTION
## Description :sparkles:

* Show customer language in application and customer views

## Issues :bug:

### Closes :no_good_woman:

* [VEN-540](https://helsinkisolutionoffice.atlassian.net/browse/VEN-540): Add customer's preferred language to customer details

## Testing :alembic:

### Automated tests :gear:️

* Updated test data and snapshots

### Manual testing :construction_worker_man:

* Check that language is shown on customer profile card in application view
  * [URL](http://localhost:3000/applications/QmVydGhBcHBsaWNhdGlvbk5vZGU6NDY=)
* Check that language is shown on customer profile card in customer view
  * [URL for private customer](http://localhost:3000/customers/UHJvZmlsZU5vZGU6MDNmZmQ4MjAtOGFlNi00OGUzLWE2ZGItZGFjNTkzMTkzMjQw)
  * [URL for organization customer](http://localhost:3000/customers/UHJvZmlsZU5vZGU6MzJlMjIyOTAtNWFjYi00ZTc0LTk2M2UtYmNlZDY3NTllOWU5)
* Check that language is showin in stories for CustomerProfileCard
  * [URL for private customer](http://localhost:6006/?path=/story/customerprofilecard--private-customer)
  * [URL for organization customer](http://localhost:6006/?path=/story/customerprofilecard--organization-customer)