### PR TITLE
VEN-737 | Show unnamed boats in customer list

### DIFF
--- a/src/features/customerList/customerDetails/CustomerDetails.tsx
+++ b/src/features/customerList/customerDetails/CustomerDetails.tsx
@@ -51,7 +51,7 @@ const CustomerDetails = ({
     <div>
       <Grid colsCount={4}>
         <div>
-          <Section title={t('harborList.details.customer')}>{name}</Section>
+          <Section title={t('common.terminology.customer').toUpperCase()}>{name}</Section>
           <Section>
             {address}
             <br />
@@ -66,17 +66,17 @@ const CustomerDetails = ({
           </Section>
         </div>
         <div>
-          <Section title={t('harborList.details.berths')}>
+          <Section title={t('common.terminology.berths').toUpperCase()}>
             {berths.map((berth) => (
               <div key={berth.id}>{berth.title}</div>
             ))}
           </Section>
-          <Section title={t('harborList.details.winterStoragePlaces')}>
+          <Section title={t('common.terminology.winterStoragePlaces').toUpperCase()}>
             {winterStoragePlaces.map((place) => (
               <div key={place.id}>{place.title}</div>
             ))}
           </Section>
-          <Section title={t('harborList.details.boats')}>
+          <Section title={t('common.terminology.boats').toUpperCase()}>
             {boats.map((boat) => (
               <div key={boat.id}>
                 {boat.name.length > 0 ? boat.name : <Text italic>{t('common.terminology.unnamedBoat')}</Text>}
@@ -85,19 +85,19 @@ const CustomerDetails = ({
           </Section>
         </div>
         <div>
-          <Section title={t('harborList.details.applications')}>
+          <Section title={t('common.terminology.applications').toUpperCase()}>
             {applications.map((application) => (
               <div key={application.id}>{formatDate(application.createdAt, i18n.language)}</div>
             ))}
           </Section>
-          <Section title={t('harborList.details.bills')}>
+          <Section title={t('common.terminology.bills').toUpperCase()}>
             {bills.map((bill) => (
               <div key={bill.id}>{bill.date}</div>
             ))}
           </Section>
         </div>
         <div>
-          <Section title={t('harborList.details.comments')}>{comment}</Section>
+          <Section title={t('common.terminology.comments').toUpperCase()}>{comment}</Section>
         </div>
       </Grid>
     </div>

--- a/src/features/customerList/customerDetails/CustomerDetails.tsx
+++ b/src/features/customerList/customerDetails/CustomerDetails.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import Grid from '../../../common/grid/Grid';
 import Section from '../../../common/section/Section';
+import Text from '../../../common/text/Text';
 import { OrganizationType } from '../../../@types/__generated__/globalTypes';
 import {
   CustomerListApplication,
@@ -77,7 +78,9 @@ const CustomerDetails = ({
           </Section>
           <Section title={t('harborList.details.boats')}>
             {boats.map((boat) => (
-              <div key={boat.id}>{boat.name}</div>
+              <div key={boat.id}>
+                {boat.name.length > 0 ? boat.name : <Text italic>{t('common.terminology.unnamedBoat')}</Text>}
+              </div>
             ))}
           </Section>
         </div>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -82,13 +82,19 @@
     },
     "terminology": {
       "address": "Osoite",
+      "applications": "Hakemukset",
       "berth": "Venepaikka",
+      "berths": "Venepaikat",
+      "bills": "Laskut",
+      "boatSummerStorage": "Veneiden kesäsäilytys",
+      "boats": "Veneet",
+      "comments": "Huomiot",
+      "customer": "Asiakas",
       "dataEntry": "Tietue",
       "depth": "Syvyys",
       "dinghyPlace": "Jollapaikka",
-      "draught": "Syväys",
       "dockingEquipmentSummerStorage": "Telakointi\u00ADtarvikkeiden kesäsäilytys",
-      "boatSummerStorage": "Veneiden kesäsäilytys",
+      "draught": "Syväys",
       "electricity": "Sähkö",
       "gate": "Portti",
       "harborChief": "Satamapäällikkö",
@@ -106,7 +112,8 @@
       "waste": "Jäte",
       "wasteCollection": "Jätehuolto",
       "water": "Vesi",
-      "width": "Leveys"
+      "width": "Leveys",
+      "winterStoragePlaces": "Talvisäilytyspaikat"
     },
     "notification": {
       "noData": {
@@ -194,15 +201,6 @@
       "harbor": "Satama",
       "places": "Paikkoja",
       "freePlaces": "Vapaita"
-    },
-    "details": {
-      "customer": "ASIAKAS",
-      "berths": "VENEPAIKAT",
-      "winterStoragePlaces": "TALVISÄILYTYSPAIKAT",
-      "boats": "VENEET",
-      "applications": "HAKEMUKSET",
-      "bills": "LASKUT",
-      "comments": "HUOMIOT"
     }
   },
   "harborView": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -102,6 +102,7 @@
       "parkingPermit": "Pysäköintilupa",
       "serviceMap": "Palvelukartta",
       "trawlerSummerStorage": "Trailerin kesäsäilytys",
+      "unnamedBoat": "Nimetön vene",
       "waste": "Jäte",
       "wasteCollection": "Jätehuolto",
       "water": "Vesi",


### PR DESCRIPTION
## Description :sparkles:

* Show unnamed boats in customer list
* Move CustomerDetails titles to `common.terminology`

## Issues :bug:

### Closes :no_good_woman:

* [VEN-737](https://helsinkisolutionoffice.atlassian.net/browse/VEN-737): FE - Customers list page: List unnamed boats

## Testing :alembic:

### Manual testing :construction_worker_man:

* Verify that unnamed boats are shown as 'Nimetön vene' in expanded row (CustomerDetails)

