### PR TITLE
Add temporary fix for fetching customer WS leases

### DIFF
--- a/src/features/linkApplicationToCustomer/__fixtures__/mockData.ts
+++ b/src/features/linkApplicationToCustomer/__fixtures__/mockData.ts
@@ -62,10 +62,7 @@ const winterStorageLeases: WINTER_STORAGE_LEASES = {
       __typename: 'WinterStorageLeaseNodeEdge',
       node: {
         __typename: 'WinterStorageLeaseNode',
-        area: {
-          __typename: 'WinterStorageAreaNode',
-          properties: { __typename: 'WinterStorageAreaProperties', name: 'Test winter storage area' },
-        },
+        id: '123',
       },
     },
   ],

--- a/src/features/linkApplicationToCustomer/__generated__/FILTERED_CUSTOMERS.ts
+++ b/src/features/linkApplicationToCustomer/__generated__/FILTERED_CUSTOMERS.ts
@@ -64,19 +64,9 @@ export interface FILTERED_CUSTOMERS_profiles_edges_node_berthLeases {
   edges: (FILTERED_CUSTOMERS_profiles_edges_node_berthLeases_edges | null)[];
 }
 
-export interface FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges_node_area_properties {
-  __typename: "WinterStorageAreaProperties";
-  name: string | null;
-}
-
-export interface FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges_node_area {
-  __typename: "WinterStorageAreaNode";
-  properties: FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges_node_area_properties | null;
-}
-
 export interface FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges_node {
   __typename: "WinterStorageLeaseNode";
-  area: FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges_node_area | null;
+  id: string;
 }
 
 export interface FILTERED_CUSTOMERS_profiles_edges_node_winterStorageLeases_edges {

--- a/src/features/linkApplicationToCustomer/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/linkApplicationToCustomer/__tests__/__snapshots__/utils.test.ts.snap
@@ -9,7 +9,7 @@ Array [
     "customerGroup": "PRIVATE",
     "id": "MOCK-PROFILE",
     "name": "Testinen, Testi",
-    "winterStoragePlaces": "Test winter storage area",
+    "winterStoragePlaces": "",
   },
 ]
 `;

--- a/src/features/linkApplicationToCustomer/queries.ts
+++ b/src/features/linkApplicationToCustomer/queries.ts
@@ -58,11 +58,7 @@ export const FILTERED_CUSTOMERS_QUERY = gql`
           winterStorageLeases {
             edges {
               node {
-                area {
-                  properties {
-                    name
-                  }
-                }
+                id
               }
             }
           }

--- a/src/features/linkApplicationToCustomer/utils.ts
+++ b/src/features/linkApplicationToCustomer/utils.ts
@@ -19,21 +19,15 @@ export const getFilteredCustomersData = (data?: FILTERED_CUSTOMERS): CustomerDat
   if (!data?.profiles) return [];
 
   return data.profiles.edges.reduce<CustomerData[]>((acc, edge) => {
-    const {
-      id,
-      firstName,
-      lastName,
-      primaryAddress,
-      berthLeases,
-      winterStorageLeases,
-      customerGroup,
-    } = (edge as PROFILE_EDGE).node as PROFILE_NODE;
+    const { id, firstName, lastName, primaryAddress, berthLeases, customerGroup } = (edge as PROFILE_EDGE)
+      .node as PROFILE_NODE;
 
     const berths = berthLeases?.edges
       .map((edge) => edge?.node?.berth?.pier.properties?.harbor.properties?.name)
       .join(', ');
 
-    const winterStoragePlaces = winterStorageLeases?.edges.map((edge) => edge?.node?.area?.properties?.name).join(', ');
+    // TODO resolve place names
+    const winterStoragePlaces = '';
 
     return [
       ...acc,


### PR DESCRIPTION
## Description :sparkles:
Because of [VEN-813](https://helsinkisolutionoffice.atlassian.net/browse/VEN-813) we should fetch ws lease `section` instead of `area`. As temporary fix remove the `area` reference to get the query working. We need to fix the whole lease names resolving because the implementation did not take marked ws leases in account (only resolved the unmarked names via area). Will create a separate bug issue from that.

## Issues :bug:

### Related :handshake:
[VEN-813](https://helsinkisolutionoffice.atlassian.net/browse/VEN-813)
## Testing :alembic:

### Manual testing :construction_worker_man:
- land to `http://localhost:3000/applications/QmVydGhBcHBsaWNhdGlvbk5vZGU6NjY=`
- you should be able to search customer to attach to
