### PR TITLE
VEN-942 | Persist current page after refresh

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,8 @@
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:testcafe/recommended"
   ],
   "rules": {
     "@typescript-eslint/brace-style": [

--- a/browser-tests/customerListView.ts
+++ b/browser-tests/customerListView.ts
@@ -27,6 +27,15 @@ test('Selection of customers', async (t) => {
   await t.click(customers.customerList.deselectAll).expect(customers.customerList.selectedCount.exists).notOk();
 });
 
+test('Pagination', async (t) => {
+  await login(t);
+
+  // Stay on the same page after reloading the browser
+  await t.click(navigation.customers).click(customers.customerList.paginationNextButton);
+  await t.eval(() => window.location.reload());
+  await t.expect(customers.customerList.selectedPage.textContent).contains('2');
+});
+
 test('Editing customers', async (t) => {
   await login(t);
 

--- a/browser-tests/pages/customers.ts
+++ b/browser-tests/pages/customers.ts
@@ -10,6 +10,7 @@ export const customers = {
     selectedCount: Selector('div[class^="customerListTableTools_tableToolsLeft"] span[class^="text_gray"]'),
     deselectAll: Selector('div[class^="customerListTableTools_tableToolsLeft"] span[class^="text_brand"]'),
     paginationNextButton: Selector('ul[class^="pagination"] li[class^="pagination_nextBtn"] a'),
+    selectedPage: Selector('ul[class^="pagination"] li[class^="selected"] a'),
   },
   customerView: {
     firstDataLabel: Selector(

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "enzyme-to-json": "^3.4.4",
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.1",
+    "eslint-plugin-testcafe": "^0.2.1",
     "full-icu": "^1.3.0",
     "history": "^4.10.1",
     "husky": "4.2.5",

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -265,14 +265,14 @@ const Table = <D extends { id: string }>({
 
   const initialSortByState = initialState?.sortBy;
   const currentSortByState = state.sortBy;
-  const didSortByChanged = equal(initialSortByState, currentSortByState);
+  const didSortByChanged = !equal(initialSortByState, currentSortByState);
 
   useEffect(() => {
-    onSortedColChange?.(currentSortByState[0]);
+    if (didSortByChanged) onSortedColChange?.(currentSortByState[0]);
   }, [currentSortByState, onSortedColChange, didSortByChanged]);
 
   useEffect(() => {
-    onSortedColsChange?.(currentSortByState);
+    if (didSortByChanged) onSortedColsChange?.(currentSortByState);
   }, [currentSortByState, onSortedColsChange, didSortByChanged]);
 
   useEffect(() => {

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -24,6 +24,7 @@ import {
   actions,
 } from 'react-table';
 import { IconAngleDown, IconArrowLeft } from 'hds-react';
+import equal from 'fast-deep-equal';
 
 import styles from './table.module.scss';
 import Checkbox from '../checkbox/Checkbox';
@@ -262,19 +263,17 @@ const Table = <D extends { id: string }>({
     gotoPage(0);
   }, [gotoPage, state.sortBy, state.filters, state.globalFilter]);
 
-  const initialSortByState = initialState?.sortBy?.[0];
-  const currentSortByState = state.sortBy[0];
+  const initialSortByState = initialState?.sortBy;
+  const currentSortByState = state.sortBy;
+  const didSortByChanged = equal(initialSortByState, currentSortByState);
 
   useEffect(() => {
-    if (initialSortByState?.id === currentSortByState?.id && initialSortByState?.desc === currentSortByState?.desc)
-      return;
-
-    onSortedColChange?.(currentSortByState);
-  }, [currentSortByState, onSortedColChange, initialSortByState]);
+    onSortedColChange?.(currentSortByState[0]);
+  }, [currentSortByState, onSortedColChange, didSortByChanged]);
 
   useEffect(() => {
-    onSortedColsChange?.(state.sortBy);
-  }, [state.sortBy, onSortedColsChange]);
+    onSortedColsChange?.(currentSortByState);
+  }, [currentSortByState, onSortedColsChange, didSortByChanged]);
 
   useEffect(() => {
     const updateData = (newData: D[]) => {

--- a/src/common/utils/useBackendSorting.ts
+++ b/src/common/utils/useBackendSorting.ts
@@ -17,7 +17,7 @@ export const useRecoilBackendSorting = <T>(atom: RecoilState<SortingRule<T>[]>, 
   const prevSortBy = usePrevious(sortBy);
 
   useEffect(() => {
-    if (!equal(prevSortBy, sortBy)) {
+    if (prevSortBy && !equal(prevSortBy, sortBy)) {
       onSortByChange?.();
     }
   }, [prevSortBy, sortBy, onSortByChange]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8373,6 +8373,11 @@ eslint-plugin-react@7.19.0:
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
 
+eslint-plugin-testcafe@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-testcafe/-/eslint-plugin-testcafe-0.2.1.tgz#4089f646dadb69b1376a01d7e608184907e6036b"
+  integrity sha1-QIn2RtrbabE3agHX5ggYSQfmA2s=
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Description :sparkles:
- Fix the issue that causes the application to go back to the first page after reloading views with backend-paginated tables
- Fix Eslint warnings for e2e tests

## Issues :bug:

### Closes :no_good_woman:
[VEN-942](https://helsinkisolutionoffice.atlassian.net/browse/VEN-942): Refreshing paginated tables go back to the first page

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
https://github.com/City-of-Helsinki/berth-reservations-admin/blob/5528d381c244ee468838578d79133973716ae227/browser-tests/customerListView.ts#L30

### Manual testing :construction_worker_man:
- Go to one of the backend paginated tables e.g. Applications List
- Go to the second page
- Refresh the page
- The table should stay and render the second page as expected

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
