### PR TITLE
VEN-791 | Only show available berths on the offer page

### DIFF
--- a/src/features/offer/queries.ts
+++ b/src/features/offer/queries.ts
@@ -52,7 +52,7 @@ export const OFFER_QUERY = gql`
                 water
                 lighting
                 wasteCollection
-                berths {
+                berths(isAvailable: true) {
                   edges {
                     node {
                       id


### PR DESCRIPTION
## Description :sparkles:

If a berth has already been assigned to some application, it should not be offered for other applications.

## Issues :bug:

[VEN-791](https://helsinkisolutionoffice.atlassian.net/browse/VEN-791)

## Testing :alembic:

### Manual testing :construction_worker_man:

- Go to "Venepaikkahakemukset", select an application that is in state "Odottaa käsittelyä"
- Select a harbor to choose berths from
- The offer table should not contain berths already associated with applications (check and compare with the full applications list for already assigned berths)

