### PR TITLE
VEN-773, VEN-884 | Less aggressive customer form validation, unified modal behavior

### DIFF
--- a/src/assets/styles/_form.scss
+++ b/src/assets/styles/_form.scss
@@ -3,7 +3,7 @@
 
 .form {
   padding: units(1) 0;
-  max-width: container(s);
+  width: container(s);
 
   > * {
     margin: units(1) 0;
@@ -11,7 +11,7 @@
 }
 
 .confirmationModal {
-  max-width: container(s);
+  width: container(s);
 }
 
 .grid {

--- a/src/common/confirmationModal/__tests__/ConfirmationModal.test.tsx
+++ b/src/common/confirmationModal/__tests__/ConfirmationModal.test.tsx
@@ -9,7 +9,7 @@ describe('ConfirmationModal', () => {
     ReactModal.setAppElement('body');
     const wrapper = mount(
       <ConfirmationModal
-        isOpen={true}
+        isOpen
         title={'title'}
         infoText={'info text'}
         warningText={'warning text'}

--- a/src/common/modal/__tests__/Modal.test.tsx
+++ b/src/common/modal/__tests__/Modal.test.tsx
@@ -8,7 +8,7 @@ describe('Modal', () => {
   ReactModal.setAppElement('body');
   const getWrapper = (props?: Partial<ModalProps>) =>
     mount(
-      <Modal isOpen={true} {...props}>
+      <Modal isOpen {...props}>
         <p>Content</p>
       </Modal>
     );

--- a/src/features/customerForm/CustomerForm.tsx
+++ b/src/features/customerForm/CustomerForm.tsx
@@ -65,8 +65,13 @@ const CustomerForm = ({ initialValues, isSubmitting, onSubmit, onCancel }: Custo
       <Text as="h4" color="brand">
         {t('forms.customer.title').toUpperCase()}
       </Text>
-      <Formik initialValues={initial} onSubmit={(values) => onSubmit?.(values)} validationSchema={validationSchema}>
-        {({ errors, handleChange, values }) => (
+      <Formik
+        initialValues={initial}
+        onSubmit={(values) => onSubmit?.(values)}
+        validationSchema={validationSchema}
+        validateOnChange={false}
+      >
+        {({ errors, handleChange, values, validateForm }) => (
           <Form className={styles.form}>
             <Select
               id="customerGroup"
@@ -113,7 +118,7 @@ const CustomerForm = ({ initialValues, isSubmitting, onSubmit, onCancel }: Custo
               <Button variant="secondary" disabled={isSubmitting} color={'supplementary'} onClick={onCancel}>
                 {t('forms.common.cancel')}
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
+              <Button type="submit" disabled={isSubmitting} onClick={() => validateForm(values)}>
                 {t('common.save')}
               </Button>
             </div>

--- a/src/features/customerList/tableTools/CustomerListTableTools.tsx
+++ b/src/features/customerList/tableTools/CustomerListTableTools.tsx
@@ -81,7 +81,7 @@ const CustomerListTableTools = <T extends string>({
         />
       </Modal>
 
-      <Modal isOpen={addCustomerModalOpen} toggleModal={() => setAddCustomerModalOpen(true)}>
+      <Modal isOpen={addCustomerModalOpen} toggleModal={() => setAddCustomerModalOpen(false)}>
         <AddCustomerFormContainer
           onCancel={() => setAddCustomerModalOpen(false)}
           onSubmit={() => {

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -96,7 +96,7 @@ const CustomerViewContainer = () => {
         />
       </Modal>
 
-      <BillModal bill={openBill} toggleModal={() => setOpenBill(undefined)} />
+      {openBill && <BillModal isOpen={true} bill={openBill} toggleModal={() => setOpenBill(undefined)} />}
     </>
   );
 };

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -74,7 +74,7 @@ const CustomerViewContainer = () => {
       </Modal>
 
       {boatToEdit && (
-        <Modal isOpen={true} toggleModal={() => setBoatToEdit(null)}>
+        <Modal isOpen toggleModal={() => setBoatToEdit(null)}>
           <BoatEditForm
             boatTypes={boatTypes}
             initialValues={boatToEdit}
@@ -96,7 +96,7 @@ const CustomerViewContainer = () => {
         />
       </Modal>
 
-      {openBill && <BillModal isOpen={true} bill={openBill} toggleModal={() => setOpenBill(undefined)} />}
+      {openBill && <BillModal isOpen bill={openBill} toggleModal={() => setOpenBill(undefined)} />}
     </>
   );
 };

--- a/src/features/customerView/billModal/BillModal.tsx
+++ b/src/features/customerView/billModal/BillModal.tsx
@@ -26,7 +26,7 @@ const BillModal = ({ bill, toggleModal, ...modalProps }: BillModalProps) => {
 
   const { contractPeriod } = bill;
   return (
-    <Modal isOpen={true} {...modalProps}>
+    <Modal isOpen toggleModal={() => toggleModal?.(false)} {...modalProps}>
       <Text as="h4" color="brand" className={styles.heading}>
         {t('customerView.customerBill.bill')}
       </Text>

--- a/src/features/customerView/billModal/BillModal.tsx
+++ b/src/features/customerView/billModal/BillModal.tsx
@@ -13,20 +13,16 @@ import styles from './billModal.module.scss';
 import { Bill } from '../types';
 import { PriceUnits } from '../../../@types/__generated__/globalTypes';
 
-interface BillModalProps extends Omit<ModalProps, 'children' | 'isOpen'> {
-  bill?: Bill;
+interface BillModalProps extends Omit<ModalProps, 'children'> {
+  bill: Bill;
 }
 
 const BillModal = ({ bill, toggleModal, ...modalProps }: BillModalProps) => {
   const { t, i18n } = useTranslation();
 
-  if (!bill) {
-    return null;
-  }
-
   const { contractPeriod } = bill;
   return (
-    <Modal isOpen toggleModal={() => toggleModal?.(false)} {...modalProps}>
+    <Modal toggleModal={() => toggleModal?.(false)} {...modalProps}>
       <Text as="h4" color="brand" className={styles.heading}>
         {t('customerView.customerBill.bill')}
       </Text>

--- a/src/features/customerView/billModal/__tests__/BillModal.test.tsx
+++ b/src/features/customerView/billModal/__tests__/BillModal.test.tsx
@@ -10,14 +10,14 @@ describe('BillModal', () => {
 
   it('renders correctly', () => {
     ReactModal.setAppElement('body');
-    const wrapper = mount(<BillModal isOpen={true} bill={mockBills[0]} />);
+    const wrapper = mount(<BillModal isOpen bill={mockBills[0]} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 
   it('calls toggleModal method on button close click', () => {
     ReactModal.setAppElement('body');
     const toggleModalMock = jest.fn();
-    const wrapper = mount(<BillModal isOpen={true} bill={mockBills[0]} toggleModal={toggleModalMock} />);
+    const wrapper = mount(<BillModal isOpen bill={mockBills[0]} toggleModal={toggleModalMock} />);
     wrapper.find('button').simulate('click');
     expect(toggleModalMock).toBeCalledWith(false);
   });

--- a/src/features/customerView/billModal/__tests__/BillModal.test.tsx
+++ b/src/features/customerView/billModal/__tests__/BillModal.test.tsx
@@ -10,14 +10,14 @@ describe('BillModal', () => {
 
   it('renders correctly', () => {
     ReactModal.setAppElement('body');
-    const wrapper = mount(<BillModal bill={mockBills[0]} />);
+    const wrapper = mount(<BillModal isOpen={true} bill={mockBills[0]} />);
     expect(wrapper.render()).toMatchSnapshot();
   });
 
   it('calls toggleModal method on button close click', () => {
     ReactModal.setAppElement('body');
     const toggleModalMock = jest.fn();
-    const wrapper = mount(<BillModal bill={mockBills[0]} toggleModal={toggleModalMock} />);
+    const wrapper = mount(<BillModal isOpen={true} bill={mockBills[0]} toggleModal={toggleModalMock} />);
     wrapper.find('button').simulate('click');
     expect(toggleModalMock).toBeCalledWith(false);
   });

--- a/src/features/harborView/HarborViewContainer.tsx
+++ b/src/features/harborView/HarborViewContainer.tsx
@@ -46,7 +46,7 @@ const HarborViewContainer = () => {
       />
 
       {berthToEdit && (
-        <Modal isOpen={!!berthToEdit} toggleModal={() => setBerthToEdit(null)}>
+        <Modal isOpen={true} toggleModal={() => setBerthToEdit(null)}>
           <BerthEditForm
             berthId={berthToEdit}
             onCancel={() => setBerthToEdit(null)}
@@ -77,7 +77,7 @@ const HarborViewContainer = () => {
       </Modal>
 
       {pierToEdit && (
-        <Modal isOpen={!!pierToEdit} toggleModal={() => setPierToEdit(null)}>
+        <Modal isOpen={true} toggleModal={() => setPierToEdit(null)}>
           <PierEditForm
             pierId={pierToEdit}
             onCancel={() => setPierToEdit(null)}

--- a/src/features/harborView/HarborViewContainer.tsx
+++ b/src/features/harborView/HarborViewContainer.tsx
@@ -46,7 +46,7 @@ const HarborViewContainer = () => {
       />
 
       {berthToEdit && (
-        <Modal isOpen={true} toggleModal={() => setBerthToEdit(null)}>
+        <Modal isOpen toggleModal={() => setBerthToEdit(null)}>
           <BerthEditForm
             berthId={berthToEdit}
             onCancel={() => setBerthToEdit(null)}
@@ -77,7 +77,7 @@ const HarborViewContainer = () => {
       </Modal>
 
       {pierToEdit && (
-        <Modal isOpen={true} toggleModal={() => setPierToEdit(null)}>
+        <Modal isOpen toggleModal={() => setPierToEdit(null)}>
           <PierEditForm
             pierId={pierToEdit}
             onCancel={() => setPierToEdit(null)}

--- a/src/features/harborView/forms/harborForm/harborEditForm.module.scss
+++ b/src/features/harborView/forms/harborForm/harborEditForm.module.scss
@@ -2,7 +2,7 @@
 @import 'spacings';
 
 .harborEditForm {
-  max-width: container(s);
+  width: container(s);
 }
 
 .formActionButtons {

--- a/src/features/invoiceCard/InvoiceCardContainer.tsx
+++ b/src/features/invoiceCard/InvoiceCardContainer.tsx
@@ -37,7 +37,7 @@ const InvoiceCardContainer = ({
 
       {order && (
         <>
-          <Modal isOpen={sendInvoiceModalOpen}>
+          <Modal isOpen={sendInvoiceModalOpen} toggleModal={() => setSendInvoiceModalOpen(false)}>
             <SendInvoiceForm
               orderId={order.id}
               email={customerEmail}
@@ -46,7 +46,7 @@ const InvoiceCardContainer = ({
               onCancel={() => setSendInvoiceModalOpen(false)}
             />
           </Modal>
-          <Modal isOpen={editProductsModalOpen}>
+          <Modal isOpen={editProductsModalOpen} toggleModal={() => setEditProductsModalOpen(false)}>
             <EditForm
               orderId={order.id}
               selectedProducts={selectedProducts}

--- a/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
+++ b/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
@@ -104,16 +104,16 @@ const AdditionalServicePricing = ({ data, loading, className }: AdditionalServic
           />
         </CardBody>
       </Card>
-      <Modal isOpen={!!editRowValues} label={t('pricing.editModalHeading').toUpperCase()}>
-        {editRowValues && (
+      {editRowValues && (
+        <Modal isOpen={true} toggleModal={handleClose} label={t('pricing.editModalHeading').toUpperCase()}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.ADDITIONAL_SERVICES}
             initialValues={editRowValues}
             onSubmit={handleSubmit}
           />
-        )}
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
+++ b/src/features/pricing/additionalServicePricing/AdditionalServicePricing.tsx
@@ -105,7 +105,7 @@ const AdditionalServicePricing = ({ data, loading, className }: AdditionalServic
         </CardBody>
       </Card>
       {editRowValues && (
-        <Modal isOpen={true} toggleModal={handleClose} label={t('pricing.editModalHeading').toUpperCase()}>
+        <Modal isOpen toggleModal={handleClose} label={t('pricing.editModalHeading').toUpperCase()}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.ADDITIONAL_SERVICES}

--- a/src/features/pricing/berthPricing/BerthPricing.tsx
+++ b/src/features/pricing/berthPricing/BerthPricing.tsx
@@ -121,16 +121,16 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
           />
         </CardBody>
       </Card>
-      <Modal isOpen={!!editRowValues} label={t('pricing.editModalHeading').toUpperCase()}>
-        {editRowValues && (
+      {editRowValues && (
+        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.BERTHS}
             initialValues={editRowValues}
             onSubmit={handleSubmit}
           />
-        )}
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/features/pricing/berthPricing/BerthPricing.tsx
+++ b/src/features/pricing/berthPricing/BerthPricing.tsx
@@ -122,7 +122,7 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
         </CardBody>
       </Card>
       {editRowValues && (
-        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
+        <Modal isOpen label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.BERTHS}

--- a/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
+++ b/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
@@ -111,7 +111,7 @@ const HarborServicePricing = ({ data, loading, className }: HarborServicePricing
         </CardBody>
       </Card>
       {editRowValues && (
-        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
+        <Modal isOpen label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.HARBOR_SERVICES}

--- a/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
+++ b/src/features/pricing/harborServicePricing/HarborServicePricing.tsx
@@ -110,16 +110,16 @@ const HarborServicePricing = ({ data, loading, className }: HarborServicePricing
           />
         </CardBody>
       </Card>
-      <Modal isOpen={!!editRowValues} label={t('pricing.editModalHeading').toUpperCase()}>
-        {editRowValues && (
+      {editRowValues && (
+        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.HARBOR_SERVICES}
             initialValues={editRowValues}
             onSubmit={handleSubmit}
           />
-        )}
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
+++ b/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
@@ -123,16 +123,16 @@ const WinterStoragePricing = ({ data, loading, className, refetchQueries }: Wint
           />
         </CardBody>
       </Card>
-      <Modal isOpen={!!editRowValues} label={t('pricing.editModalHeading').toUpperCase()}>
-        {editRowValues && (
+      {editRowValues && (
+        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.WINTER_STORAGE}
             initialValues={editRowValues}
             onSubmit={handleSubmit}
           />
-        )}
-      </Modal>
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
+++ b/src/features/pricing/winterStoragePricing/WinterStoragePricing.tsx
@@ -124,7 +124,7 @@ const WinterStoragePricing = ({ data, loading, className, refetchQueries }: Wint
         </CardBody>
       </Card>
       {editRowValues && (
-        <Modal isOpen={true} label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
+        <Modal isOpen label={t('pricing.editModalHeading').toUpperCase()} toggleModal={handleClose}>
           <EditForm
             closeModal={handleClose}
             formType={EDIT_FORM_TYPE.WINTER_STORAGE}


### PR DESCRIPTION
## Description :sparkles:

* Make CustomerForm validate only on submit
* Make all modals close by clicking outside and remove redundant rendering conditions

## Issues :bug:

### Closes :no_good_woman:

* [VEN-773](https://helsinkisolutionoffice.atlassian.net/browse/VEN-773): FE - Customer list: Add new customer 
* [VEN-884](https://helsinkisolutionoffice.atlassian.net/browse/VEN-884): Unified modal behavior

## Testing :alembic:

### Manual testing :construction_worker_man:

* Add / edit customer form should validate when and only when the submit button is clicked, and not when changing customer groups, for example
* All modals should close when clicking the gray backdrop outside them
