### PR TITLE
VEN-852 | Improve date utils and set default due date to 14 days from now

### DIFF
--- a/src/features/invoiceCard/sendInvoiceForm/SendInvoiceForm.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/SendInvoiceForm.tsx
@@ -8,6 +8,7 @@ import styles from './sendInvoiceForm.module.scss';
 import FormHeader from '../../../common/formHeader/FormHeader';
 import Button from '../../../common/button/Button';
 import Text from '../../../common/text/Text';
+import { addDaysToDate, getToday, mapDateToDateInputValue } from './utils';
 
 type FormValues = {
   dueDate: string;
@@ -23,11 +24,6 @@ export type SendInvoiceFormProps = {
 const SendInvoiceForm = ({ email, onSubmit, onCancel, isSubmitting }: SendInvoiceFormProps) => {
   const { t } = useTranslation();
 
-  const getToday = () => new Date(Date.now());
-  const mapDateToDateInputValue = (date: Date): string => {
-    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${date.getDate()}`;
-  };
-
   const validationSchema = useMemo(
     () =>
       Yup.object<FormValues>().shape({
@@ -39,7 +35,7 @@ const SendInvoiceForm = ({ email, onSubmit, onCancel, isSubmitting }: SendInvoic
   );
 
   const initial: FormValues = {
-    dueDate: mapDateToDateInputValue(getToday()),
+    dueDate: mapDateToDateInputValue(addDaysToDate(getToday(), 14)),
   };
 
   return (

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/SendInvoiceForm.test.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/SendInvoiceForm.test.tsx
@@ -37,7 +37,7 @@ describe('SendInvoiceForm', () => {
     await act(async () => {
       wrapper.find('Form').simulate('submit');
     });
-    expect(onSubmit).toHaveBeenCalledWith({ dueDate: '2020-09-23' });
+    expect(onSubmit).toHaveBeenCalledWith({ dueDate: '2020-10-07' });
   });
 
   it('disables submit button if email is missing', async () => {

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/SendInvoiceFormContainer.test.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/SendInvoiceFormContainer.test.tsx
@@ -43,7 +43,7 @@ describe('SendInvoiceFormContainer', () => {
         query: APPROVE_ORDERS_MUTATION,
         variables: {
           input: {
-            dueDate: '2020-09-23',
+            dueDate: '2020-10-07',
             orders: [
               {
                 email: mockProps.email,

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`SendInvoiceForm renders normally 1`] = `
           id="dueDate"
           required=""
           type="date"
-          value="2020-09-23"
+          value="2020-10-07"
         />
       </div>
     </div>

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`SendInvoiceFormContainer renders normally 1`] = `
           id="dueDate"
           required=""
           type="date"
-          value="2020-09-23"
+          value="2020-10-07"
         />
       </div>
     </div>

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/utils.test.ts
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/utils.test.ts
@@ -1,0 +1,30 @@
+import { addDaysToDate, getToday, mapDateToDateInputValue } from '../utils';
+
+describe('sendInvoiceForm utils', () => {
+  describe('getToday', () => {
+    const mockDate: Date = new Date('2020-09-23T00:00:00.000Z');
+    const dateSpy = jest.spyOn(global.Date, 'now').mockImplementation(() => mockDate.valueOf());
+
+    it('should return the mocked date', () => {
+      expect(getToday()).toEqual(new Date('2020-09-23T00:00:00.000Z'));
+      expect(getToday()).not.toEqual(new Date('2020-09-24T00:00:00.000Z'));
+    });
+
+    afterAll(() => {
+      dateSpy.mockRestore();
+    });
+  });
+
+  describe('addDaysToDate', () => {
+    it('should add the days to the date correctly', () => {
+      expect(addDaysToDate(new Date('2020-09-23T00:00:00.000Z'), 1)).toEqual(new Date('2020-09-24T00:00:00.000Z'));
+      expect(addDaysToDate(new Date('2020-09-23T00:00:00.000Z'), 14)).toEqual(new Date('2020-10-07T00:00:00.000Z'));
+    });
+  });
+
+  describe('mapDateToDateInputValue', () => {
+    it('should map a date to an ISO 8601 date string', () => {
+      expect(mapDateToDateInputValue(new Date('2020-09-23T00:00:00.000Z'))).toEqual('2020-09-23');
+    });
+  });
+});

--- a/src/features/invoiceCard/sendInvoiceForm/utils.ts
+++ b/src/features/invoiceCard/sendInvoiceForm/utils.ts
@@ -1,0 +1,13 @@
+export const getToday = () => new Date(Date.now());
+
+export const addDaysToDate = (_date: Date, days: number) => {
+  const date = new Date(_date.getTime());
+  date.setDate(date.getDate() + days); // magic
+  return date;
+};
+
+// Date inputs use ISO 8601 Date (YYYY-MM-DD) format as value
+export const mapDateToDateInputValue = (date: Date): string => {
+  // .toISOString() returns YYYY-MM-DDTHH:mm:ss.sssZ
+  return date.toISOString().slice(0, 10);
+};


### PR DESCRIPTION
## Description :sparkles:

* Improve date utils
* Set default due date to 14 days from now

## Issues :bug:

### Closes :no_good_woman:

* [VEN-852](https://helsinkisolutionoffice.atlassian.net/browse/VEN-852): Creating invoices for unmarked winter storage notices

## Testing :alembic:

### Automated tests :gear:️

* Added better tests for date utils
* Updated related snapshots

### Manual testing :construction_worker_man:

* Open the invoice sending modal
* Confirm that the default value is 14 days from now
