### PR TITLE
VEN-874 | Put berth invoicing behind feature flag

### DIFF
--- a/src/common/utils/featureFlags.ts
+++ b/src/common/utils/featureFlags.ts
@@ -13,3 +13,7 @@ export const maintenanceFeatureFlag = () => {
 export const harborMooringFeatureFlag = () => {
   return process.env.NODE_ENV !== 'production';
 };
+
+export const berthInvoicingFeatureFlag = () => {
+  return process.env.NODE_ENV !== 'production';
+};

--- a/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
+++ b/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
@@ -12,6 +12,7 @@ import PlaceDetails from './PlaceDetails';
 import { LeaseDetails } from './types';
 import { ApplicationStatus } from '../../../@types/__generated__/globalTypes';
 import DeleteButton from '../../../common/deleteButton/DeleteButton';
+import { berthInvoicingFeatureFlag } from '../../../common/utils/featureFlags';
 
 export interface BerthOfferCardProps {
   className?: string;
@@ -79,6 +80,7 @@ const BerthOfferCard = ({
         }
         className={className}
         customerEmail={customerEmail}
+        invoicingDisabled={!berthInvoicingFeatureFlag()}
         order={order}
         placeDetails={
           <PlaceDetails

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -15,33 +15,35 @@ import Button from '../../common/button/Button';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
 
 export interface InvoiceCardProps {
+  applicationStatus: ApplicationStatus;
   buttonsRight?: React.ReactNode;
   className?: string;
   editAdditionalServices: () => void;
+  invoicingDisabled?: boolean;
+  order: Order | null;
+  placeDetails?: React.ReactNode;
+  placeName: React.ReactNode;
+  placeProperties: PlaceProperty[];
+  placeType: string;
   sendButtonLabel?: string;
   sendInvoice: () => void;
-  order: Order | null;
-  placeType: string;
-  placeName: React.ReactNode;
-  placeDetails?: React.ReactNode;
-  placeProperties: PlaceProperty[];
   title: string;
-  applicationStatus: ApplicationStatus;
 }
 
 const InvoiceCard = ({
+  applicationStatus,
   buttonsRight,
   className,
   editAdditionalServices,
-  sendButtonLabel,
-  sendInvoice,
+  invoicingDisabled,
   order,
   placeDetails,
   placeName,
   placeProperties,
   placeType,
+  sendButtonLabel,
+  sendInvoice,
   title,
-  applicationStatus,
 }: InvoiceCardProps) => {
   const { t } = useTranslation();
 
@@ -61,7 +63,10 @@ const InvoiceCard = ({
     );
 
   const renderSendButton = () => {
-    if (applicationStatus !== ApplicationStatus.OFFER_GENERATED && applicationStatus !== ApplicationStatus.OFFER_SENT) {
+    if (
+      invoicingDisabled ||
+      (applicationStatus !== ApplicationStatus.OFFER_GENERATED && applicationStatus !== ApplicationStatus.OFFER_SENT)
+    ) {
       return null;
     }
     return (

--- a/src/features/winterStorageApplicationView/WinterStorageApplicationView.tsx
+++ b/src/features/winterStorageApplicationView/WinterStorageApplicationView.tsx
@@ -65,14 +65,12 @@ const WinterStorageApplicationView = ({
         />
       )}
 
-      {applicationDetails && (
-        <Card className={styles.fullWidth}>
-          <CardHeader title={t('applicationView.applicationDetails.title')} />
-          <CardBody>
-            <ApplicationDetails {...applicationDetails} handleDeleteLease={handleDeleteLease} />
-          </CardBody>
-        </Card>
-      )}
+      <Card className={styles.fullWidth}>
+        <CardHeader title={t('applicationView.applicationDetails.title')} />
+        <CardBody>
+          <ApplicationDetails {...applicationDetails} handleDeleteLease={handleDeleteLease} />
+        </CardBody>
+      </Card>
     </PageContent>
   );
 };

--- a/src/features/winterStorageApplicationView/WinterStorageApplicationView.tsx
+++ b/src/features/winterStorageApplicationView/WinterStorageApplicationView.tsx
@@ -71,6 +71,8 @@ const WinterStorageApplicationView = ({
           <ApplicationDetails {...applicationDetails} handleDeleteLease={handleDeleteLease} />
         </CardBody>
       </Card>
+
+      {/*  TODO: Offer and invoicing */}
     </PageContent>
   );
 };


### PR DESCRIPTION
## Description :sparkles:

* Put berth invoicing behind feature flag
* ~Put WS invoicing behind feature flag~
  * No implementation exists, so `noop`
  * Removed redundant rendering condition from WS application view
  * Added TODO comment about WS invoicing

## Issues :bug:

### Closes :no_good_woman:

* [VEN-874](https://helsinkisolutionoffice.atlassian.net/browse/VEN-874): Hide "send invoice button" on berth and WS applications

## Testing :alembic:

### Manual testing :construction_worker_man:

* Berth invoicing should work in local development environment and be hidden in testing/production environments
