### PR TITLE
VEN-825 | Put queue features behind feature flag

### DIFF
--- a/src/common/applicationDetails/ApplicationDetails.tsx
+++ b/src/common/applicationDetails/ApplicationDetails.tsx
@@ -18,6 +18,7 @@ import ApplicationChoicesList, {
   HarborChoice,
   WinterStorageAreaChoice,
 } from './applicationChoicesList/ApplicationChoicesList';
+import { queueFeatureFlag } from '../utils/featureFlags';
 import DeleteButton from '../deleteButton/DeleteButton';
 
 interface Lease {
@@ -109,7 +110,9 @@ const ApplicationDetails = ({
             label={t('applicationList.applicationDetails.receivedDate')}
             value={formatDate(createdAt, i18n.language, true)}
           />
-          <LabelValuePair label={t('applicationList.applicationDetails.queueNumber')} value={`${queue}`} />
+          {queueFeatureFlag() ? (
+            <LabelValuePair label={t('applicationList.applicationDetails.queueNumber')} value={`${queue}`} />
+          ) : null}
           <LabelValuePair
             label={t('applicationList.applicationDetails.status')}
             value={t(APPLICATION_STATUS[status]?.label)}

--- a/src/common/harborCard/HarborCard.tsx
+++ b/src/common/harborCard/HarborCard.tsx
@@ -16,6 +16,7 @@ import placeholderImage from '../placeholderImage.svg';
 import MapLinks from '../mapLinks/MapLinks';
 import { IconFence, IconPlug, IconStreetLight, IconWaterTap } from '../icons';
 import { formatAddress } from '../utils/format';
+import { queueFeatureFlag } from '../utils/featureFlags';
 
 export interface HarborCardProps {
   className?: string;
@@ -97,7 +98,11 @@ const HarborCard = ({
             <div />
             <Property counter={properties.numberOfPlaces} label={t('harborCard.numberOfPlaces')} />
             <Property counter={properties.numberOfFreePlaces} label={t('harborCard.numberOfFreePlaces')} />
-            <Property counter={properties.queue} label={t('common.terminology.inQueue')} />
+            {queueFeatureFlag() ? (
+              <Property counter={properties.queue} label={t('common.terminology.inQueue')} />
+            ) : (
+              <div />
+            )}
             <Property counter={properties.maxWidth} label={t('harborCard.maxWidth')} />
 
             <Property

--- a/src/common/utils/featureFlags.ts
+++ b/src/common/utils/featureFlags.ts
@@ -17,3 +17,7 @@ export const harborMooringFeatureFlag = () => {
 export const berthInvoicingFeatureFlag = () => {
   return process.env.NODE_ENV !== 'production';
 };
+
+export const queueFeatureFlag = () => {
+  return process.env.NODE_ENV !== 'production';
+};

--- a/src/features/applicationList/ApplicationList.tsx
+++ b/src/features/applicationList/ApplicationList.tsx
@@ -15,6 +15,7 @@ import { formatDate } from '../../common/utils/format';
 import Chip from '../../common/chip/Chip';
 import { APPLICATION_STATUS } from '../../common/utils/consonants';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
+import { queueFeatureFlag } from '../../common/utils/featureFlags';
 
 export interface ApplicationListProps {
   data: BERTH_APPLICATIONS | undefined;
@@ -47,7 +48,7 @@ const ApplicationList = ({
 }: ApplicationListProps) => {
   const { t, i18n } = useTranslation();
 
-  const columns: ColumnType[] = [
+  const rawColumns: (ColumnType | undefined)[] = [
     {
       Cell: ({ cell }) => (
         <InternalLink to={`/applications/${cell.row.original.id}`}>
@@ -68,12 +69,14 @@ const ApplicationList = ({
       accessor: 'createdAt',
       width: COLUMN_WIDTH.S,
     },
-    {
-      Header: t('applicationList.tableHeaders.queue') as string,
-      accessor: 'queue',
-      disableSortBy: true,
-      width: COLUMN_WIDTH.XS,
-    },
+    queueFeatureFlag()
+      ? {
+          Header: t('applicationList.tableHeaders.queue') as string,
+          accessor: 'queue',
+          disableSortBy: true,
+          width: COLUMN_WIDTH.XS,
+        }
+      : undefined,
     {
       Header: t('applicationList.tableHeaders.municipality') as string,
       accessor: 'municipality',
@@ -105,6 +108,7 @@ const ApplicationList = ({
       width: COLUMN_WIDTH.XL,
     },
   ];
+  const columns: ColumnType[] = rawColumns.filter((column): column is ColumnType => column !== undefined);
 
   return (
     <PageContent>

--- a/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
+++ b/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
@@ -14,6 +14,7 @@ import { WinterStorageApplication } from './utils';
 import ApplicationDetails from '../../common/applicationDetails/ApplicationDetails';
 import TableFilters from '../../common/tableFilters/TableFilters';
 import Pagination from '../../common/pagination/Pagination';
+import { queueFeatureFlag } from '../../common/utils/featureFlags';
 
 interface WinterStorageApplicationListProps {
   applications: WinterStorageApplication[];
@@ -35,7 +36,8 @@ const WinterStorageApplicationList = ({
   onSortedColChange,
 }: WinterStorageApplicationListProps) => {
   const { t, i18n } = useTranslation();
-  const columns: ColumnType[] = [
+
+  const rawColumns: (ColumnType | undefined)[] = [
     {
       Cell: ({ cell }) => (
         <InternalLink to={`/winter-storage-applications/${cell.value}`}>
@@ -54,12 +56,14 @@ const WinterStorageApplicationList = ({
       accessor: 'createdAt',
       width: COLUMN_WIDTH.S,
     },
-    {
-      Header: t('applicationList.tableHeaders.queue') || '',
-      accessor: 'queue',
-      disableSortBy: true,
-      width: COLUMN_WIDTH.XS,
-    },
+    queueFeatureFlag()
+      ? {
+          Header: t('applicationList.tableHeaders.queue') || '',
+          accessor: 'queue',
+          disableSortBy: true,
+          width: COLUMN_WIDTH.XS,
+        }
+      : undefined,
     {
       Header: t('applicationList.tableHeaders.municipality') || '',
       accessor: 'municipality',
@@ -79,6 +83,7 @@ const WinterStorageApplicationList = ({
       width: COLUMN_WIDTH.M,
     },
   ];
+  const columns: ColumnType[] = rawColumns.filter((column): column is ColumnType => column !== undefined);
 
   return (
     <PageContent>


### PR DESCRIPTION
## Description :sparkles:

* Put queue features behind feature flag

## Issues :bug:

### Closes :no_good_woman:

* [VEN-825](https://helsinkisolutionoffice.atlassian.net/browse/VEN-825): Move placeholder components behind a feature flag

## Testing :alembic:

### Manual testing :construction_worker_man:

* Queue number and number of items in queue should be hidden in testing environment but visible in local development environment
