### PR TITLE
VEN-887 | Disable create new user button if users with identical information exist

### DIFF
--- a/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
+++ b/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLazyQuery } from '@apollo/react-hooks';
+import { useLazyQuery, useQuery } from '@apollo/react-hooks';
 import { useDebounce } from 'use-debounce';
 
 import { getFilteredCustomersData } from './utils';
@@ -38,7 +38,7 @@ const LinkApplicationToCustomerContainer = ({
 }: LinkApplicationToCustomerContainerProps) => {
   const { t } = useTranslation();
 
-  const [searchBy, setSearchBy] = useState<SearchBy>(SearchBy.LAST_NAME);
+  const [searchBy, setSearchBy] = useState<SearchBy>(SearchBy.EMAIL);
   const prevSearchBy = usePrevious(searchBy);
   const [searchVal, setSearchVal] = useState<string>('');
   const [debouncedSearchVal] = useDebounce(searchVal, 500, {
@@ -61,10 +61,27 @@ const LinkApplicationToCustomerContainer = ({
     variables: filteredCustomersVars,
   });
 
+  const exactlyFilteredCustomersVars: FILTERED_CUSTOMERS_VARS = {
+    first: 1,
+    [SearchBy.FIRST_NAME]: application.firstName,
+    [SearchBy.LAST_NAME]: application.lastName,
+    [SearchBy.EMAIL]: application.email,
+  };
+  const { data: exactlyFilteredCustomersData, loading: loadingExactlyFilteredCustomers } = useQuery<
+    FILTERED_CUSTOMERS,
+    FILTERED_CUSTOMERS_VARS
+  >(FILTERED_CUSTOMERS_QUERY, {
+    variables: exactlyFilteredCustomersVars,
+  });
+
   const createNewCustomer = useCreateNewCustomer([
     {
       query: FILTERED_CUSTOMERS_QUERY,
       variables: filteredCustomersVars,
+    },
+    {
+      query: FILTERED_CUSTOMERS_QUERY,
+      variables: exactlyFilteredCustomersVars,
     },
   ]);
 
@@ -84,6 +101,8 @@ const LinkApplicationToCustomerContainer = ({
   }, [called, fetchFilteredCustomers]);
 
   const filteredCustomersData = getFilteredCustomersData(customersData);
+  const canCreateNewCustomer =
+    !getFilteredCustomersData(exactlyFilteredCustomersData).length && !loadingExactlyFilteredCustomers;
 
   const handleCreateCustomer = () => {
     createNewCustomer(application);
@@ -96,6 +115,7 @@ const LinkApplicationToCustomerContainer = ({
         searchVal,
         searchBy,
         setSearchVal,
+        canCreateNewCustomer,
         setSearchBy: (searchBy) => {
           setSearchBy(searchBy);
           setSearchVal(application[searchBy] ?? '');

--- a/src/features/linkApplicationToCustomer/__tests__/LinkApplicationToCustomer.test.tsx
+++ b/src/features/linkApplicationToCustomer/__tests__/LinkApplicationToCustomer.test.tsx
@@ -5,6 +5,7 @@ import { act } from 'react-dom/test-utils';
 import LinkApplicationToCustomer, { LinkApplicationToCustomerProps } from '../LinkApplicationToCustomer';
 import { SearchBy } from '../../applicationView/ApplicationView';
 import { CustomerGroup } from '../../../@types/__generated__/globalTypes';
+import CustomersTableTools from '../tableTools/CustomersTableTools';
 
 const mockProps: LinkApplicationToCustomerProps = {
   customersTableTools: {
@@ -12,6 +13,7 @@ const mockProps: LinkApplicationToCustomerProps = {
     searchBy: SearchBy.FIRST_NAME,
     searchByOptions: [],
     searchVal: undefined,
+    canCreateNewCustomer: true,
     setSearchBy: jest.fn(),
     handleCreateCustomer: jest.fn(),
     handleLinkCustomer: jest.fn(),
@@ -85,5 +87,19 @@ describe('LinkApplicationToCustomer', () => {
 
     wrapper.find('CustomersTableTools').find('Button').at(0).simulate('click');
     expect(handleLinkCustomer).toHaveBeenCalledWith('1');
+  });
+
+  it('does not render create new user button when canCreateNewCustomer is false', () => {
+    const wrapper = getWrapper({
+      customersTableTools: { ...mockProps.customersTableTools, canCreateNewCustomer: false },
+    });
+    expect(wrapper.find(CustomersTableTools).text().includes('Luo uusi asiakas')).toBe(false);
+  });
+
+  it('renders create new user button when canCreateNewCustomer is true', () => {
+    const wrapper = getWrapper({
+      customersTableTools: { ...mockProps.customersTableTools, canCreateNewCustomer: true },
+    });
+    expect(wrapper.find(CustomersTableTools).text().includes('Luo uusi asiakas')).toBe(true);
   });
 });

--- a/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomerContainer.test.tsx.snap
+++ b/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomerContainer.test.tsx.snap
@@ -70,7 +70,7 @@ Array [
             <span
               class="Dropdown-module_buttonLabel__2jVRU"
             >
-              Sukunimi
+              Sähköposti
             </span>
             <svg
               class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Dropdown-module_angleIcon__1Y1mT"
@@ -111,7 +111,7 @@ Array [
             class="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
             id="searchSimilarCustomers"
             type="text"
-            value="Käyttäjä"
+            value="test@example.com"
           />
         </div>
       </div>

--- a/src/features/linkApplicationToCustomer/tableTools/CustomersTableTools.tsx
+++ b/src/features/linkApplicationToCustomer/tableTools/CustomersTableTools.tsx
@@ -12,6 +12,7 @@ export interface CustomersTableToolsProps<T> {
   searchVal: string | undefined;
   searchBy: T;
   searchByOptions: Array<{ value: T; label: string }>;
+  canCreateNewCustomer: boolean;
   setSearchVal(val: string): void;
   setSearchBy(val: T): void;
   handleLinkCustomer?(): void;
@@ -23,6 +24,7 @@ const CustomersTableTools = <T extends string>({
   searchVal,
   searchBy,
   searchByOptions,
+  canCreateNewCustomer,
   setSearchVal,
   setSearchBy,
   handleLinkCustomer,
@@ -48,9 +50,11 @@ const CustomersTableTools = <T extends string>({
       <Button disabled={!handleLinkCustomer} onClick={handleLinkCustomer}>
         {t('applicationView.customerTableTools.linkCustomer')}
       </Button>
-      <Button variant="secondary" onClick={handleCreateCustomer}>
-        {t('applicationView.customerTableTools.createNewCustomer')}
-      </Button>
+      {canCreateNewCustomer && (
+        <Button variant="secondary" onClick={handleCreateCustomer}>
+          {t('applicationView.customerTableTools.createNewCustomer')}
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/features/linkApplicationToCustomer/tableTools/__tests__/CustomersTableTools.test.tsx
+++ b/src/features/linkApplicationToCustomer/tableTools/__tests__/CustomersTableTools.test.tsx
@@ -30,6 +30,7 @@ const mockProps: CustomersTableToolsProps<string> = {
   searchBy: '',
   searchByOptions: searchByOptions,
   searchVal: undefined,
+  canCreateNewCustomer: true,
   setSearchBy: jest.fn(),
   handleCreateCustomer: jest.fn(),
   handleLinkCustomer: jest.fn(),

--- a/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeViewContainer.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeViewContainer.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`UnmarkedWsNoticeViewContainer renders normally 1`] = `
             <span
               class="Dropdown-module_buttonLabel__2jVRU"
             >
-              Sukunimi
+              Sähköposti
             </span>
             <svg
               class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Dropdown-module_angleIcon__1Y1mT"
@@ -154,7 +154,7 @@ exports[`UnmarkedWsNoticeViewContainer renders normally 1`] = `
             class="TextInput-module_input__35GDy text-input_hds-text-input__input__2XAyI"
             id="searchSimilarCustomers"
             type="text"
-            value="test"
+            value="test@test.com"
           />
         </div>
       </div>


### PR DESCRIPTION
## Description :sparkles:

Disables the create new user button in LinkApplicationToCustomer if users with identical information exist on the backend. Users with same first and last name as well as email count as identical. Additionally sets default filtering to be based on email instead of last name.

## Issues :bug:

[VEN-887](https://helsinkisolutionoffice.atlassian.net/browse/VEN-887)

## Testing :alembic:

### Automated tests :gear:️

- Updated relevant tests
- Added tests to `src/features/linkApplicationToCustomer/__tests__/LinkApplicationToCustomer.test.tsx`

### Manual testing :construction_worker_man:

- Select an application in state "Odottaa käsittelyä" with no connected user
- If the list of users contains a user with identical information, the create new user button should not appear
- If the list does not contain an identical user, the button should first appear but disappear after creating a new user