### PR TITLE
VEN-571 | Set default sorting order for all tables

### DIFF
--- a/src/features/applicationList/ApplicationList.tsx
+++ b/src/features/applicationList/ApplicationList.tsx
@@ -112,6 +112,7 @@ const ApplicationList = ({
       <Table
         data={tableData}
         loading={loading || isDeleting}
+        initialState={{ sortBy: [{ id: 'createdAt', desc: false }] }}
         columns={columns}
         renderSubComponent={(row) => <ApplicationDetails {...row.original} handleDeleteLease={handleDeleteLease} />}
         renderMainHeader={() => {

--- a/src/features/applicationList/__tests__/ApplicationListContainer.test.tsx
+++ b/src/features/applicationList/__tests__/ApplicationListContainer.test.tsx
@@ -24,7 +24,7 @@ const queryMock = {
       first: 10,
       after: undefined,
       switchApplications: undefined,
-      orderBy: undefined,
+      orderBy: 'createdAt',
     },
   },
   result: {

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ApplicationList renders normally with all props 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -572,7 +572,7 @@ exports[`ApplicationList renders normally with minimum props 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ApplicationListContainer renders normally 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -93,6 +93,7 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColChange
         data={data}
         loading={loading}
         columns={columns}
+        initialState={{ sortBy: [{ id: 'name', desc: false }] }}
         renderSubComponent={(row) => {
           return (
             <CustomerDetails

--- a/src/features/harborList/HarborList.tsx
+++ b/src/features/harborList/HarborList.tsx
@@ -90,6 +90,7 @@ const HarborList = ({ data, loading }: HarborListProps) => {
         data={data}
         loading={loading}
         columns={columns}
+        initialState={{ sortBy: [{ id: 'name', desc: false }] }}
         renderTableToolsTop={(_, setters) => <GlobalSearchTableTools handleGlobalFilter={setters.setGlobalFilter} />}
         renderSubComponent={(row) => <HarborDetails {...row.original} />}
         renderMainHeader={() => t('harborList.tableHeaders.mainHeader')}

--- a/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
+++ b/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`PricingPage renders normally 1`] = `
                   >
                     Leveys
                     <div
-                      class="sortArrowWrapper"
+                      class="sortArrowWrapper isSorted"
                     >
                       <svg
                         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -297,7 +297,7 @@ exports[`PricingPage renders normally 1`] = `
                   >
                     Alue
                     <div
-                      class="sortArrowWrapper"
+                      class="sortArrowWrapper isSorted"
                     >
                       <svg
                         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -513,7 +513,7 @@ exports[`PricingPage renders normally 1`] = `
             <div
               class="table basic noMainHeader"
               role="table"
-              style="min-width: 525px;"
+              style="min-width: 562.5px;"
             >
               <div
                 class="stickyHeaders"
@@ -532,7 +532,7 @@ exports[`PricingPage renders normally 1`] = `
                   >
                     Palvelu
                     <div
-                      class="sortArrowWrapper"
+                      class="sortArrowWrapper isSorted"
                     >
                       <svg
                         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -558,7 +558,7 @@ exports[`PricingPage renders normally 1`] = `
                     class="headerCell"
                     colspan="1"
                     role="columnheader"
-                    style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                     title="Toggle SortBy"
                   >
                     Hinta
@@ -646,7 +646,7 @@ exports[`PricingPage renders normally 1`] = `
                     <div
                       class="tableCell"
                       role="cell"
-                      style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                     >
                       10,00 €
                     </div>
@@ -701,7 +701,7 @@ exports[`PricingPage renders normally 1`] = `
             <div
               class="table basic noMainHeader"
               role="table"
-              style="min-width: 600px;"
+              style="min-width: 675px;"
             >
               <div
                 class="stickyHeaders"
@@ -720,7 +720,7 @@ exports[`PricingPage renders normally 1`] = `
                   >
                     Palvelu
                     <div
-                      class="sortArrowWrapper"
+                      class="sortArrowWrapper isSorted"
                     >
                       <svg
                         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -746,7 +746,7 @@ exports[`PricingPage renders normally 1`] = `
                     class="headerCell"
                     colspan="1"
                     role="columnheader"
-                    style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                     title="Toggle SortBy"
                   >
                     Hinta
@@ -777,7 +777,7 @@ exports[`PricingPage renders normally 1`] = `
                     class="headerCell"
                     colspan="1"
                     role="columnheader"
-                    style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                     title="Toggle SortBy"
                   >
                     ALV
@@ -865,14 +865,14 @@ exports[`PricingPage renders normally 1`] = `
                     <div
                       class="tableCell"
                       role="cell"
-                      style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                     >
                       10,00 €
                     </div>
                     <div
                       class="tableCell"
                       role="cell"
-                      style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                     >
                       24 %
                     </div>

--- a/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
+++ b/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
@@ -45,26 +45,26 @@ const AdditionalServicePricing = ({ data, loading, className }: AdditionalServic
     {
       Header: t('pricing.additionalServices.service') || '',
       width: COLUMN_WIDTH.L,
-      accessor: 'service',
-      Cell: ({ cell }) => t(getProductServiceTKey(cell.value)),
+      accessor: ({ service }) => t(getProductServiceTKey(service)),
+      id: 'service',
     },
     {
       Header: t('pricing.additionalServices.price') || '',
-      width: COLUMN_WIDTH.XS,
-      accessor: 'price',
-      Cell: ({ cell }) => formatPrice(cell.value, i18n.language),
+      width: COLUMN_WIDTH.S,
+      accessor: ({ price }) => formatPrice(price, i18n.language),
+      id: 'price',
     },
     {
       Header: t('pricing.additionalServices.tax') || '',
-      width: COLUMN_WIDTH.XS,
-      accessor: 'tax',
-      Cell: ({ cell }) => getProductTax(cell.value, i18n.language),
+      width: COLUMN_WIDTH.S,
+      accessor: ({ tax }) => getProductTax(tax, i18n.language),
+      id: 'tax',
     },
     {
       Header: t('pricing.additionalServices.period') || '',
       width: COLUMN_WIDTH.S,
-      accessor: 'period',
-      Cell: ({ cell }) => t(getPeriodTKey(cell.value)),
+      accessor: ({ period }) => t(getPeriodTKey(period)),
+      id: 'period',
     },
     {
       id: 'edit',
@@ -96,6 +96,7 @@ const AdditionalServicePricing = ({ data, loading, className }: AdditionalServic
         <CardBody>
           <Table
             columns={additionalServicesCols}
+            initialState={{ sortBy: [{ id: 'service', desc: false }] }}
             data={getAdditionalServiceData(data)}
             loading={loading}
             theme="basic"

--- a/src/features/pricing/additionalServicePricing/__tests__/__snapshots__/AdditionalServicePricing.test.tsx.snap
+++ b/src/features/pricing/additionalServicePricing/__tests__/__snapshots__/AdditionalServicePricing.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`AdditionalServicePricing renders noData message when there is no data 1
         <div
           class="table basic noMainHeader"
           role="table"
-          style="min-width: 600px;"
+          style="min-width: 675px;"
         >
           <div
             class="stickyHeaders"
@@ -42,7 +42,7 @@ exports[`AdditionalServicePricing renders noData message when there is no data 1
               >
                 Palvelu
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -68,7 +68,7 @@ exports[`AdditionalServicePricing renders noData message when there is no data 1
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 Hinta
@@ -99,7 +99,7 @@ exports[`AdditionalServicePricing renders noData message when there is no data 1
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 ALV
@@ -212,7 +212,7 @@ exports[`AdditionalServicePricing renders normally 1`] = `
         <div
           class="table basic noMainHeader"
           role="table"
-          style="min-width: 600px;"
+          style="min-width: 675px;"
         >
           <div
             class="stickyHeaders"
@@ -231,7 +231,7 @@ exports[`AdditionalServicePricing renders normally 1`] = `
               >
                 Palvelu
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -257,7 +257,7 @@ exports[`AdditionalServicePricing renders normally 1`] = `
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 Hinta
@@ -288,7 +288,7 @@ exports[`AdditionalServicePricing renders normally 1`] = `
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 ALV
@@ -376,14 +376,14 @@ exports[`AdditionalServicePricing renders normally 1`] = `
                 <div
                   class="tableCell"
                   role="cell"
-                  style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                 >
                   10,00 €
                 </div>
                 <div
                   class="tableCell"
                   role="cell"
-                  style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                 >
                   24 %
                 </div>

--- a/src/features/pricing/berthPricing/BerthPricing.tsx
+++ b/src/features/pricing/berthPricing/BerthPricing.tsx
@@ -68,8 +68,8 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
     },
     {
       Header: t('pricing.berths.period') || '',
-      accessor: 'period',
-      Cell: ({ cell }) => t(getPeriodTKey(cell.value)),
+      accessor: ({ period }) => t(getPeriodTKey(period)),
+      id: 'period',
     },
     {
       id: 'edit',
@@ -113,6 +113,7 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
           <Section>{t('pricing.berths.description')}</Section>
           <Table
             columns={harborCols}
+            initialState={{ sortBy: [{ id: 'name', desc: false }] }}
             data={getBerthsData(data)}
             loading={loading}
             theme="basic"

--- a/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
+++ b/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
               >
                 Leveys
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -249,7 +249,7 @@ exports[`BerthPricing renders normally 1`] = `
               >
                 Leveys
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
+++ b/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
@@ -47,29 +47,29 @@ const HarborServicePricing = ({ data, loading, className }: HarborServicePricing
     {
       Header: t('pricing.harborServices.service') || '',
       width: COLUMN_WIDTH.L,
-      accessor: 'service',
-      Cell: ({ cell }) => t(getProductServiceTKey(cell.value)),
+      accessor: ({ service }) => t(getProductServiceTKey(service)),
+      id: 'service',
     },
     {
       Header: t('pricing.harborServices.price') || '',
-      width: COLUMN_WIDTH.XS,
-      accessor: 'price',
-      Cell: ({ row, cell }) => {
-        switch (row.original.unit) {
+      width: COLUMN_WIDTH.S,
+      accessor: ({ price, unit }) => {
+        switch (unit) {
           case PriceUnits.AMOUNT:
-            return formatPrice(cell.value, i18n.language);
+            return formatPrice(price, i18n.language);
           case PriceUnits.PERCENTAGE:
-            return formatPercentage(cell.value, i18n.language);
+            return formatPercentage(price, i18n.language);
           default:
-            return cell.value;
+            return price;
         }
       },
+      id: 'price',
     },
     {
       Header: t('pricing.harborServices.period') || '',
       width: COLUMN_WIDTH.S,
-      accessor: 'period',
-      Cell: ({ cell }) => t(getPeriodTKey(cell.value)),
+      accessor: ({ period }) => t(getPeriodTKey(period)),
+      id: 'period',
     },
     {
       id: 'edit',
@@ -102,6 +102,7 @@ const HarborServicePricing = ({ data, loading, className }: HarborServicePricing
           <Section>{t('pricing.harborServices.description')}</Section>
           <Table
             columns={harborServicesCols}
+            initialState={{ sortBy: [{ id: 'service', desc: false }] }}
             data={getHarborServicesData(data)}
             loading={loading}
             theme="basic"

--- a/src/features/pricing/harborServicePricing/__tests__/__snapshots__/HarborServicePricing.test.tsx.snap
+++ b/src/features/pricing/harborServicePricing/__tests__/__snapshots__/HarborServicePricing.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`HarborServicePricing renders noData message when there is no data 1`] =
         <div
           class="table basic noMainHeader"
           role="table"
-          style="min-width: 525px;"
+          style="min-width: 562.5px;"
         >
           <div
             class="stickyHeaders"
@@ -51,7 +51,7 @@ exports[`HarborServicePricing renders noData message when there is no data 1`] =
               >
                 Palvelu
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -77,7 +77,7 @@ exports[`HarborServicePricing renders noData message when there is no data 1`] =
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 Hinta
@@ -199,7 +199,7 @@ exports[`HarborServicePricing renders normally 1`] = `
         <div
           class="table basic noMainHeader"
           role="table"
-          style="min-width: 525px;"
+          style="min-width: 562.5px;"
         >
           <div
             class="stickyHeaders"
@@ -218,7 +218,7 @@ exports[`HarborServicePricing renders normally 1`] = `
               >
                 Palvelu
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -244,7 +244,7 @@ exports[`HarborServicePricing renders normally 1`] = `
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px; cursor: pointer;"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
                 title="Toggle SortBy"
               >
                 Hinta
@@ -332,7 +332,7 @@ exports[`HarborServicePricing renders normally 1`] = `
                 <div
                   class="tableCell"
                   role="cell"
-                  style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                 >
                   10,00 €
                 </div>

--- a/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
+++ b/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
@@ -70,8 +70,8 @@ const WinterStoragePricing = ({ data, loading, className, refetchQueries }: Wint
     },
     {
       Header: t('pricing.winterStorage.period') || '',
-      accessor: 'period',
-      Cell: ({ cell }) => t(getPeriodTKey(cell.value)),
+      accessor: ({ period }) => t(getPeriodTKey(period)),
+      id: 'period',
     },
     {
       id: 'edit',
@@ -115,6 +115,7 @@ const WinterStoragePricing = ({ data, loading, className, refetchQueries }: Wint
           <Section>{t('pricing.winterStorage.description')}</Section>
           <Table
             columns={winterStorageCols}
+            initialState={{ sortBy: [{ id: 'area', desc: false }] }}
             data={getWinterStorageData(data)}
             loading={loading}
             theme="basic"

--- a/src/features/pricing/winterStoragePricing/__tests__/__snapshots__/WinterStoragePricing.test.tsx.snap
+++ b/src/features/pricing/winterStoragePricing/__tests__/__snapshots__/WinterStoragePricing.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`WinterStoragePricing renders noData message when there is no data 1`] =
               >
                 Alue
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -249,7 +249,7 @@ exports[`WinterStoragePricing renders normally 1`] = `
               >
                 Alue
                 <div
-                  class="sortArrowWrapper"
+                  class="sortArrowWrapper isSorted"
                 >
                   <svg
                     class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
+++ b/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
@@ -89,6 +89,7 @@ const UnmarkedWsNoticeList = ({
         columns={columns}
         data={notices}
         loading={loading}
+        initialState={{ sortBy: [{ id: 'createdAt', desc: false }] }}
         renderSubComponent={(row) => (
           <Grid colsCount={3}>
             <UnmarkedWsNoticeDetails {...row.original} />

--- a/src/features/unmarkedWsNoticeList/__tests__/UnmarkedWsNoticeListContainer.test.tsx
+++ b/src/features/unmarkedWsNoticeList/__tests__/UnmarkedWsNoticeListContainer.test.tsx
@@ -16,7 +16,7 @@ const queryMock = {
     variables: {
       first: 10,
       after: undefined,
-      orderBy: undefined,
+      orderBy: 'createdAt',
     },
   },
   result: {

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`UnmarkedWsNoticeList renders normally with data 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
@@ -1295,7 +1295,7 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`UnmarkedWsNoticeListContainer renders normally 1`] = `
             >
               PVM
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"

--- a/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
+++ b/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
@@ -87,6 +87,7 @@ const WinterStorageApplicationList = ({
         columns={columns}
         data={applications}
         loading={loading}
+        initialState={{ sortBy: [{ id: 'createdAt', desc: false }] }}
         renderSubComponent={(row) => <ApplicationDetails {...row.original} />}
         renderMainHeader={() => (
           <TableFilters

--- a/src/features/winterStorageAreaList/WinterStorageAreaList.tsx
+++ b/src/features/winterStorageAreaList/WinterStorageAreaList.tsx
@@ -80,6 +80,7 @@ const WinterStorageAreaList = ({ data, loading }: WinterStorageAreaListProps) =>
         canSelectRows
         columns={columns}
         data={data}
+        initialState={{ sortBy: [{ id: 'name', desc: false }] }}
         loading={loading}
         renderEmptyStateRow={() => t('common.notification.noData.description')}
         renderMainHeader={() => t('winterStorageAreaList.tableHeaders.mainHeader')}

--- a/src/features/winterStorageAreaList/__tests__/__snapshots__/WinterStorageAreaList.test.tsx.snap
+++ b/src/features/winterStorageAreaList/__tests__/__snapshots__/WinterStorageAreaList.test.tsx.snap
@@ -90,7 +90,7 @@ exports[`WinterStorageAreaList renders normally 1`] = `
             >
               Alue
               <div
-                class="sortArrowWrapper"
+                class="sortArrowWrapper isSorted"
               >
                 <svg
                   class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"


### PR DESCRIPTION
## Description :sparkles:
- Sort Harbors List, Winter Storage Areas List, and Customers List tables by name.
- Sort Berth Applications List, Winter Storage Applications List, and Unmarked Winter Storage Notices List by created date.
- Sort the tables on the Pricing page by first columns.

### Closes :no_good_woman:
**[VEN-571](https://helsinkisolutionoffice.atlassian.net/browse/VEN-571):** Set default sorting order for tables

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
- Upadated the relevant snapshots

### Manual testing :construction_worker_man:
- The table on the `Venepaikat` page should be sorted by default alphabetically by `Satama`
- The table on `Talvisäilytys` page should be sorted by default alphabetically by `Alue`
- All tables under `Hakemukset` section should be sorted by `PVM` in a descending order
- The table on `Asiakkaat` page should be sorted by default alphabetically by `Nimi`
- The tables on `Hinnasto` page should be sorted by the first column

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/95185495-748eb180-07d1-11eb-80f9-117bef839c0c.png)
