### PR TITLE
VEN-943 | Caching issues & Link to WS application

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -540,18 +540,18 @@ export interface UpdateProfileInput {
   language?: Language | null;
   contactMethod?: ContactMethod | null;
   addEmails?: (CreateEmailInput | null)[] | null;
-  updateEmails?: (UpdateEmailInput | null)[] | null;
-  removeEmails?: (string | null)[] | null;
   addPhones?: (CreatePhoneInput | null)[] | null;
-  updatePhones?: (UpdatePhoneInput | null)[] | null;
-  removePhones?: (string | null)[] | null;
   addAddresses?: (CreateAddressInput | null)[] | null;
-  updateAddresses?: (UpdateAddressInput | null)[] | null;
-  removeAddresses?: (string | null)[] | null;
   subscriptions?: (SubscriptionInputType | null)[] | null;
   youthProfile?: YouthProfileFields | null;
   sensitivedata?: SensitiveDataFields | null;
   id: string;
+  updateEmails?: (UpdateEmailInput | null)[] | null;
+  removeEmails?: (string | null)[] | null;
+  updatePhones?: (UpdatePhoneInput | null)[] | null;
+  removePhones?: (string | null)[] | null;
+  updateAddresses?: (UpdateAddressInput | null)[] | null;
+  removeAddresses?: (string | null)[] | null;
 }
 
 export interface UpdateProfileMutationInput {

--- a/src/features/applicationList/ApplicationListContainer.tsx
+++ b/src/features/applicationList/ApplicationListContainer.tsx
@@ -25,6 +25,7 @@ const ApplicationListContainer = () => {
   };
 
   const { loading, data } = useQuery<BERTH_APPLICATIONS, BERTH_APPLICATIONS_VARS>(BERTH_APPLICATIONS_QUERY, {
+    fetchPolicy: 'no-cache',
     variables: berthApplicationsVars,
   });
 

--- a/src/features/applicationList/__fixtures__/mockData.ts
+++ b/src/features/applicationList/__fixtures__/mockData.ts
@@ -88,7 +88,7 @@ export const mockData: BERTH_APPLICATIONS = {
           customer: { __typename: 'ProfileNode', id: 'MOCK-PROFILE' },
           firstName: 'Maija',
           harborChoices: null,
-          id: 'MOCK-APPLICATION-0',
+          id: 'MOCK-APPLICATION-1',
           lastName: 'Meikäläinen',
           lease: {
             __typename: 'BerthLeaseNode',

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -259,6 +259,131 @@ exports[`ApplicationList renders normally with all props 1`] = `
               >
                 <a
                   class="internalLink brand"
+                  href="#/harbors/MOCK-HARBOR-0"
+                  title="Testisatama G 7"
+                >
+                  Testisatama G 7
+                </a>
+              </div>
+              <div
+                class="tableCell expander"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <div
+                  style="cursor: pointer;"
+                  title="Toggle Row Expanded"
+                >
+                  <svg
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv expandArrow"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="rowWrapper"
+          >
+            <div
+              role="row"
+              style="display: flex; flex: 1 0 auto; min-width: 0px;"
+            >
+              <div
+                class="tableCell selector"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <div
+                  class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+                  style="cursor: pointer;"
+                >
+                  <input
+                    class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+                    id="checkbox-MOCK-APPLICATION-1"
+                    title="Toggle Row Selected"
+                    type="checkbox"
+                    value=""
+                  />
+                  <label
+                    class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+                    for="checkbox-MOCK-APPLICATION-1"
+                  />
+                </div>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <a
+                  class="internalLink brand"
+                  href="#/applications/MOCK-APPLICATION-1"
+                >
+                  Maija Meikäläinen
+                </a>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+              >
+                Vaihto
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+              >
+                16.07.2020
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+              >
+                0
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+              >
+                Helsinki
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <span
+                  class="StatusLabel-module_statusLabel__3R2J2 status-label_hds-status-label__1L8YI StatusLabel-module_alert__2VR8r status-label_hds-status-label--alert__1ecsX"
+                >
+                  Odottaa käsittelyä
+                </span>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 300 0 auto; min-width: 0px; width: 300px;"
+              >
+                <a
+                  class="internalLink brand"
                   href="#/harbors/MOCK-HARBOR-1"
                   title="Pier Brosnan 7"
                 >

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
@@ -259,10 +259,10 @@ exports[`ApplicationListContainer renders normally 1`] = `
               >
                 <a
                   class="internalLink brand"
-                  href="#/harbors/MOCK-HARBOR-0"
-                  title="Testisatama G 7"
+                  href="#/harbors/MOCK-HARBOR-1"
+                  title="Pier Brosnan 7"
                 >
-                  Testisatama G 7
+                  Pier Brosnan 7
                 </a>
               </div>
               <div

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
@@ -259,6 +259,131 @@ exports[`ApplicationListContainer renders normally 1`] = `
               >
                 <a
                   class="internalLink brand"
+                  href="#/harbors/MOCK-HARBOR-0"
+                  title="Testisatama G 7"
+                >
+                  Testisatama G 7
+                </a>
+              </div>
+              <div
+                class="tableCell expander"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <div
+                  style="cursor: pointer;"
+                  title="Toggle Row Expanded"
+                >
+                  <svg
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv expandArrow"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="rowWrapper"
+          >
+            <div
+              role="row"
+              style="display: flex; flex: 1 0 auto; min-width: 0px;"
+            >
+              <div
+                class="tableCell selector"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <div
+                  class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+                  style="cursor: pointer;"
+                >
+                  <input
+                    class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+                    id="checkbox-MOCK-APPLICATION-1"
+                    title="Toggle Row Selected"
+                    type="checkbox"
+                    value=""
+                  />
+                  <label
+                    class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+                    for="checkbox-MOCK-APPLICATION-1"
+                  />
+                </div>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <a
+                  class="internalLink brand"
+                  href="#/applications/MOCK-APPLICATION-1"
+                >
+                  Maija Meikäläinen
+                </a>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+              >
+                Vaihto
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+              >
+                16.07.2020
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 75 0 auto; min-width: 0px; width: 75px;"
+              >
+                0
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 112.5 0 auto; min-width: 0px; width: 112.5px;"
+              >
+                Helsinki
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+              >
+                <span
+                  class="StatusLabel-module_statusLabel__3R2J2 status-label_hds-status-label__1L8YI StatusLabel-module_alert__2VR8r status-label_hds-status-label--alert__1ecsX"
+                >
+                  Odottaa käsittelyä
+                </span>
+              </div>
+              <div
+                class="tableCell"
+                role="cell"
+                style="box-sizing: border-box; flex: 300 0 auto; min-width: 0px; width: 300px;"
+              >
+                <a
+                  class="internalLink brand"
                   href="#/harbors/MOCK-HARBOR-1"
                   title="Pier Brosnan 7"
                 >

--- a/src/features/applicationList/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/utils.test.ts.snap
@@ -65,7 +65,7 @@ Array [
     "createdAt": "2020-07-16",
     "customerId": "MOCK-PROFILE",
     "firstName": "Maija",
-    "id": "MOCK-APPLICATION-0",
+    "id": "MOCK-APPLICATION-1",
     "isSwitch": true,
     "lastName": "Meikäläinen",
     "lease": Object {

--- a/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeListContainer.tsx
+++ b/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeListContainer.tsx
@@ -17,6 +17,7 @@ const UnmarkedWsNoticeListContainer = () => {
   const { loading, data } = useQuery<UNMARKED_WINTER_STORAGE_NOTICES, UNMARKED_WINTER_STORAGE_NOTICES_VARS>(
     UNMARKED_WINTER_STORAGE_NOTICES_QUERY,
     {
+      fetchPolicy: 'no-cache',
       variables: {
         first: pageSize,
         after: cursor,

--- a/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
+++ b/src/features/winterStorageApplicationList/WinterStorageApplicationList.tsx
@@ -46,7 +46,7 @@ const WinterStorageApplicationList = ({
           },
         },
       }) => (
-        <InternalLink to={`/applications/${id}`}>
+        <InternalLink to={`/winter-storage-applications/${id}`}>
           {firstName} {lastName}
         </InternalLink>
       ),

--- a/src/features/winterStorageApplicationList/WinterStorageApplicationListContainer.tsx
+++ b/src/features/winterStorageApplicationList/WinterStorageApplicationListContainer.tsx
@@ -17,6 +17,7 @@ const WinterStorageApplicationListContainer = () => {
   const { loading, data } = useQuery<WINTER_STORAGE_APPLICATIONS, WINTER_STORAGE_APPLICATIONS_VARS>(
     WINTER_STORAGE_APPLICATIONS_QUERY,
     {
+      fetchPolicy: 'no-cache',
       variables: {
         first: pageSize,
         after: cursor,


### PR DESCRIPTION
## Description :sparkles:
- Set fetch policy on application lists to `no-cache`
- Fix the link to a single WS application.

## Issues :bug:

### Closes :no_good_woman:
[VEN-943](url)https://helsinkisolutionoffice.atlassian.net/browse/VEN-943
### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
Updated relevant tests

### Manual testing :construction_worker_man:
- Go to one of the applications list page e.g. Berth Applications List
- Click on one of the applications to go to the single application view
- Go back to the applications list page
- The table displays all the applications
---
- Go to the WS applications
- Click on one of the applications
- It should go to the corresponding application