### PR TITLE
Use temporarily direct BE URL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ build-production:
   variables:
     DOCKER_IMAGE_NAME: "$CI_PROJECT_NAME-production"
     DOCKER_BUILD_ARG_REACT_APP_SERVICE_MAP_URI: "https://palvelukartta.hel.fi/unit/"
-    DOCKER_BUILD_ARG_REACT_APP_API_URI: https://api.hel.fi/berths-federation/
+    DOCKER_BUILD_ARG_REACT_APP_API_URI: https://venepaikka-federation.prod.kuva.hel.ninja/
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: https://api.hel.fi/sso
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: "api-tokens"
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_RENEW_ENDPOINT: "silent_renew"


### PR DESCRIPTION
## Description :sparkles:

As the proper URL for the BE is behind a nginx proxy managed
by Kanslia, which is pending necessary config updates, we
could temporarily use the original URL that is provided directly
by Kuva's infra.

Needed to get further testing going by the end users in prod.