### PR TITLE
Add refetching to pricing page mutations

### DIFF
--- a/src/features/pricing/PricingContainer.tsx
+++ b/src/features/pricing/PricingContainer.tsx
@@ -26,10 +26,12 @@ const PricingContainer = () => {
   const [editingAdditionalServiceId, setEditingAdditionalServiceId] = useState<string>();
   const [isAddingAdditionalService, setIsAddingAdditionalService] = useState<boolean>(false);
   const [addAdditionalService] = useMutation<ADD_ADDITIONAL_SERVICE, ADD_ADDITIONAL_SERVICE_VARS>(
-    ADD_ADDITIONAL_SERVICE_MUTATION
+    ADD_ADDITIONAL_SERVICE_MUTATION,
+    { refetchQueries: [{ query: PRICING_QUERY }] }
   );
   const [updateAdditionalServicePrice] = useMutation<UPDATE_ADDITIONAL_SERVICE_PRICE, UPDATE_HARBOR_SERVICE_PRICE_VARS>(
-    UPDATE_ADDITIONAL_SERVICE_PRICE_MUTATION
+    UPDATE_ADDITIONAL_SERVICE_PRICE_MUTATION,
+    { refetchQueries: [{ query: PRICING_QUERY }] }
   );
   const isAdditionalServiceModalOpen = !!editingAdditionalServiceId || isAddingAdditionalService;
   const handleCloseAdditionalServiceModal = () => {


### PR DESCRIPTION
## Description :sparkles:

The pricing page should refresh contents without forcing the user to reload the page after changes. Added a refetch to the mutations.

### Related :handshake:

[VEN-814](https://helsinkisolutionoffice.atlassian.net/browse/VEN-814) discussion.
