### PR TITLE
 VEN-814 | Add "STORAGE_ON_ICE" to additional services

### DIFF
--- a/src/common/select/Select.tsx
+++ b/src/common/select/Select.tsx
@@ -27,6 +27,7 @@ export type SelectProps<T extends OptionValue = string> = {
   options: Option<T>[];
   required?: boolean;
   value?: T;
+  visibleOptions?: number;
 };
 
 const Select = <T extends OptionValue = string>({
@@ -38,6 +39,7 @@ const Select = <T extends OptionValue = string>({
   options,
   required,
   value,
+  visibleOptions,
 }: SelectProps<T>) => {
   const selectedOption = options.find((option) => option.value === value);
 
@@ -66,6 +68,7 @@ const Select = <T extends OptionValue = string>({
       options={options}
       required={required}
       selectedOption={selectedOption}
+      visibleOptions={visibleOptions}
     />
   );
 };

--- a/src/features/pricing/additionalServicePricing/form/AdditionalServicesForm.tsx
+++ b/src/features/pricing/additionalServicePricing/form/AdditionalServicesForm.tsx
@@ -63,6 +63,7 @@ const OPTIONAL_SERVICES = [
   ProductServiceType.SUMMER_STORAGE_FOR_TRAILERS,
   ProductServiceType.PARKING_PERMIT,
   ProductServiceType.DINGHY_PLACE,
+  ProductServiceType.STORAGE_ON_ICE,
 ];
 
 const AdditionalServicesForm = ({ initialValues, onSubmit, onCancel }: AdditionalServicesFormProps) => {
@@ -98,6 +99,7 @@ const AdditionalServicesForm = ({ initialValues, onSubmit, onCancel }: Additiona
                 name="service"
                 label={t('pricing.additionalServices.service')}
                 disabled={initialValues?.service}
+                visibleOptions={4}
                 options={serviceOptions
                   .filter((option) => OPTIONAL_SERVICES.includes(option))
                   .map((option) => ({

--- a/src/features/pricing/additionalServicePricing/form/__tests__/__snapshots__/AdditionalServicesForm.test.tsx.snap
+++ b/src/features/pricing/additionalServicePricing/form/__tests__/__snapshots__/AdditionalServicesForm.test.tsx.snap
@@ -79,10 +79,10 @@ exports[`AdditionalServicesForm renders normally 1`] = `
       </div>
       <ul
         aria-labelledby="service-label"
-        class="Dropdown-module_menu__3xwA0"
+        class="Dropdown-module_menu__3xwA0 Dropdown-module_overflow__3tPgF"
         id="service-menu"
         role="listbox"
-        style="max-height: calc(var(--dropdown-height) * 5);"
+        style="max-height: calc(var(--dropdown-height) * 4);"
         tabindex="-1"
       />
     </div>


### PR DESCRIPTION
## Description :sparkles:
- Add `STORAGE_ON_ICE` to additional services

## Issues :bug:

### Closes :no_good_woman:
[VEN-814](https://helsinkisolutionoffice.atlassian.net/browse/VEN-814): Pricing page: support "Add New" additional services

### Related :handshake:
[VEN-933](https://helsinkisolutionoffice.atlassian.net/browse/VEN-933): Backend: Add missing product services

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to the pricing page
- On the "Lisäpalvelut" table, click on "Lisää uusi" button
- Fill in the "Lisää uusi" modal and submit
- The services should include "Jäissä säilytys" option in the dropdown

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
