### PR TITLE
VEN-834 | Fix create customer button on the single application page

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -17,6 +17,13 @@ export enum AdditionalProductType {
   OPTIONAL_SERVICE = "OPTIONAL_SERVICE",
 }
 
+export enum AddressType {
+  HOME = "HOME",
+  NONE = "NONE",
+  OTHER = "OTHER",
+  WORK = "WORK",
+}
+
 export enum ApplicationStatus {
   EXPIRED = "EXPIRED",
   HANDLED = "HANDLED",
@@ -90,6 +97,7 @@ export enum NotificationTemplateLanguage {
 }
 
 export enum OrderStatus {
+  CANCELLED = "CANCELLED",
   EXPIRED = "EXPIRED",
   PAID = "PAID",
   REJECTED = "REJECTED",
@@ -146,6 +154,15 @@ export interface AddBoatCertificateInput {
   checkedBy?: string | null;
 }
 
+export interface CreateAddressInput {
+  countryCode?: string | null;
+  primary?: boolean | null;
+  address: string;
+  postalCode: string;
+  city: string;
+  addressType: AddressType;
+}
+
 export interface CreateBerthLeaseMutationInput {
   boatId?: string | null;
   startDate?: any | null;
@@ -173,6 +190,14 @@ export interface CreateBerthProductMutationInput {
   priceValue: any;
   priceGroupId: string;
   harborId?: string | null;
+  clientMutationId?: string | null;
+}
+
+export interface CreateBerthServicesProfileMutationInput {
+  invoicingType?: InvoicingType | null;
+  comment?: string | null;
+  id: string;
+  organization?: OrganizationInput | null;
   clientMutationId?: string | null;
 }
 
@@ -249,6 +274,15 @@ export interface DeletePierMutationInput {
 export interface DeleteWinterStorageLeaseMutationInput {
   id: string;
   clientMutationId?: string | null;
+}
+
+export interface OrganizationInput {
+  organizationType: OrganizationType;
+  businessId?: string | null;
+  name?: string | null;
+  address?: string | null;
+  postalCode?: string | null;
+  city?: string | null;
 }
 
 export interface UpdateAdditionalProductMutationInput {

--- a/src/common/hooks/__fixtures__/useCreateNewCustomerMockData.ts
+++ b/src/common/hooks/__fixtures__/useCreateNewCustomerMockData.ts
@@ -1,0 +1,92 @@
+import { CREATE_NEW_PROFILE_MUTATION } from '../../mutations/createProfile';
+import { AddressType } from '../../../@types/__generated__/globalTypes';
+
+export const customerInfoMock = {
+  firstName: 'John',
+  lastName: 'Doe',
+  address: 'Address',
+  email: 'john@doe.net',
+  phoneNumber: '+358111111111',
+  zipCode: '00100',
+  municipality: 'Helsinki',
+  businessId: '',
+  companyName: '',
+};
+
+export const responseIdMock = '1234';
+
+export const createProfileMutationMock = {
+  request: {
+    query: CREATE_NEW_PROFILE_MUTATION,
+    variables: {
+      firstName: customerInfoMock.firstName,
+      lastName: customerInfoMock.lastName,
+      addresses: [
+        {
+          address: customerInfoMock.address,
+          postalCode: customerInfoMock.zipCode,
+          city: customerInfoMock.municipality,
+          primary: true,
+          addressType: AddressType.NONE,
+        },
+      ],
+      phone: customerInfoMock.phoneNumber,
+      email: customerInfoMock.email,
+    },
+  },
+  result: {
+    data: {
+      createProfile: {
+        profile: {
+          id: responseIdMock,
+          lastName: customerInfoMock.lastName,
+          firstName: customerInfoMock.firstName,
+          primaryAddress: {
+            address: customerInfoMock.address,
+            city: customerInfoMock.municipality,
+            __typename: 'AddressNode',
+          },
+          __typename: 'ProfileNode',
+        },
+        __typename: 'CreateProfileMutationPayload',
+      },
+    },
+  },
+};
+
+export const organizationCustomerInfoMock = {
+  firstName: 'John',
+  lastName: 'Doe',
+  address: 'Address',
+  email: 'john@doe.net',
+  phoneNumber: '+358111111111',
+  zipCode: '00100',
+  municipality: 'Helsinki',
+  businessId: '111111',
+  companyName: 'Test Oy',
+};
+
+export const createOrganizationProfileMutationMock = {
+  request: {
+    query: CREATE_NEW_PROFILE_MUTATION,
+    variables: {
+      firstName: organizationCustomerInfoMock.firstName,
+      lastName: organizationCustomerInfoMock.lastName,
+      phone: organizationCustomerInfoMock.phoneNumber,
+      email: organizationCustomerInfoMock.email,
+    },
+  },
+  result: {
+    data: {
+      createProfile: {
+        profile: {
+          id: responseIdMock,
+          lastName: organizationCustomerInfoMock.lastName,
+          firstName: organizationCustomerInfoMock.firstName,
+          __typename: 'ProfileNode',
+        },
+        __typename: 'CreateProfileMutationPayload',
+      },
+    },
+  },
+};

--- a/src/common/hooks/__tests__/useCreateNewCustomer.test.tsx
+++ b/src/common/hooks/__tests__/useCreateNewCustomer.test.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect } from 'react';
+import { MockedProvider } from '@apollo/react-testing';
+import { mount } from 'enzyme';
+import waitForExpect from 'wait-for-expect';
+import { act } from 'react-dom/test-utils';
+
+import useCreateNewCustomer, { CustomerInfo } from '../useCreateNewCustomer';
+import { CREATE_BERTH_SERVICE_PROFILE_MUTATION } from '../../mutations/createProfile';
+import {
+  createOrganizationProfileMutationMock,
+  createProfileMutationMock,
+  customerInfoMock,
+  organizationCustomerInfoMock,
+  responseIdMock,
+} from '../__fixtures__/useCreateNewCustomerMockData';
+import { OrganizationType } from '../../../@types/__generated__/globalTypes';
+
+const CallsCreateUser = ({ customerInfo }: { customerInfo: CustomerInfo }) => {
+  const createNewCustomer = useCreateNewCustomer();
+  useEffect(() => createNewCustomer(customerInfo), []);
+  return null;
+};
+
+describe('useCreateNewCustomer', () => {
+  beforeEach(() => {
+    // Disable console.warn to silence MockedProvider from complaining about missing fields in result values.
+    jest.spyOn(console, 'warn').mockImplementation(() => {
+      /* NO-OP */
+    });
+  });
+
+  it('calls createProfile and createBerthServicesProfile correctly', async () => {
+    let createBerthServiceProfileCalled = false;
+    const createCustomerProfileMutationMocks = [
+      createProfileMutationMock,
+      {
+        request: { query: CREATE_BERTH_SERVICE_PROFILE_MUTATION, variables: { input: { id: responseIdMock } } },
+        result: () => {
+          createBerthServiceProfileCalled = true;
+          return { data: {} };
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockedProvider mocks={createCustomerProfileMutationMocks}>
+        <CallsCreateUser customerInfo={customerInfoMock} />
+      </MockedProvider>
+    );
+
+    await act(async () => {
+      await waitForExpect(() => {
+        wrapper.update();
+        expect(createBerthServiceProfileCalled).toBe(true);
+      });
+    });
+  });
+
+  it('calls createBerthServicesProfile with organization information when businessId is present', async () => {
+    let createBerthServiceProfileCalled = false;
+    const createOrganizationCustomerProfileMutationMocks = [
+      createOrganizationProfileMutationMock,
+      {
+        request: {
+          query: CREATE_BERTH_SERVICE_PROFILE_MUTATION,
+          variables: {
+            input: {
+              id: responseIdMock,
+              organization: {
+                businessId: organizationCustomerInfoMock.businessId,
+                name: organizationCustomerInfoMock.companyName,
+                organizationType: OrganizationType.COMPANY,
+                address: organizationCustomerInfoMock.address,
+                postalCode: organizationCustomerInfoMock.zipCode,
+                city: organizationCustomerInfoMock.municipality,
+              },
+            },
+          },
+        },
+        result: () => {
+          createBerthServiceProfileCalled = true;
+          return { data: {} };
+        },
+      },
+    ];
+
+    const wrapper = mount(
+      <MockedProvider mocks={createOrganizationCustomerProfileMutationMocks}>
+        <CallsCreateUser customerInfo={organizationCustomerInfoMock} />
+      </MockedProvider>
+    );
+
+    await act(async () => {
+      await waitForExpect(() => {
+        wrapper.update();
+        expect(createBerthServiceProfileCalled).toBe(true);
+      });
+    });
+  });
+});

--- a/src/common/hooks/useCreateNewCustomer.ts
+++ b/src/common/hooks/useCreateNewCustomer.ts
@@ -1,0 +1,102 @@
+import { useMutation } from '@apollo/react-hooks';
+import { PureQueryOptions } from 'apollo-client';
+import { RefetchQueriesFunction } from '@apollo/react-common';
+
+import {
+  CREATE_NEW_PROFILE,
+  CREATE_NEW_PROFILEVariables as CREATE_NEW_PROFILE_VARS,
+} from '../mutations/__generated__/CREATE_NEW_PROFILE';
+import { CREATE_BERTH_SERVICE_PROFILE_MUTATION, CREATE_NEW_PROFILE_MUTATION } from '../mutations/createProfile';
+import {
+  CREATE_BERTH_SERVICE_PROFILE,
+  CREATE_BERTH_SERVICE_PROFILEVariables as CREATE_BERTH_SERVICE_PROFILE_VARS,
+} from '../mutations/__generated__/CREATE_BERTH_SERVICE_PROFILE';
+import { AddressType, OrganizationType } from '../../@types/__generated__/globalTypes';
+
+export type CustomerInfo = {
+  firstName: string;
+  lastName: string;
+  address: string;
+  email: string;
+  phoneNumber: string;
+  zipCode: string;
+  municipality: string;
+  businessId: string;
+  companyName: string;
+};
+
+const useCreateNewCustomer = (refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction) => {
+  const [createNewCustomer] = useMutation<CREATE_NEW_PROFILE, CREATE_NEW_PROFILE_VARS>(CREATE_NEW_PROFILE_MUTATION, {
+    refetchQueries,
+  });
+
+  const [createNewBerthProfile] = useMutation<CREATE_BERTH_SERVICE_PROFILE, CREATE_BERTH_SERVICE_PROFILE_VARS>(
+    CREATE_BERTH_SERVICE_PROFILE_MUTATION,
+    { refetchQueries }
+  );
+
+  return (customerInfo: CustomerInfo) => {
+    const {
+      firstName,
+      lastName,
+      address,
+      email,
+      phoneNumber,
+      zipCode,
+      municipality,
+      businessId,
+      companyName,
+    } = customerInfo;
+
+    if (businessId === '') {
+      createNewCustomer({
+        variables: {
+          firstName: firstName,
+          lastName: lastName,
+          addresses: [
+            { address, postalCode: zipCode, city: municipality, primary: true, addressType: AddressType.NONE },
+          ],
+          phone: phoneNumber,
+          email: email,
+        },
+      }).then(({ data }) => {
+        if (!data?.createProfile?.profile?.id) {
+          return;
+        }
+        return createNewBerthProfile({
+          variables: { input: { id: data.createProfile.profile.id } },
+        });
+      });
+    } else {
+      createNewCustomer({
+        variables: {
+          firstName: firstName,
+          lastName: lastName,
+          phone: phoneNumber,
+          email: email,
+        },
+      }).then(({ data }) => {
+        if (!data?.createProfile?.profile?.id) {
+          return;
+        }
+        return createNewBerthProfile({
+          variables: {
+            input: {
+              id: data.createProfile.profile.id,
+              organization: {
+                businessId,
+                name: companyName,
+                organizationType: OrganizationType.COMPANY,
+                address,
+                postalCode: zipCode,
+                city: municipality,
+              },
+            },
+          },
+        });
+      });
+    }
+  };
+};
+
+export default useCreateNewCustomer;

--- a/src/common/mutations/__generated__/CREATE_BERTH_SERVICE_PROFILE.ts
+++ b/src/common/mutations/__generated__/CREATE_BERTH_SERVICE_PROFILE.ts
@@ -1,0 +1,39 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateBerthServicesProfileMutationInput, InvoicingType, OrganizationType } from "./../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: CREATE_BERTH_SERVICE_PROFILE
+// ====================================================
+
+export interface CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile_profile_organization {
+  __typename: "OrganizationNode";
+  id: string;
+  organizationType: OrganizationType;
+  businessId: string;
+  name: string;
+}
+
+export interface CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile_profile {
+  __typename: "ProfileNode";
+  id: string;
+  invoicingType: InvoicingType | null;
+  comment: string | null;
+  organization: CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile_profile_organization | null;
+}
+
+export interface CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile {
+  __typename: "CreateBerthServicesProfileMutationPayload";
+  profile: CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile_profile | null;
+}
+
+export interface CREATE_BERTH_SERVICE_PROFILE {
+  createBerthServicesProfile: CREATE_BERTH_SERVICE_PROFILE_createBerthServicesProfile | null;
+}
+
+export interface CREATE_BERTH_SERVICE_PROFILEVariables {
+  input: CreateBerthServicesProfileMutationInput;
+}

--- a/src/common/mutations/__generated__/CREATE_NEW_PROFILE.ts
+++ b/src/common/mutations/__generated__/CREATE_NEW_PROFILE.ts
@@ -3,6 +3,8 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
+import { CreateAddressInput } from "./../../../@types/__generated__/globalTypes";
+
 // ====================================================
 // GraphQL mutation operation: CREATE_NEW_PROFILE
 // ====================================================
@@ -33,9 +35,7 @@ export interface CREATE_NEW_PROFILE {
 export interface CREATE_NEW_PROFILEVariables {
   firstName: string;
   lastName: string;
-  address: string;
-  postalCode: string;
-  city: string;
+  addresses?: (CreateAddressInput | null)[] | null;
   email: string;
   phone: string;
 }

--- a/src/common/mutations/createProfile.ts
+++ b/src/common/mutations/createProfile.ts
@@ -14,7 +14,7 @@ export const CREATE_NEW_PROFILE_MUTATION = gql`
         profile: {
           firstName: $firstName
           lastName: $lastName
-          addAddresses: { address: $address, postalCode: $postalCode, city: $city, primary: true, addressType: NONE }
+          addAddresses: $addresses
           addEmails: { email: $email, emailType: NONE, primary: true }
           addPhones: { phone: $phone, phoneType: NONE, primary: true }
         }

--- a/src/common/mutations/createProfile.ts
+++ b/src/common/mutations/createProfile.ts
@@ -4,9 +4,7 @@ export const CREATE_NEW_PROFILE_MUTATION = gql`
   mutation CREATE_NEW_PROFILE(
     $firstName: String!
     $lastName: String!
-    $address: String!
-    $postalCode: String!
-    $city: String!
+    $addresses: [CreateAddressInput]
     $email: String!
     $phone: String!
   ) {
@@ -29,6 +27,24 @@ export const CREATE_NEW_PROFILE_MUTATION = gql`
         primaryAddress {
           address
           city
+        }
+      }
+    }
+  }
+`;
+
+export const CREATE_BERTH_SERVICE_PROFILE_MUTATION = gql`
+  mutation CREATE_BERTH_SERVICE_PROFILE($input: CreateBerthServicesProfileMutationInput!) {
+    createBerthServicesProfile(input: $input) {
+      profile {
+        id
+        invoicingType
+        comment
+        organization {
+          id
+          organizationType
+          businessId
+          name
         }
       }
     }

--- a/src/common/utils/translations.ts
+++ b/src/common/utils/translations.ts
@@ -60,7 +60,8 @@ export const getOrderStatusTKey = (orderStatus: OrderStatus): string => {
       return 'common.orderStatus.expired';
     case OrderStatus.REJECTED:
       return 'common.orderStatus.rejected';
-
+    case OrderStatus.CANCELLED:
+      return 'common.orderStatus.cancelled';
     default:
       return orderStatus;
   }

--- a/src/features/customerView/billingHistoryCard/BillingHistoryCard.tsx
+++ b/src/features/customerView/billingHistoryCard/BillingHistoryCard.tsx
@@ -31,6 +31,10 @@ const BillingHistoryCard = ({ bills, onClick }: BillingHistoryProps) => {
         return 'red';
       case OrderStatus.REJECTED:
         return 'grey';
+      case OrderStatus.CANCELLED:
+        return 'grey';
+      default:
+        return 'grey';
     }
   };
 

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -137,7 +137,8 @@
       "waiting": "Odottaa maksua",
       "expired": "Erääntynyt",
       "rejected": "Hylätty",
-      "paid": "Maksettu"
+      "paid": "Maksettu",
+      "cancelled": "Peruttu"
     }
   },
   "login": {


### PR DESCRIPTION
## Description :sparkles:

After sending createProfile mutation the button should also call createBerthServicesProfile, which will also create a profile in the venepaikka backend.

### Closes :no_good_woman:

[VEN-834](https://helsinkisolutionoffice.atlassian.net/browse/VEN-834)

## Testing :alembic:

### Automated tests :gear:️

`src/common/hooks/__tests__/useCreateNewCustomer.test.tsx `

### Manual testing :construction_worker_man:

- Open a single application (either winter storage or harbor) that does not have a connected customer
- Click the "Add new customer" button
- (Network inspector should show a request made to `createProfile` followed by a request to `createBerthServicesProfile` with the input id corresponding to the returned id value from `createProfile`)
- It should be possible to connect the application to the newly created user

## Notes

`OrderStatus` enum has been extended in the backend, which also required changes to a few files after regeneration of types.
