### PR TITLE
VEN-565 | Sort select harbor and WS area properties first in desc. order

### DIFF
--- a/src/features/harborList/HarborList.tsx
+++ b/src/features/harborList/HarborList.tsx
@@ -36,41 +36,48 @@ const HarborList = ({ data, loading }: HarborListProps) => {
       Header: t('harborList.tableHeaders.places') || '',
       accessor: 'numberOfPlaces',
       width: COLUMN_WIDTH.S,
+      sortDescFirst: true,
     },
     {
       Header: t('harborList.tableHeaders.freePlaces') || '',
       accessor: 'numberOfFreePlaces',
       width: COLUMN_WIDTH.S,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconPlug} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconPlug} />,
       accessor: 'electricity',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconFence} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconFence} />,
       accessor: 'gate',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconStreetLight} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconStreetLight} />,
       accessor: 'lighting',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconWaterTap} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconWaterTap} />,
       accessor: 'water',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconTrash} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconTrash} />,
       accessor: 'wasteCollection',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
   ];
 

--- a/src/features/winterStorageAreaList/WinterStorageAreaList.tsx
+++ b/src/features/winterStorageAreaList/WinterStorageAreaList.tsx
@@ -35,41 +35,48 @@ const WinterStorageAreaList = ({ data, loading }: WinterStorageAreaListProps) =>
       Header: t('winterStorageAreaList.tableHeaders.places') || '',
       accessor: 'numberOfPlaces',
       width: COLUMN_WIDTH.S,
+      sortDescFirst: true,
     },
     {
       Header: t('winterStorageAreaList.tableHeaders.freePlaces') || '',
       accessor: 'numberOfFreePlaces',
       width: COLUMN_WIDTH.S,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconPlug} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconPlug} />,
       accessor: 'electricity',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconWaterTap} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconWaterTap} />,
       accessor: 'water',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconFence} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconFence} />,
       accessor: 'gate',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconTrestle} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconTrestle} />,
       accessor: 'summerStorageForDockingEquipment',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
     {
       Cell: ({ cell }) => <IconWrapper outlined icon={IconDollyEmpty} color={!cell.value ? 'disabled' : 'standard'} />,
       Header: () => <IconWrapper outlined icon={IconDollyEmpty} />,
       accessor: 'summerStorageForTrailers',
       width: COLUMN_WIDTH.XS,
+      sortDescFirst: true,
     },
   ];
 


### PR DESCRIPTION
## Description :sparkles:

* Sort select harbor and WS area properties first in desc. order

## Issues :bug:

### Closes :no_good_woman:

* [VEN-565](https://helsinkisolutionoffice.atlassian.net/browse/VEN-565): Table number and pier property columns should sort first in descending order

## Testing :alembic:

### Manual testing :construction_worker_man:

* Place counts and properties on harbor and winter storage area lists should be first sorted in descending order