### PR TITLE
VEN-984 | Add confirmation toast after changing the sticker number

### DIFF
--- a/src/common/confirmationModal/ConfirmationModal.tsx
+++ b/src/common/confirmationModal/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 import { ButtonProps } from 'hds-react';
 
 import Modal from '../modal/Modal';
@@ -32,7 +33,7 @@ const ConfirmationModal = ({
   className,
 }: ConfirmationModalProps) => {
   return (
-    <Modal isOpen={isOpen} toggleModal={onCancel} className={className}>
+    <Modal isOpen={isOpen} toggleModal={onCancel} className={classNames(styles.confirmationModal, className)}>
       <Text as="h4" color="brand" className={styles.uppercase}>
         {title}
       </Text>

--- a/src/common/confirmationModal/__tests__/__snapshots__/ConfirmationModal.test.tsx.snap
+++ b/src/common/confirmationModal/__tests__/__snapshots__/ConfirmationModal.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ConfirmationModal renders correctly 1`] = `
   class="ReactModal__Overlay ReactModal__Overlay--after-open overlay"
 >
   <div
-    class="ReactModal__Content ReactModal__Content--after-open modal"
+    class="ReactModal__Content ReactModal__Content--after-open modal confirmationModal"
     role="dialog"
     tabindex="-1"
   >

--- a/src/common/confirmationModal/confirmationModal.module.scss
+++ b/src/common/confirmationModal/confirmationModal.module.scss
@@ -1,21 +1,26 @@
 @import 'spacings';
+@import 'containers';
 
-.uppercase {
-  text-transform: uppercase;
-}
+.confirmationModal {
+  max-width: container(s);
 
-.infoTexts {
-  margin: units(2) 0;
-  display: flex;
-  flex-direction: column;
-}
+  .uppercase {
+    text-transform: uppercase;
+  }
 
-.warningText {
-  @extend .uppercase;
-  margin-top: units(1);
-}
+  .infoTexts {
+    margin: units(2) 0;
+    display: flex;
+    flex-direction: column;
+  }
 
-.actionButtons {
-  display: flex;
-  justify-content: space-between;
+  .warningText {
+    @extend .uppercase;
+    margin-top: units(1);
+  }
+
+  .actionButtons {
+    display: flex;
+    justify-content: space-between;
+  }
 }

--- a/src/common/deleteButton/__tests__/__snapshots__/DeleteButton.test.tsx.snap
+++ b/src/common/deleteButton/__tests__/__snapshots__/DeleteButton.test.tsx.snap
@@ -16,7 +16,7 @@ Array [
     class="ReactModal__Overlay ReactModal__Overlay--after-open overlay"
   >
     <div
-      class="ReactModal__Content ReactModal__Content--after-open modal"
+      class="ReactModal__Content ReactModal__Content--after-open modal confirmationModal"
       role="dialog"
       tabindex="-1"
     >

--- a/src/features/unmarkedWsNoticeDetails/fragments/stickerDetails/StickerDetailsContainer.tsx
+++ b/src/features/unmarkedWsNoticeDetails/fragments/stickerDetails/StickerDetailsContainer.tsx
@@ -13,6 +13,7 @@ import {
   ASSIGN_NEW_STICKER_NUMBERVariables as ASSIGN_NEW_STICKER_NUMBER_VARS,
 } from './__generated__/ASSIGN_NEW_STICKER_NUMBER';
 import { LeaseStatus } from '../../../../@types/__generated__/globalTypes';
+import hdsToast from '../../../../common/toast/hdsToast';
 
 interface StickerDetailsContainerProps {
   leaseId: string;
@@ -41,7 +42,15 @@ const StickerDetailsContainer = ({ leaseId, leaseStatus }: StickerDetailsContain
 
   const handleAssignNewStickerNumber =
     leaseStatus === LeaseStatus.PAID
-      ? () => assignNewStickerNumber({ variables: { input: { leaseId: leaseId } } })
+      ? () =>
+          assignNewStickerNumber({ variables: { input: { leaseId: leaseId } } }).then(() => {
+            hdsToast({
+              translated: true,
+              labelText: 'toast.stickerNumChanged.label',
+              text: 'toast.stickerNumChanged.description',
+              type: 'success',
+            });
+          })
       : undefined;
 
   return (

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -661,6 +661,10 @@
     "invoiceSent": {
       "label": "Tarjous on lähetetty asiakkaalle",
       "description": "Hakemuksen tila on päivitetty ja se odottaa asiakkaan toimenpiteitä"
+    },
+    "stickerNumChanged": {
+      "label": "Muutokset tallennettu",
+      "description": "Tarranumeron vaihto onnistui"
     }
   },
   "winterStorageAreaList": {
@@ -723,7 +727,7 @@
         "assign": {
           "buttonText": "Vaihda numero",
           "modalTitle": "VAIHDA NUMERO",
-          "infoText": "Oletko varma että haluat vaihtaa tarranumeron tälle hakemukselle?",
+          "infoText": "Järjestelmä valitsee seuraavan vapaana olevan tarranumeron.\nOletko varma että haluat vaihtaa tarranumeron tälle hakemukselle?",
           "confirm": "Vaihda"
         }
       }


### PR DESCRIPTION
## Description :sparkles:
- Change the text on the changing sticker number dialog
- Render `hds-toast` after changing the sticker number successfully

## Issues :bug:
[VEN-984](https://helsinkisolutionoffice.atlassian.net/browse/VEN-984): Add confirmation toast to unmarked WS sticker number change

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to [Nostojärjestysilmoitukset page](https://venepaikka-admin.test.kuva.hel.ninja/unmarked-ws-notices)
- Click on `Vaihda numero` button (in the expanded row of an application that has a sticker or on the single application page)
- You would get a confirmation toast if the number changes successfully

Also, the text on the dialog is changed to: 
>Järjestelmä valitsee seuraavan vapaana olevan tarranumeron. Oletko varma että haluat vaihtaa tarranumeron tälle hakemukselle?

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/99076297-91ce5100-25c3-11eb-9a74-65b21b58c769.png)
![image](https://user-images.githubusercontent.com/23040926/99076317-9a268c00-25c3-11eb-9efb-890d60567031.png)

## Additional notes :spiral_notepad:
