### PR TITLE
VEN-894 | Add period and headers to InvoicingHistoryCard

### DIFF
--- a/src/common/pageContent/pageContent.module.scss
+++ b/src/common/pageContent/pageContent.module.scss
@@ -1,5 +1,7 @@
 @import 'spacings';
 
 .pageContent {
-  margin: units(2);
+  padding: units(2);
+  width: min-content;
+  min-width: 100%;
 }

--- a/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
+++ b/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
@@ -21,6 +21,8 @@ interface InvoicingHistoryProps {
 }
 
 const InvoicingHistoryCard = ({ invoices, onClick }: InvoicingHistoryProps) => {
+  const { t, i18n } = useTranslation();
+
   const invoiceStatusToType = (invoiceStatus: OrderStatus): StatusLabelProps['type'] => {
     switch (invoiceStatus) {
       case OrderStatus.WAITING:
@@ -37,37 +39,49 @@ const InvoicingHistoryCard = ({ invoices, onClick }: InvoicingHistoryProps) => {
     }
   };
 
-  const { t, i18n } = useTranslation();
+  const getRows = () =>
+    invoices.map((invoice, id) => (
+      <React.Fragment key={id}>
+        <button onClick={() => onClick(invoice)} className={styles.gridItem}>
+          <Text color="brand">
+            {isBerthInvoice(invoice)
+              ? t('common.terminology.berthRent')
+              : t('common.terminology.winterStoragePlaceRent')}
+          </Text>
+        </button>
+        <div className={styles.gridItem}>
+          <Text>
+            {`${formatDate(invoice.contractPeriod.startDate, i18n.language)} - ${formatDate(
+              invoice.contractPeriod.endDate,
+              i18n.language
+            )}`}
+          </Text>
+        </div>
+        <div className={styles.gridItem}>
+          <Text>{formatDate(invoice.dueDate, i18n.language)}</Text>
+        </div>
+        <div className={styles.gridItem}>
+          <Text>{formatPrice(invoice.totalPrice, i18n.language)}</Text>
+        </div>
+        <div className={styles.gridItem}>
+          <StatusLabel type={invoiceStatusToType(invoice.status)} label={t(getOrderStatusTKey(invoice.status))} />
+        </div>
+      </React.Fragment>
+    ));
+
   return (
     <Card>
       <CardHeader title={t('customerView.invoicingHistory.title')} />
       <CardBody>
         {invoices.length > 0 ? (
-          <Section title={t('common.terminology.invoices').toUpperCase()}>
-            <Grid colsCount={4}>
-              {invoices.map((invoice, id) => (
-                <React.Fragment key={id}>
-                  <button onClick={() => onClick(invoice)} className={styles.gridItem}>
-                    <Text color="brand">
-                      {isBerthInvoice(invoice)
-                        ? t('common.terminology.berthRent')
-                        : t('common.terminology.winterStoragePlaceRent')}
-                    </Text>
-                  </button>
-                  <div className={styles.gridItem}>
-                    <Text>{formatDate(invoice.dueDate, i18n.language)}</Text>
-                  </div>
-                  <div className={styles.gridItem}>
-                    <Text>{formatPrice(invoice.totalPrice, i18n.language)}</Text>
-                  </div>
-                  <div className={styles.gridItem}>
-                    <StatusLabel
-                      type={invoiceStatusToType(invoice.status)}
-                      label={t(getOrderStatusTKey(invoice.status))}
-                    />
-                  </div>
-                </React.Fragment>
-              ))}
+          <Section>
+            <Grid colsCount={5}>
+              <div className={styles.gridHeader}>Tyyppi</div>
+              <div className={styles.gridHeader}>Kausi</div>
+              <div className={styles.gridHeader}>Eräpäivä</div>
+              <div className={styles.gridHeader}>Summa</div>
+              <div className={styles.gridHeader}>Tila</div>
+              {getRows()}
             </Grid>
           </Section>
         ) : (

--- a/src/features/customerView/invoicingHistoryCard/__tests__/__snapshots__/InvoicingHistoryCard.test.tsx.snap
+++ b/src/features/customerView/invoicingHistoryCard/__tests__/__snapshots__/InvoicingHistoryCard.test.tsx.snap
@@ -19,17 +19,37 @@ exports[`InvoicingHistoryCard renders correctly 1`] = `
     <article
       class="section"
     >
-      <h4
-        class="text standard h4 m title"
-      >
-        LASKUT
-      </h4>
       <section
         class="body"
       >
         <div
-          class="grid cols4"
+          class="grid cols5"
         >
+          <div
+            class="gridHeader"
+          >
+            Tyyppi
+          </div>
+          <div
+            class="gridHeader"
+          >
+            Kausi
+          </div>
+          <div
+            class="gridHeader"
+          >
+            Eräpäivä
+          </div>
+          <div
+            class="gridHeader"
+          >
+            Summa
+          </div>
+          <div
+            class="gridHeader"
+          >
+            Tila
+          </div>
           <button
             class="gridItem"
           >
@@ -39,6 +59,15 @@ exports[`InvoicingHistoryCard renders correctly 1`] = `
               Venepaikan vuokra
             </span>
           </button>
+          <div
+            class="gridItem"
+          >
+            <span
+              class="text standard span"
+            >
+              26.06.2020 - 14.09.2020
+            </span>
+          </div>
           <div
             class="gridItem"
           >

--- a/src/features/customerView/invoicingHistoryCard/invoicingHistoryCard.module.scss
+++ b/src/features/customerView/invoicingHistoryCard/invoicingHistoryCard.module.scss
@@ -1,8 +1,14 @@
 @import 'spacings';
 
+.gridHeader,
 .gridItem {
   text-align: left;
   margin: units(0.5) 0;
   display: flex;
   align-items: center;
+}
+
+.gridHeader {
+  font-weight: bold;
+  text-transform: uppercase;
 }


### PR DESCRIPTION
## Description :sparkles:

* Add period and headers to InvoicingHistoryCard
* Adjust page content behavior on smaller screen sizes
  * Card content overflowed on small screen sizes previously, now cards are scaled accordingly

## Issues :bug:

### Closes :no_good_woman:

* [VEN-894](https://helsinkisolutionoffice.atlassian.net/browse/VEN-894): FE: Change the due date into right term (sopimuskausi)

## Testing :alembic:

### Automated tests :gear:️

* Updated snapshot

### Manual testing :construction_worker_man:

* Invoicing history card should now show the period billed in the invoice
* There should be one scrollbar for overflowing page content on smaller screens