### PR TITLE
VEN-920 | Fit admin UI to a minimum screen width

### DIFF
--- a/src/app/page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/app/page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -70,113 +70,83 @@ exports[`Page renders normally 1`] = `
     </header>
   </header>
   <nav
-    class="sidebar"
+    class="side"
   >
     <div
       class="sidebar"
     >
       <div
-        class="mainWrapper"
+        class="sidebar"
       >
         <div
-          class="elementWrapper"
+          class="mainWrapper"
         >
-          <a
-            class="internalNavLink standard"
-            href="#/harbors"
+          <div
+            class="elementWrapper"
           >
-            <div
-              class="icon"
+            <a
+              class="internalNavLink standard"
+              href="#/harbors"
             >
-              <svg
-                class="icon s"
-                height="100%"
-                viewBox="0 0 24 24"
-                width="100%"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="icon"
               >
-                <g
-                  id="prefix__prefix__Symbols"
+                <svg
+                  class="icon s"
+                  height="100%"
+                  viewBox="0 0 24 24"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
                 >
                   <g
-                    id="prefix__prefix__app_x2F_navigation-sidebar"
-                    transform="translate(-21 -24)"
+                    id="prefix__prefix__Symbols"
                   >
                     <g
-                      id="prefix__prefix__Venepaikat"
-                      transform="translate(0 16)"
+                      id="prefix__prefix__app_x2F_navigation-sidebar"
+                      transform="translate(-21 -24)"
                     >
                       <g
-                        id="prefix__prefix__atoms_x2F_icons_x2F_ship_x2F_24"
-                        transform="translate(20 3.5)"
+                        id="prefix__prefix__Venepaikat"
+                        transform="translate(0 16)"
                       >
                         <g
-                          id="prefix__prefix__Icon-color"
-                          transform="translate(1 5)"
+                          id="prefix__prefix__atoms_x2F_icons_x2F_ship_x2F_24"
+                          transform="translate(20 3.5)"
                         >
                           <g
-                            id="prefix__prefix__Mask"
+                            id="prefix__prefix__Icon-color"
+                            transform="translate(1 5)"
                           >
-                            <path
-                              d="M22 15.1l-1.5-4H1l2.9 4.4c-.1.1-.2.1-.3.2-.6.4-1 .7-1.8.7v1.5c1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7.7 0 1.2.3 1.8.7.6.4 1.4.9 2.6.9 1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7s1.2.3 1.8.7c.7.4 1.4.9 2.6.9 1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7v-1.5c-.8-.1-1.4.1-1.8.3m-4.5.5c-.6-.4-1.4-.9-2.5-.9-1.2 0-1.9.5-2.5.9-.6.4-1 .7-1.8.7s-1.2-.3-1.8-.7c-.6-.4-1.4-.9-2.5-.9-.4 0-.7 0-1 .1l-1.5-2.3h15.8l1.2 3.3c-.4.3-.8.4-1.5.4-.9.1-1.4-.2-1.9-.6"
-                            />
-                            <path
-                              d="M19.1 9V4.5h-3.2l-2.1 3.1h-7l-.9 1.5L19.1 9zm-2.5-3h1v1.7h-2.1L16.6 6z"
-                            />
+                            <g
+                              id="prefix__prefix__Mask"
+                            >
+                              <path
+                                d="M22 15.1l-1.5-4H1l2.9 4.4c-.1.1-.2.1-.3.2-.6.4-1 .7-1.8.7v1.5c1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7.7 0 1.2.3 1.8.7.6.4 1.4.9 2.6.9 1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7s1.2.3 1.8.7c.7.4 1.4.9 2.6.9 1.2 0 2-.5 2.6-.9.6-.4 1-.7 1.8-.7v-1.5c-.8-.1-1.4.1-1.8.3m-4.5.5c-.6-.4-1.4-.9-2.5-.9-1.2 0-1.9.5-2.5.9-.6.4-1 .7-1.8.7s-1.2-.3-1.8-.7c-.6-.4-1.4-.9-2.5-.9-.4 0-.7 0-1 .1l-1.5-2.3h15.8l1.2 3.3c-.4.3-.8.4-1.5.4-.9.1-1.4-.2-1.9-.6"
+                              />
+                              <path
+                                d="M19.1 9V4.5h-3.2l-2.1 3.1h-7l-.9 1.5L19.1 9zm-2.5-3h1v1.7h-2.1L16.6 6z"
+                              />
+                            </g>
                           </g>
                         </g>
                       </g>
                     </g>
                   </g>
-                </g>
-              </svg>
-            </div>
-            <div
-              class="label"
-            >
-              Venepaikat
-            </div>
-          </a>
-        </div>
-        <div
-          class="elementWrapper"
-        >
-          <a
-            class="internalNavLink standard"
-            href="#/winter-storage-areas"
-          >
-            <div
-              class="icon"
-            >
-              <svg
-                class="icon s"
-                height="100%"
-                viewBox="0 0 24 24"
-                width="100%"
-                xmlns="http://www.w3.org/2000/svg"
+                </svg>
+              </div>
+              <div
+                class="label"
               >
-                <path
-                  d="M9.299.5v2.91L7.036 2.163l-.682 1.221 2.945 1.639v5.231L4.643 7.602l.027-3.279H3.241l-.025 2.466L.707 5.367 0 6.586l2.535 1.446-2.213 1.31.733 1.192 2.893-1.688 4.644 2.629-4.644 2.655-2.893-1.691-.733 1.195 2.211 1.295L0 16.39l.707 1.219 2.509-1.423.025 2.439H4.67l-.027-3.276 4.656-2.628v5.205l-2.945 1.639.682 1.244 2.263-1.268V22.5h1.428v-2.911l2.186 1.22.682-1.244-2.868-1.587v-5.284l4.553 2.604-.026 3.327h1.416l.038-2.528 2.572 1.487.72-1.218v-.001l-2.559-1.46 2.161-1.271-.708-1.195-2.88 1.667-4.58-2.631 4.58-2.604 2.88 1.663.708-1.192-2.161-1.271L20 6.611V6.61l-.72-1.22-2.572 1.475-.039-2.542h-1.415l.026 3.355-4.553 2.605V4.998l2.868-1.614-.682-1.221-2.186 1.221V.5z"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </div>
-            <div
-              class="label"
-            >
-              Talvisäilytys
-            </div>
-          </a>
-        </div>
-        <div
-          class="elementWrapper"
-        >
+                Venepaikat
+              </div>
+            </a>
+          </div>
           <div
-            class="expandableNavItem"
+            class="elementWrapper"
           >
-            <div
-              class="headerBtn label"
-              role="button"
+            <a
+              class="internalNavLink standard"
+              href="#/winter-storage-areas"
             >
               <div
                 class="icon"
@@ -189,7 +159,7 @@ exports[`Page renders normally 1`] = `
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="M1.741 9.5v10.35h14.517V9.5H18v12H0v-12h1.741zm12.859 7v1.7H3v-1.7h11.6zm0-3v1.7H3v-1.7h11.6zM8.385.5l1.492.022v6.104l3.249-3.26.966 1.117-4.96 5-5.132-5 .986-1.116 3.4 3.258V.5z"
+                    d="M9.299.5v2.91L7.036 2.163l-.682 1.221 2.945 1.639v5.231L4.643 7.602l.027-3.279H3.241l-.025 2.466L.707 5.367 0 6.586l2.535 1.446-2.213 1.31.733 1.192 2.893-1.688 4.644 2.629-4.644 2.655-2.893-1.691-.733 1.195 2.211 1.295L0 16.39l.707 1.219 2.509-1.423.025 2.439H4.67l-.027-3.276 4.656-2.628v5.205l-2.945 1.639.682 1.244 2.263-1.268V22.5h1.428v-2.911l2.186 1.22.682-1.244-2.868-1.587v-5.284l4.553 2.604-.026 3.327h1.416l.038-2.528 2.572 1.487.72-1.218v-.001l-2.559-1.46 2.161-1.271-.708-1.195-2.88 1.667-4.58-2.631 4.58-2.604 2.88 1.663.708-1.192-2.161-1.271L20 6.611V6.61l-.72-1.22-2.572 1.475-.039-2.542h-1.415l.026 3.355-4.553 2.605V4.998l2.868-1.614-.682-1.221-2.186 1.221V.5z"
                     fill-rule="evenodd"
                   />
                 </svg>
@@ -197,137 +167,194 @@ exports[`Page renders normally 1`] = `
               <div
                 class="label"
               >
-                Hakemukset
+                Talvisäilytys
+              </div>
+            </a>
+          </div>
+          <div
+            class="elementWrapper"
+          >
+            <div
+              class="expandableNavItem"
+            >
+              <div
+                class="headerBtn label"
+                role="button"
+              >
+                <div
+                  class="icon"
+                >
+                  <svg
+                    class="icon s"
+                    height="100%"
+                    viewBox="0 0 24 24"
+                    width="100%"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M1.741 9.5v10.35h14.517V9.5H18v12H0v-12h1.741zm12.859 7v1.7H3v-1.7h11.6zm0-3v1.7H3v-1.7h11.6zM8.385.5l1.492.022v6.104l3.249-3.26.966 1.117-4.96 5-5.132-5 .986-1.116 3.4 3.258V.5z"
+                      fill-rule="evenodd"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="label"
+                >
+                  Hakemukset
+                </div>
+              </div>
+              <div
+                class="headerBtn arrow"
+              >
+                <svg
+                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                    />
+                    <path
+                      d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                      fill="currentColor"
+                    />
+                  </g>
+                </svg>
               </div>
             </div>
             <div
-              class="headerBtn arrow"
+              class="children"
             >
-              <svg
-                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-                role="img"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <a
+                class="internalNavLink standard"
+                href="#/applications"
               >
-                <g
-                  fill="none"
-                  fill-rule="evenodd"
+                <div
+                  class="label"
                 >
-                  <path
-                    d="M0 0h24v24H0z"
-                  />
-                  <path
-                    d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-                    fill="currentColor"
-                  />
-                </g>
-              </svg>
+                  Venepaikkahakemukset
+                </div>
+              </a>
+              <a
+                class="internalNavLink standard"
+                href="#/winter-storage-applications"
+              >
+                <div
+                  class="label"
+                >
+                  Talvisäilytyshakemukset
+                </div>
+              </a>
+              <a
+                class="internalNavLink standard"
+                href="#/unmarked-ws-notices"
+              >
+                <div
+                  class="label"
+                >
+                  Nostojärjestysilmoitukset
+                </div>
+              </a>
             </div>
           </div>
           <div
-            class="children"
+            class="elementWrapper"
           >
             <a
               class="internalNavLink standard"
-              href="#/applications"
+              href="#/customers"
             >
+              <div
+                class="icon"
+              >
+                <svg
+                  class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                  role="img"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                  >
+                    <path
+                      d="M0 0h24v24H0z"
+                    />
+                    <path
+                      d="M16.267 13a4.733 4.733 0 014.728 4.517l.005.216V22H3v-4.267a4.733 4.733 0 014.517-4.728L7.733 13h8.534zm-8.534 2a2.733 2.733 0 00-2.728 2.567L5 17.733V20h14v-2.267c0-1.416-1.107-2.636-2.46-2.726l-.163-.005L7.733 15zM12 2a5 5 0 110 10 5 5 0 010-10zm0 2a3 3 0 100 6 3 3 0 000-6z"
+                      fill="currentColor"
+                    />
+                  </g>
+                </svg>
+              </div>
               <div
                 class="label"
               >
-                Venepaikkahakemukset
+                Asiakkaat
               </div>
             </a>
+          </div>
+          <div
+            class="elementWrapper"
+          >
             <a
               class="internalNavLink standard"
-              href="#/winter-storage-applications"
+              href="#/pricing"
             >
               <div
-                class="label"
+                class="icon"
               >
-                Talvisäilytyshakemukset
+                <svg
+                  class="icon s"
+                  height="100%"
+                  viewBox="0 0 24 24"
+                  width="100%"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M11 .5c6.075 0 11 4.925 11 11s-4.925 11-11 11-11-4.925-11-11S4.925.5 11 .5zm0 1.792a9.208 9.208 0 100 18.416 9.208 9.208 0 000-18.416zm.682 4.18c1.692 0 2.834 1.113 3.25 2.531l-1.773 1.14c0-1.14-.416-2.057-1.477-2.057-.927 0-1.437.723-1.679 1.724h2.539l-.376 1.32H9.842v.807h2.122l-.39 1.32h-1.57c.228.932.698 1.558 1.678 1.558 1.088 0 1.464-1.001 1.477-2.141l1.773 1.154c-.416 1.404-1.49 2.6-3.25 2.6s-3.089-1.057-3.559-3.17H6.968v-1.321h.994c-.013-.153-.013-.32-.013-.5v-.307h-.98V9.81h1.14c.47-2.197 1.894-3.337 3.573-3.337z"
+                    fill-rule="nonzero"
+                  />
+                </svg>
               </div>
-            </a>
-            <a
-              class="internalNavLink standard"
-              href="#/unmarked-ws-notices"
-            >
               <div
                 class="label"
               >
-                Nostojärjestysilmoitukset
+                Hinnasto
               </div>
             </a>
           </div>
         </div>
-        <div
-          class="elementWrapper"
-        >
-          <a
-            class="internalNavLink standard"
-            href="#/customers"
-          >
-            <div
-              class="icon"
-            >
-              <svg
-                class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-                role="img"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <g
-                  fill="none"
-                  fill-rule="evenodd"
-                >
-                  <path
-                    d="M0 0h24v24H0z"
-                  />
-                  <path
-                    d="M16.267 13a4.733 4.733 0 014.728 4.517l.005.216V22H3v-4.267a4.733 4.733 0 014.517-4.728L7.733 13h8.534zm-8.534 2a2.733 2.733 0 00-2.728 2.567L5 17.733V20h14v-2.267c0-1.416-1.107-2.636-2.46-2.726l-.163-.005L7.733 15zM12 2a5 5 0 110 10 5 5 0 010-10zm0 2a3 3 0 100 6 3 3 0 000-6z"
-                    fill="currentColor"
-                  />
-                </g>
-              </svg>
-            </div>
-            <div
-              class="label"
-            >
-              Asiakkaat
-            </div>
-          </a>
-        </div>
-        <div
-          class="elementWrapper"
-        >
-          <a
-            class="internalNavLink standard"
-            href="#/pricing"
-          >
-            <div
-              class="icon"
-            >
-              <svg
-                class="icon s"
-                height="100%"
-                viewBox="0 0 24 24"
-                width="100%"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11 .5c6.075 0 11 4.925 11 11s-4.925 11-11 11-11-4.925-11-11S4.925.5 11 .5zm0 1.792a9.208 9.208 0 100 18.416 9.208 9.208 0 000-18.416zm.682 4.18c1.692 0 2.834 1.113 3.25 2.531l-1.773 1.14c0-1.14-.416-2.057-1.477-2.057-.927 0-1.437.723-1.679 1.724h2.539l-.376 1.32H9.842v.807h2.122l-.39 1.32h-1.57c.228.932.698 1.558 1.678 1.558 1.088 0 1.464-1.001 1.477-2.141l1.773 1.154c-.416 1.404-1.49 2.6-3.25 2.6s-3.089-1.057-3.559-3.17H6.968v-1.321h.994c-.013-.153-.013-.32-.013-.5v-.307h-.98V9.81h1.14c.47-2.197 1.894-3.337 3.573-3.337z"
-                  fill-rule="nonzero"
-                />
-              </svg>
-            </div>
-            <div
-              class="label"
-            >
-              Hinnasto
-            </div>
-          </a>
-        </div>
       </div>
     </div>
+    <button
+      class="sidebarToggle"
+    >
+      <svg
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M24 0v24H0V0z"
+          />
+          <path
+            d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
+            fill="currentColor"
+          />
+        </g>
+      </svg>
+    </button>
   </nav>
   <div
     class="content"

--- a/src/app/page/__tests__/__snapshots__/Page.test.tsx.snap
+++ b/src/app/page/__tests__/__snapshots__/Page.test.tsx.snap
@@ -332,29 +332,38 @@ exports[`Page renders normally 1`] = `
         </div>
       </div>
     </div>
-    <button
-      class="sidebarToggle"
+    <div
+      class="sidebarToggleArea"
     >
-      <svg
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 sidebarToggle"
+        type="button"
       >
-        <g
-          fill="none"
-          fill-rule="evenodd"
+        <span
+          class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
         >
-          <path
-            d="M24 0v24H0V0z"
-          />
-          <path
-            d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-    </button>
+          <svg
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <path
+                d="M24 0v24H0V0z"
+              />
+              <path
+                d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </span>
+      </button>
+    </div>
   </nav>
   <div
     class="content"

--- a/src/common/contactInformationCard/ContactInformationDetails.tsx
+++ b/src/common/contactInformationCard/ContactInformationDetails.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 
 import Section from '../section/Section';
 import ExternalLink from '../externalLink/ExternalLink';
-import LabelValuePair from '../labelValuePair/LabelValuePair';
 
 export interface ContactInformationDetailsProps {
   className?: string;
@@ -22,12 +21,9 @@ const ContactInformationDetails = ({ className }: ContactInformationDetailsProps
       </Section>
 
       <Section title={t('common.terminology.harborChief').toUpperCase() + ' (PLACEHOLDER)'} className={className}>
-        <LabelValuePair label={'Nimi'} value={'Mikko Mallikas'} />
-        <LabelValuePair label={'Puhelin'} value={'+358 00 000 0000'} />
-        <LabelValuePair
-          label={'Sähköposti'}
-          value={<ExternalLink href="mailto:etunimi.sukunimi@gmail.com">etunimi.sukunimi@gmail.com</ExternalLink>}
-        />
+        <p>Mikko Mallikas</p>
+        <p>+358 00 000 0000</p>
+        <ExternalLink href="mailto:etunimi.sukunimi@gmail.com">etunimi.sukunimi@gmail.com</ExternalLink>
       </Section>
     </>
   );

--- a/src/common/contactInformationCard/__tests__/__snapshots__/ContactInformationCard.test.tsx.snap
+++ b/src/common/contactInformationCard/__tests__/__snapshots__/ContactInformationCard.test.tsx.snap
@@ -54,55 +54,20 @@ exports[`ContactInformationCard renders normally with all props 1`] = `
       <section
         class="body"
       >
-        <div
-          class="labelValuePair"
+        <p>
+          Mikko Mallikas
+        </p>
+        <p>
+          +358 00 000 0000
+        </p>
+        <a
+          class="link default"
+          href="mailto:etunimi.sukunimi@gmail.com"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <span
-            class="label standard"
-          >
-            Nimi:
-          </span>
-          <span
-            class="value left"
-          >
-            Mikko Mallikas
-          </span>
-        </div>
-        <div
-          class="labelValuePair"
-        >
-          <span
-            class="label standard"
-          >
-            Puhelin:
-          </span>
-          <span
-            class="value left"
-          >
-            +358 00 000 0000
-          </span>
-        </div>
-        <div
-          class="labelValuePair"
-        >
-          <span
-            class="label standard"
-          >
-            Sähköposti:
-          </span>
-          <span
-            class="value left"
-          >
-            <a
-              class="link default"
-              href="mailto:etunimi.sukunimi@gmail.com"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              etunimi.sukunimi@gmail.com
-            </a>
-          </span>
-        </div>
+          etunimi.sukunimi@gmail.com
+        </a>
       </section>
     </article>
   </div>

--- a/src/common/layout/Layout.tsx
+++ b/src/common/layout/Layout.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
+import { IconAngleLeft, IconAngleRight } from 'hds-react';
 
 import styles from './layout.module.scss';
 
@@ -10,13 +11,24 @@ export interface LayoutProps {
   footer?: JSX.Element;
 }
 
-const Layout = ({ header, sidebar, children, footer }: LayoutProps) => (
-  <main className={classNames(styles.layout, { [styles.noSidebar]: !sidebar })}>
-    <header className={styles.header}>{header}</header>
-    {sidebar && <nav className={styles.sidebar}>{sidebar}</nav>}
-    <div className={styles.content}>{children}</div>
-    {footer && <footer className={styles.footer}>{footer}</footer>}
-  </main>
-);
+const Layout = ({ header, sidebar, children, footer }: LayoutProps) => {
+  const [sidebarVisible, setSidebarVisible] = useState(true);
+
+  return (
+    <main className={classNames(styles.layout, { [styles.noSidebar]: !sidebar })}>
+      <header className={styles.header}>{header}</header>
+      {sidebar && (
+        <nav className={classNames(styles.side)}>
+          <div className={classNames(styles.sidebar, !sidebarVisible && styles.sidebarHidden)}>{sidebar}</div>
+          <button className={styles.sidebarToggle} onClick={() => setSidebarVisible(!sidebarVisible)}>
+            {sidebarVisible ? <IconAngleLeft /> : <IconAngleRight />}
+          </button>
+        </nav>
+      )}
+      <div className={styles.content}>{children}</div>
+      {footer && <footer className={styles.footer}>{footer}</footer>}
+    </main>
+  );
+};
 
 export default Layout;

--- a/src/common/layout/Layout.tsx
+++ b/src/common/layout/Layout.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { IconAngleLeft, IconAngleRight } from 'hds-react';
 
 import styles from './layout.module.scss';
+import Button from '../button/Button';
 
 export interface LayoutProps {
   header: JSX.Element;
@@ -18,11 +19,16 @@ const Layout = ({ header, sidebar, children, footer }: LayoutProps) => {
     <main className={classNames(styles.layout, { [styles.noSidebar]: !sidebar })}>
       <header className={styles.header}>{header}</header>
       {sidebar && (
-        <nav className={classNames(styles.side)}>
+        <nav className={styles.side}>
           <div className={classNames(styles.sidebar, !sidebarVisible && styles.sidebarHidden)}>{sidebar}</div>
-          <button className={styles.sidebarToggle} onClick={() => setSidebarVisible(!sidebarVisible)}>
-            {sidebarVisible ? <IconAngleLeft /> : <IconAngleRight />}
-          </button>
+          <div className={styles.sidebarToggleArea}>
+            <Button
+              className={classNames(styles.sidebarToggle, !sidebarVisible && styles.sidebarToggleShow)}
+              onClick={() => setSidebarVisible(!sidebarVisible)}
+            >
+              {sidebarVisible ? <IconAngleLeft /> : <IconAngleRight />}
+            </Button>
+          </div>
         </nav>
       )}
       <div className={styles.content}>{children}</div>

--- a/src/common/layout/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/src/common/layout/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -12,11 +12,38 @@ exports[`Layout renders normally 1`] = `
     </div>
   </header>
   <nav
-    class="sidebar"
+    class="side"
   >
-    <div>
-      sidebar
+    <div
+      class="sidebar"
+    >
+      <div>
+        sidebar
+      </div>
     </div>
+    <button
+      class="sidebarToggle"
+    >
+      <svg
+        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+        role="img"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <g
+          fill="none"
+          fill-rule="evenodd"
+        >
+          <path
+            d="M24 0v24H0V0z"
+          />
+          <path
+            d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
+            fill="currentColor"
+          />
+        </g>
+      </svg>
+    </button>
   </nav>
   <div
     class="content"

--- a/src/common/layout/__tests__/__snapshots__/Layout.test.tsx.snap
+++ b/src/common/layout/__tests__/__snapshots__/Layout.test.tsx.snap
@@ -21,29 +21,38 @@ exports[`Layout renders normally 1`] = `
         sidebar
       </div>
     </div>
-    <button
-      class="sidebarToggle"
+    <div
+      class="sidebarToggleArea"
     >
-      <svg
-        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
-        role="img"
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 sidebarToggle"
+        type="button"
       >
-        <g
-          fill="none"
-          fill-rule="evenodd"
+        <span
+          class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
         >
-          <path
-            d="M24 0v24H0V0z"
-          />
-          <path
-            d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
-            fill="currentColor"
-          />
-        </g>
-      </svg>
-    </button>
+          <svg
+            class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <g
+              fill="none"
+              fill-rule="evenodd"
+            >
+              <path
+                d="M24 0v24H0V0z"
+              />
+              <path
+                d="M10.5 12l5 5-1.5 1.5L7.5 12 14 5.5 15.5 7z"
+                fill="currentColor"
+              />
+            </g>
+          </svg>
+        </span>
+      </button>
+    </div>
   </nav>
   <div
     class="content"

--- a/src/common/layout/layout.module.scss
+++ b/src/common/layout/layout.module.scss
@@ -43,7 +43,7 @@ $noSidebar: 'header  header' 'content content' 'footer  footer';
 
   .content {
     grid-area: content;
-    overflow-y: scroll;
+    overflow-y: auto;
     background-color: $black-5;
   }
 

--- a/src/common/layout/layout.module.scss
+++ b/src/common/layout/layout.module.scss
@@ -33,12 +33,39 @@ $noSidebar: 'header  header' 'content content' 'footer  footer';
     width: 0;
   }
 
-  .sidebarToggle {
-    display: block;
-    text-align: center;
-    width: units(1.5);
+  .sidebarToggleArea {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    width: 0;
     height: 100%;
     background: $black-10;
+  }
+
+  .sidebarToggle {
+    width: units(2);
+    height: units(2);
+    overflow: hidden;
+    border-radius: 50%;
+    filter: grayscale(1) brightness(2);
+    margin-top: units(0.5);
+
+    &:hover {
+      filter: none;
+    }
+
+    span {
+      padding: 0;
+      margin: 0;
+      line-height: unset;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
+  }
+
+  .sidebarToggleShow {
+    left: units(1);
   }
 
   .content {

--- a/src/common/layout/layout.module.scss
+++ b/src/common/layout/layout.module.scss
@@ -6,7 +6,7 @@ $noSidebar: 'header  header' 'content content' 'footer  footer';
 
 .layout {
   display: grid;
-  grid-template-columns: minmax(units(16), max-content) 4fr;
+  grid-template-columns: max-content 4fr;
   grid-template-rows: minmax(units(4), min-content) 1fr auto;
   grid-template-areas:
     'header  header'
@@ -19,8 +19,26 @@ $noSidebar: 'header  header' 'content content' 'footer  footer';
     grid-area: header;
   }
 
-  .sidebar {
+  .side {
     grid-area: side;
+    display: flex;
+  }
+
+  .sidebar {
+    display: block;
+    overflow: hidden;
+  }
+
+  .sidebarHidden {
+    width: 0;
+  }
+
+  .sidebarToggle {
+    display: block;
+    text-align: center;
+    width: units(1.5);
+    height: 100%;
+    background: $black-10;
   }
 
   .content {

--- a/src/common/pageContent/pageContent.module.scss
+++ b/src/common/pageContent/pageContent.module.scss
@@ -1,6 +1,5 @@
 @import 'spacings';
 
 .pageContent {
-  min-height: 100%;
-  padding: units(2);
+  margin: units(2);
 }

--- a/src/common/table/table.module.scss
+++ b/src/common/table/table.module.scss
@@ -3,8 +3,8 @@
 @import 'z-index';
 
 $rows-spacing: units(0.25);
-$cell-padding-vertical: units(0.5);
-$cell-padding-horizontal: units(1);
+$cell-padding-vertical: units(0.25);
+$cell-padding-horizontal: units(0.5);
 $transition-duration: 300ms;
 $placeholder-bg-size: 1000px;
 

--- a/src/common/table/table.module.scss
+++ b/src/common/table/table.module.scss
@@ -43,7 +43,8 @@ $placeholder-bg-size: 1000px;
 
     .placeholder {
       height: units(1.5);
-      width: 100%;
+      width: calc(100% - #{units(0.5)});
+      margin: 0 units(0.25);
       background: linear-gradient(90deg, $black-5, $black-10, $black-5);
       background-size: $placeholder-bg-size 100%;
       animation: shimmer 2s ease-in-out infinite;

--- a/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
+++ b/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
@@ -359,55 +359,20 @@ exports[`HarborView renders normally 1`] = `
           <section
             class="body"
           >
-            <div
-              class="labelValuePair"
+            <p>
+              Mikko Mallikas
+            </p>
+            <p>
+              +358 00 000 0000
+            </p>
+            <a
+              class="link default"
+              href="mailto:etunimi.sukunimi@gmail.com"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <span
-                class="label standard"
-              >
-                Nimi:
-              </span>
-              <span
-                class="value left"
-              >
-                Mikko Mallikas
-              </span>
-            </div>
-            <div
-              class="labelValuePair"
-            >
-              <span
-                class="label standard"
-              >
-                Puhelin:
-              </span>
-              <span
-                class="value left"
-              >
-                +358 00 000 0000
-              </span>
-            </div>
-            <div
-              class="labelValuePair"
-            >
-              <span
-                class="label standard"
-              >
-                Sähköposti:
-              </span>
-              <span
-                class="value left"
-              >
-                <a
-                  class="link default"
-                  href="mailto:etunimi.sukunimi@gmail.com"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  etunimi.sukunimi@gmail.com
-                </a>
-              </span>
-            </div>
+              etunimi.sukunimi@gmail.com
+            </a>
           </section>
         </article>
       </div>

--- a/src/features/pricing/Pricing.tsx
+++ b/src/features/pricing/Pricing.tsx
@@ -39,17 +39,10 @@ const Pricing = ({
   return (
     <PageContent className={styles.pricing}>
       <PageTitle title={t('pricing.title')} />
-      <div className={styles.grid}>
-        <BerthPricing
-          className={styles.fullWidth}
-          data={berthsData}
-          loading={loading}
-          refetchQueries={refetchQueries}
-        />
-        <WinterStoragePricing className={styles.fullWidth} data={winterStorageData} loading={loading} />
-        <HarborServicePricing data={harborServicesData} loading={loading} />
-        <AdditionalServicePricing {...additionalServicesModal} data={additionalServicesData} loading={loading} />
-      </div>
+      <BerthPricing data={berthsData} loading={loading} refetchQueries={refetchQueries} />
+      <WinterStoragePricing data={winterStorageData} loading={loading} />
+      <HarborServicePricing data={harborServicesData} loading={loading} />
+      <AdditionalServicePricing {...additionalServicesModal} data={additionalServicesData} loading={loading} />
     </PageContent>
   );
 };

--- a/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
+++ b/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
@@ -10,477 +10,234 @@ exports[`PricingPage renders normally 1`] = `
     HINNASTO
   </h2>
   <div
-    class="grid"
+    class="card"
   >
     <div
-      class="card fullWidth"
+      class="cardHeader"
     >
-      <div
-        class="cardHeader"
+      <span
+        class="title"
       >
-        <span
-          class="title"
-        >
-          Venepaikka
-        </span>
-      </div>
-      <div
-        class="cardBody"
-      >
-        <article
-          class="section"
-        >
-          <section
-            class="body"
-          >
-            Perushinta. Hinnat sisältävät alv 24 %.
-          </section>
-        </article>
-        <div>
-          <div
-            class="tableWrapper"
-          >
-            <div
-              class="table basic noMainHeader"
-              role="table"
-              style="min-width: 712.5px;"
-            >
-              <div
-                class="stickyHeaders"
-              >
-                <div
-                  class="header"
-                  role="row"
-                  style="display: flex; flex: 1 0 auto; min-width: 0px;"
-                >
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Leveys
-                    <div
-                      class="sortArrowWrapper isSorted"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Yksityinen
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Yritys
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Aika
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                  >
-                    Muokkaa
-                  </div>
-                </div>
-              </div>
-              <div
-                role="rowgroup"
-              >
-                <div
-                  class="rowWrapper"
-                >
-                  <div
-                    role="row"
-                    style="display: flex; flex: 1 0 auto; min-width: 0px;"
-                  >
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      sed sed debitis
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      10,20 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      20,40 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      Kausi
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      <button>
-                        <span
-                          class="text brand span"
-                        >
-                          Muokkaa
-                        </span>
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-       
+        Venepaikka
+      </span>
     </div>
     <div
-      class="card fullWidth"
+      class="cardBody"
     >
-      <div
-        class="cardHeader"
+      <article
+        class="section"
       >
-        <span
-          class="title"
+        <section
+          class="body"
         >
-          Talvisäilytyspaikka
-        </span>
-      </div>
-      <div
-        class="cardBody"
-      >
-        <article
-          class="section"
+          Perushinta. Hinnat sisältävät alv 24 %.
+        </section>
+      </article>
+      <div>
+        <div
+          class="tableWrapper"
         >
-          <section
-            class="body"
-          >
-            Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.
-          </section>
-        </article>
-        <div>
           <div
-            class="tableWrapper"
+            class="table basic noMainHeader"
+            role="table"
+            style="min-width: 712.5px;"
           >
             <div
-              class="table basic noMainHeader"
-              role="table"
-              style="min-width: 712.5px;"
+              class="stickyHeaders"
             >
               <div
-                class="stickyHeaders"
+                class="header"
+                role="row"
+                style="display: flex; flex: 1 0 auto; min-width: 0px;"
               >
                 <div
-                  class="header"
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Leveys
+                  <div
+                    class="sortArrowWrapper isSorted"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Yksityinen
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Yritys
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Aika
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                >
+                  Muokkaa
+                </div>
+              </div>
+            </div>
+            <div
+              role="rowgroup"
+            >
+              <div
+                class="rowWrapper"
+              >
+                <div
                   role="row"
                   style="display: flex; flex: 1 0 auto; min-width: 0px;"
                 >
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Alue
-                    <div
-                      class="sortArrowWrapper isSorted"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    sed sed debitis
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Yksityinen
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    10,20 €
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Yritys
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    20,40 €
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Aika
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    Kausi
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
+                    class="tableCell"
+                    role="cell"
                     style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                   >
-                    Muokkaa
-                  </div>
-                </div>
-              </div>
-              <div
-                role="rowgroup"
-              >
-                <div
-                  class="rowWrapper"
-                >
-                  <div
-                    role="row"
-                    style="display: flex; flex: 1 0 auto; min-width: 0px;"
-                  >
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      Corporate Developer Mobility
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      10,20 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      20,40 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
-                    >
-                      Kausi
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      <button>
-                        <span
-                          class="text brand span"
-                        >
-                          Muokkaa
-                        </span>
-                      </button>
-                    </div>
+                    <button>
+                      <span
+                        class="text brand span"
+                      >
+                        Muokkaa
+                      </span>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -488,199 +245,238 @@ exports[`PricingPage renders normally 1`] = `
           </div>
         </div>
       </div>
-       
+    </div>
+     
+  </div>
+  <div
+    class="card"
+  >
+    <div
+      class="cardHeader"
+    >
+      <span
+        class="title"
+      >
+        Talvisäilytyspaikka
+      </span>
     </div>
     <div
-      class="card"
+      class="cardBody"
     >
-      <div
-        class="cardHeader"
+      <article
+        class="section"
       >
-        <span
-          class="title"
+        <section
+          class="body"
         >
-          Satamapalvelut
-        </span>
-      </div>
-      <div
-        class="cardBody"
-      >
-        <article
-          class="section"
+          Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.
+        </section>
+      </article>
+      <div>
+        <div
+          class="tableWrapper"
         >
-          <section
-            class="body"
-          >
-            Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.
-          </section>
-        </article>
-        <div>
           <div
-            class="tableWrapper"
+            class="table basic noMainHeader"
+            role="table"
+            style="min-width: 712.5px;"
           >
             <div
-              class="table basic noMainHeader"
-              role="table"
-              style="min-width: 562.5px;"
+              class="stickyHeaders"
             >
               <div
-                class="stickyHeaders"
+                class="header"
+                role="row"
+                style="display: flex; flex: 1 0 auto; min-width: 0px;"
               >
                 <div
-                  class="header"
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Alue
+                  <div
+                    class="sortArrowWrapper isSorted"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Yksityinen
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Yritys
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Aika
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                >
+                  Muokkaa
+                </div>
+              </div>
+            </div>
+            <div
+              role="rowgroup"
+            >
+              <div
+                class="rowWrapper"
+              >
+                <div
                   role="row"
                   style="display: flex; flex: 1 0 auto; min-width: 0px;"
                 >
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Palvelu
-                    <div
-                      class="sortArrowWrapper isSorted"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    Corporate Developer Mobility
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Hinta
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    10,20 €
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
                   >
-                    Aika
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    20,40 €
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+                  >
+                    Kausi
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
                     style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                   >
-                    Muokkaa
-                  </div>
-                </div>
-              </div>
-              <div
-                role="rowgroup"
-              >
-                <div
-                  class="rowWrapper"
-                >
-                  <div
-                    role="row"
-                    style="display: flex; flex: 1 0 auto; min-width: 0px;"
-                  >
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px;"
-                    >
-                      Jollapaikka
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      10,00 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      Kausi
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      <button>
-                        <span
-                          class="text brand span"
-                        >
-                          Muokkaa
-                        </span>
-                      </button>
-                    </div>
+                    <button>
+                      <span
+                        class="text brand span"
+                      >
+                        Muokkaa
+                      </span>
+                    </button>
                   </div>
                 </div>
               </div>
@@ -688,247 +484,447 @@ exports[`PricingPage renders normally 1`] = `
           </div>
         </div>
       </div>
-       
+    </div>
+     
+  </div>
+  <div
+    class="card"
+  >
+    <div
+      class="cardHeader"
+    >
+      <span
+        class="title"
+      >
+        Satamapalvelut
+      </span>
     </div>
     <div
-      class="card additionalServicePricing"
+      class="cardBody"
     >
-      <div
-        class="cardHeader"
+      <article
+        class="section"
       >
-        <span
-          class="title"
+        <section
+          class="body"
         >
-          Lisäpalvelut
-        </span>
-      </div>
-      <div
-        class="cardBody"
-      >
-        <div>
+          Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.
+        </section>
+      </article>
+      <div>
+        <div
+          class="tableWrapper"
+        >
           <div
-            class="tableWrapper"
+            class="table basic noMainHeader"
+            role="table"
+            style="min-width: 562.5px;"
           >
             <div
-              class="table basic noMainHeader"
-              role="table"
-              style="min-width: 675px;"
+              class="stickyHeaders"
             >
               <div
-                class="stickyHeaders"
+                class="header"
+                role="row"
+                style="display: flex; flex: 1 0 auto; min-width: 0px;"
               >
                 <div
-                  class="header"
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Palvelu
+                  <div
+                    class="sortArrowWrapper isSorted"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Hinta
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Aika
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                >
+                  Muokkaa
+                </div>
+              </div>
+            </div>
+            <div
+              role="rowgroup"
+            >
+              <div
+                class="rowWrapper"
+              >
+                <div
                   role="row"
                   style="display: flex; flex: 1 0 auto; min-width: 0px;"
                 >
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px; cursor: pointer;"
-                    title="Toggle SortBy"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px;"
                   >
-                    Palvelu
-                    <div
-                      class="sortArrowWrapper isSorted"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
+                    Jollapaikka
                   </div>
                   <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Hinta
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    ALV
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
-                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
-                    title="Toggle SortBy"
-                  >
-                    Aika
-                    <div
-                      class="sortArrowWrapper"
-                    >
-                      <svg
-                        class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                        role="img"
-                        viewBox="0 0 24 24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <g
-                          fill="none"
-                          fill-rule="evenodd"
-                        >
-                          <path
-                            d="M0 0h24v24H0z"
-                          />
-                          <path
-                            d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
-                            fill="currentColor"
-                          />
-                        </g>
-                      </svg>
-                    </div>
-                  </div>
-                  <div
-                    class="headerCell"
-                    colspan="1"
-                    role="columnheader"
+                    class="tableCell"
+                    role="cell"
                     style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                   >
-                    Muokkaa
+                    10,00 €
                   </div>
-                </div>
-              </div>
-              <div
-                role="rowgroup"
-              >
-                <div
-                  class="rowWrapper"
-                >
                   <div
-                    role="row"
-                    style="display: flex; flex: 1 0 auto; min-width: 0px;"
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
                   >
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px;"
-                    >
-                      Jollapaikka
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      10,00 €
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      24 %
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      Kausi
-                    </div>
-                    <div
-                      class="tableCell"
-                      role="cell"
-                      style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
-                    >
-                      <button>
-                        <span
-                          class="text brand span"
-                        >
-                          Muokkaa
-                        </span>
-                      </button>
-                    </div>
+                    Kausi
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                  >
+                    <button>
+                      <span
+                        class="text brand span"
+                      >
+                        Muokkaa
+                      </span>
+                    </button>
                   </div>
                 </div>
               </div>
             </div>
           </div>
-          <button
-            class="addButton"
-          >
-            <span
-              class="text brand span"
-            >
-              Lisää uusi
-            </span>
-          </button>
         </div>
       </div>
-       
     </div>
+     
+  </div>
+  <div
+    class="card additionalServicePricing"
+  >
+    <div
+      class="cardHeader"
+    >
+      <span
+        class="title"
+      >
+        Lisäpalvelut
+      </span>
+    </div>
+    <div
+      class="cardBody"
+    >
+      <div>
+        <div
+          class="tableWrapper"
+        >
+          <div
+            class="table basic noMainHeader"
+            role="table"
+            style="min-width: 675px;"
+          >
+            <div
+              class="stickyHeaders"
+            >
+              <div
+                class="header"
+                role="row"
+                style="display: flex; flex: 1 0 auto; min-width: 0px;"
+              >
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Palvelu
+                  <div
+                    class="sortArrowWrapper isSorted"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Hinta
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  ALV
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px; cursor: pointer;"
+                  title="Toggle SortBy"
+                >
+                  Aika
+                  <div
+                    class="sortArrowWrapper"
+                  >
+                    <svg
+                      class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
+                      role="img"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <g
+                        fill="none"
+                        fill-rule="evenodd"
+                      >
+                        <path
+                          d="M0 0h24v24H0z"
+                        />
+                        <path
+                          d="M10 5.636l1.414 1.414L7.465 11H20v2H7.464l3.95 3.95L10 18.364 3.636 12z"
+                          fill="currentColor"
+                        />
+                      </g>
+                    </svg>
+                  </div>
+                </div>
+                <div
+                  class="headerCell"
+                  colspan="1"
+                  role="columnheader"
+                  style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                >
+                  Muokkaa
+                </div>
+              </div>
+            </div>
+            <div
+              role="rowgroup"
+            >
+              <div
+                class="rowWrapper"
+              >
+                <div
+                  role="row"
+                  style="display: flex; flex: 1 0 auto; min-width: 0px;"
+                >
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 225 0 auto; min-width: 0px; width: 225px;"
+                  >
+                    Jollapaikka
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                  >
+                    10,00 €
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                  >
+                    24 %
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                  >
+                    Kausi
+                  </div>
+                  <div
+                    class="tableCell"
+                    role="cell"
+                    style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+                  >
+                    <button>
+                      <span
+                        class="text brand span"
+                      >
+                        Muokkaa
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <button
+          class="addButton"
+        >
+          <span
+            class="text brand span"
+          >
+            Lisää uusi
+          </span>
+        </button>
+      </div>
+    </div>
+     
   </div>
 </div>
 `;

--- a/src/features/pricing/pricing.module.scss
+++ b/src/features/pricing/pricing.module.scss
@@ -1,11 +1,7 @@
 @import 'spacings';
 
-.grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-gap: units(1);
-}
-
-.fullWidth {
-  grid-column: -1 / 1;
+.pricing {
+  > :not(:first-child) {
+    margin-top: units(1);
+  }
 }

--- a/src/features/winterStorageAreaList/winterStorageAreaDetails/__tests__/__snapshots__/WinterStorageAreaDetails.test.tsx.snap
+++ b/src/features/winterStorageAreaList/winterStorageAreaDetails/__tests__/__snapshots__/WinterStorageAreaDetails.test.tsx.snap
@@ -132,55 +132,20 @@ exports[`WinterStorageAreaDetails renders normally 1`] = `
       <section
         class="body"
       >
-        <div
-          class="labelValuePair"
+        <p>
+          Mikko Mallikas
+        </p>
+        <p>
+          +358 00 000 0000
+        </p>
+        <a
+          class="link default"
+          href="mailto:etunimi.sukunimi@gmail.com"
+          rel="noopener noreferrer"
+          target="_blank"
         >
-          <span
-            class="label standard"
-          >
-            Nimi:
-          </span>
-          <span
-            class="value left"
-          >
-            Mikko Mallikas
-          </span>
-        </div>
-        <div
-          class="labelValuePair"
-        >
-          <span
-            class="label standard"
-          >
-            Puhelin:
-          </span>
-          <span
-            class="value left"
-          >
-            +358 00 000 0000
-          </span>
-        </div>
-        <div
-          class="labelValuePair"
-        >
-          <span
-            class="label standard"
-          >
-            Sähköposti:
-          </span>
-          <span
-            class="value left"
-          >
-            <a
-              class="link default"
-              href="mailto:etunimi.sukunimi@gmail.com"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              etunimi.sukunimi@gmail.com
-            </a>
-          </span>
-        </div>
+          etunimi.sukunimi@gmail.com
+        </a>
       </section>
     </article>
   </div>

--- a/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
+++ b/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
@@ -318,55 +318,20 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
           <section
             class="body"
           >
-            <div
-              class="labelValuePair"
+            <p>
+              Mikko Mallikas
+            </p>
+            <p>
+              +358 00 000 0000
+            </p>
+            <a
+              class="link default"
+              href="mailto:etunimi.sukunimi@gmail.com"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              <span
-                class="label standard"
-              >
-                Nimi:
-              </span>
-              <span
-                class="value left"
-              >
-                Mikko Mallikas
-              </span>
-            </div>
-            <div
-              class="labelValuePair"
-            >
-              <span
-                class="label standard"
-              >
-                Puhelin:
-              </span>
-              <span
-                class="value left"
-              >
-                +358 00 000 0000
-              </span>
-            </div>
-            <div
-              class="labelValuePair"
-            >
-              <span
-                class="label standard"
-              >
-                Sähköposti:
-              </span>
-              <span
-                class="value left"
-              >
-                <a
-                  class="link default"
-                  href="mailto:etunimi.sukunimi@gmail.com"
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  etunimi.sukunimi@gmail.com
-                </a>
-              </span>
-            </div>
+              etunimi.sukunimi@gmail.com
+            </a>
           </section>
         </article>
       </div>


### PR DESCRIPTION
## Description :sparkles:

* Fit admin UI to a minimum screen width
  * Reduce table cell padding
  * Make pricing page single column
  * Toggleable sidebar
  * Disable scrolling if there's nothing to scroll
  * Simplify harbor chief information 

## Issues :bug:

### Closes :no_good_woman:

* [VEN-920](https://helsinkisolutionoffice.atlassian.net/browse/VEN-920): Fit admin UI to a minimum screen width

## Testing :alembic:

### Automated tests :gear:️

* Updated related snapshots (harbor chief)

### Manual testing :construction_worker_man:

* Test that the toggleable sidebar works correctly
* No functionality regressions should be caused by this