### PR TITLE
Fix: Show GraphQL errors

### DIFF
--- a/src/app/apolloClient.ts
+++ b/src/app/apolloClient.ts
@@ -43,7 +43,10 @@ const authLink = setContext((_, { headers }) => {
   };
 });
 
-const errorLink = onError(({ networkError }) => {
+const errorLink = onError(({ graphQLErrors, networkError }) => {
+  if (graphQLErrors) {
+    hdsToast.graphQLErrors(graphQLErrors);
+  }
   if (networkError && networkError.name !== 'ServerError') {
     // An explicit id is passed here to the toast,
     // so it can be automatically dismissed on e.g. reconnection.


### PR DESCRIPTION
## Description :sparkles:

* This fixes an error handling regression caused by changes related to removing SSN from the application.