### PR TITLE
VEN-967 | Show success notification when assigning berth

### DIFF
--- a/src/common/toast/hdsToast.tsx
+++ b/src/common/toast/hdsToast.tsx
@@ -10,6 +10,7 @@ import { HDSToastContainerId } from './HDSToastContainer';
 
 interface HDSToastArgs {
   autoDismiss?: boolean;
+  autoDismissTime?: number;
   type: NotificationProps['type'];
   labelText: string;
   text: string;
@@ -24,17 +25,25 @@ interface NotificationWrapperProps extends HDSToastArgs {
 
 const AUTO_DISMISS_TIME = 3000;
 
-const NotificationWrapper = ({ autoDismiss, type, labelText, text, toastId, translated }: NotificationWrapperProps) => {
+const NotificationWrapper = ({
+  autoDismiss,
+  autoDismissTime = AUTO_DISMISS_TIME,
+  type,
+  labelText,
+  text,
+  toastId,
+  translated,
+}: NotificationWrapperProps) => {
   const { t } = useTranslation();
 
   useEffect(() => {
     if (autoDismiss) {
       const timer = setTimeout(() => {
         toast.dismiss(toastId);
-      }, AUTO_DISMISS_TIME);
+      }, autoDismissTime);
       return () => clearTimeout(timer);
     }
-  }, [autoDismiss, toastId]);
+  }, [autoDismiss, autoDismissTime, toastId]);
 
   return (
     <Notification
@@ -49,7 +58,15 @@ const NotificationWrapper = ({ autoDismiss, type, labelText, text, toastId, tran
   );
 };
 
-const hdsToast = ({ autoDismiss = true, type, labelText, text, toastId, translated = false }: HDSToastArgs) => {
+const hdsToast = ({
+  autoDismiss = true,
+  autoDismissTime = AUTO_DISMISS_TIME,
+  type,
+  labelText,
+  text,
+  toastId,
+  translated = false,
+}: HDSToastArgs) => {
   const id = toastId ?? uuidv4();
   return toast(
     <NotificationWrapper
@@ -59,6 +76,7 @@ const hdsToast = ({ autoDismiss = true, type, labelText, text, toastId, translat
       text={text}
       toastId={id}
       translated={translated}
+      autoDismissTime={autoDismissTime}
     />,
     {
       toastId: id,

--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -22,7 +22,7 @@ interface OfferProps {
   applicationStatus: ApplicationStatus;
   applicationType: string;
   boat: Boat | null;
-  handleClickSelect: (berthId: string) => void;
+  handleClickSelect: (berth: BerthData) => void;
   handleReturn: () => void;
   harbor: HarborCardProps | null;
   isSubmitting: boolean;
@@ -49,7 +49,7 @@ const Offer = ({
   const columns: ColumnType[] = [
     {
       Cell: ({ row }) => (
-        <Button onClick={() => handleClickSelect(row.original.id)} disabled={isSubmitting}>
+        <Button onClick={() => handleClickSelect(row.original)} disabled={isSubmitting}>
           {t('offer.tableCells.select')}
         </Button>
       ),

--- a/src/features/offer/OfferContainer.tsx
+++ b/src/features/offer/OfferContainer.tsx
@@ -14,6 +14,8 @@ import { formatDate } from '../../common/utils/format';
 import { CREATE_LEASE_MUTATION } from './mutations';
 import { CREATE_LEASE, CREATE_LEASEVariables as CREATE_LEASE_VARS } from './__generated__/CREATE_LEASE';
 import { BERTH_APPLICATIONS_QUERY } from '../applicationList/queries';
+import hdsToast from '../../common/toast/hdsToast';
+import { BerthData } from './types';
 
 function useRouterQuery() {
   return new URLSearchParams(useLocation().search);
@@ -64,15 +66,28 @@ const OfferContainer = () => {
   const harbor = getHarbor(data);
   const boat = getBoat(data);
 
-  const handleClickSelect = (berthId: string) => {
+  const handleClickSelect = (berth: BerthData) => {
     createBerthLease({
       variables: {
         input: {
           applicationId: applicationId || '',
-          berthId,
+          berthId: berth.id,
         },
       },
-    }).then(() => history.push('/applications'));
+    }).then(() => {
+      history.push('/applications');
+      hdsToast({
+        type: 'success',
+        autoDismiss: false,
+        labelText: t('offer.notifications.berthLeaseCreated.label'),
+        text: t('offer.notifications.berthLeaseCreated.description', {
+          name: `${data.berthApplication?.customer?.firstName} ${data.berthApplication?.customer?.lastName}`,
+          harbor: berth.harbor,
+          pier: berth.pier,
+          berth: berth.berth,
+        }),
+      });
+    });
   };
 
   return (

--- a/src/features/offer/OfferContainer.tsx
+++ b/src/features/offer/OfferContainer.tsx
@@ -78,7 +78,8 @@ const OfferContainer = () => {
       history.push('/applications');
       hdsToast({
         type: 'success',
-        autoDismiss: false,
+        autoDismiss: true,
+        autoDismissTime: 5000,
         labelText: t('offer.notifications.berthLeaseCreated.label'),
         text: t('offer.notifications.berthLeaseCreated.description', {
           name: `${data.berthApplication?.customer?.firstName} ${data.berthApplication?.customer?.lastName}`,

--- a/src/features/offer/__fixtures__/mockData.ts
+++ b/src/features/offer/__fixtures__/mockData.ts
@@ -11,6 +11,8 @@ export const OfferQueryData: OFFER = {
     customer: {
       __typename: 'ProfileNode',
       id: '1',
+      firstName: 'test',
+      lastName: 'test',
     },
     boatType: 'rowboat',
     boatRegistrationNumber: '1234',

--- a/src/features/offer/__generated__/OFFER.ts
+++ b/src/features/offer/__generated__/OFFER.ts
@@ -17,6 +17,8 @@ export interface OFFER_berthApplication_berthSwitch {
 export interface OFFER_berthApplication_customer {
   __typename: "ProfileNode";
   id: string;
+  firstName: string;
+  lastName: string;
 }
 
 export interface OFFER_berthApplication {

--- a/src/features/offer/queries.ts
+++ b/src/features/offer/queries.ts
@@ -11,6 +11,8 @@ export const OFFER_QUERY = gql`
       }
       customer {
         id
+        firstName
+        lastName
       }
       boatType
       boatRegistrationNumber

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -457,6 +457,12 @@
       "boatLength": "Veneen pituus",
       "boatDraught": "Veneen syväys",
       "boatWeight": "Veneen paino"
+    },
+    "notifications": {
+      "berthLeaseCreated": {
+        "label": "Hakemus käsitelty",
+        "description": "{{harbor}} laituri {{pier}} venepaikka {{berth}} myönnetty asiakkaalle {{name}}."
+      }
     }
   },
   "customerList": {


### PR DESCRIPTION
## Description :sparkles:

Adds a success toast when assigning berths to customers.

### Closes :no_good_woman:

[VEN-967](https://helsinkisolutionoffice.atlassian.net/browse/VEN-967)

## Testing :alembic:

### Manual testing :construction_worker_man:

- Open applications list
- Select an unhandled application
- Go through the application handling flow, assign a suitable berth
- After assigning, the user should be redirected back to the applications list and a success toast with berth and customer information should be shown