### PR TITLE
VEN-989 | Fix venepaikat column in customer list table

### DIFF
--- a/src/common/wrappingTableCell/WrappingTableCell.tsx
+++ b/src/common/wrappingTableCell/WrappingTableCell.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import styles from './wrappingTableCell.module.scss';
+
+export interface WrappingTableCellProps {
+  children: React.ReactNode;
+}
+
+const WrappingTableCell = ({ children }: WrappingTableCellProps) => (
+  <p className={styles.wrappingTableCell}>{children}</p>
+);
+
+export default WrappingTableCell;

--- a/src/common/wrappingTableCell/wrappingTableCell.module.scss
+++ b/src/common/wrappingTableCell/wrappingTableCell.module.scss
@@ -1,0 +1,5 @@
+.wrappingTableCell {
+  margin: auto;
+  white-space: normal;
+  width: 100%;
+}

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { SortingRule } from 'react-table';
+import { Cell, SortingRule } from 'react-table';
 
 import PageTitle from '../../common/pageTitle/PageTitle';
 import Table, { Column, COLUMN_WIDTH } from '../../common/table/Table';
@@ -13,6 +13,7 @@ import CustomerDetails from './customerDetails/CustomerDetails';
 import { getSelectedRowIds } from '../../common/utils/getSelectedRowIds';
 import PageContent from '../../common/pageContent/PageContent';
 import { getCustomerGroupKey } from '../../common/utils/translations';
+import WrappingTableCell from '../../common/wrappingTableCell/WrappingTableCell';
 
 export enum SearchBy {
   FIRST_NAME = 'firstName',
@@ -63,14 +64,16 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColsChang
       minWidth: COLUMN_WIDTH.S,
     },
     {
+      Cell: ({ cell }: { cell: Cell<CustomerData, string> }) => <WrappingTableCell>{cell.value}</WrappingTableCell>,
       Header: t('customerList.tableHeaders.berths') || '',
       id: 'berths',
-      accessor: ({ berthLeases }) => berthLeases.map((berthLease) => berthLease.title).join(', '),
+      accessor: ({ berthLeases }): string => berthLeases.map((berthLease) => berthLease.title).join(', '),
       disableSortBy: true,
       width: COLUMN_WIDTH.L,
       minWidth: COLUMN_WIDTH.L,
     },
     {
+      Cell: ({ cell }: { cell: Cell<CustomerData, string> }) => <WrappingTableCell>{cell.value}</WrappingTableCell>,
       Header: t('customerList.tableHeaders.applications') || '',
       id: 'applications',
       accessor: ({ applications }) =>

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -67,7 +67,11 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColsChang
       Cell: ({ cell }: { cell: Cell<CustomerData, string> }) => <WrappingTableCell>{cell.value}</WrappingTableCell>,
       Header: t('customerList.tableHeaders.berths') || '',
       id: 'berths',
-      accessor: ({ berthLeases }): string => berthLeases.map((berthLease) => berthLease.title).join(', '),
+      accessor: ({ berthLeases }): string =>
+        berthLeases
+          .filter((berthLease) => berthLease.isActive)
+          .map((berthLease) => berthLease.title)
+          .join(', '),
       disableSortBy: true,
       width: COLUMN_WIDTH.L,
       minWidth: COLUMN_WIDTH.L,

--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -123,6 +123,7 @@ export interface CUSTOMERS_profiles_edges_node_berthLeases_edges_node_berth {
 export interface CUSTOMERS_profiles_edges_node_berthLeases_edges_node {
   __typename: "BerthLeaseNode";
   id: string;
+  isActive: boolean;
   berth: CUSTOMERS_profiles_edges_node_berthLeases_edges_node_berth;
 }
 

--- a/src/features/customerList/__mocks__/customersMockResponse.ts
+++ b/src/features/customerList/__mocks__/customersMockResponse.ts
@@ -69,6 +69,7 @@ export const customersResponse: CUSTOMERS = {
               {
                 node: {
                   id: 'QmVydGhMZWFzZU5vZGU6YThhNGNkOGEtMDcxYy00ZGU3LThkMGYtYTE5NmIyMDVmMWZi',
+                  isActive: true,
                   berth: {
                     number: '37',
                     pier: {
@@ -91,6 +92,7 @@ export const customersResponse: CUSTOMERS = {
               {
                 node: {
                   id: 'QmVydGhMZWFzZU5vZGU6MWE1ZTRkOGItNDQ2Yy00NTA1LThiMDgtNDc4NTkxYTFmZTQ3',
+                  isActive: true,
                   berth: {
                     number: '6',
                     pier: {

--- a/src/features/customerList/customerDetails/CustomerDetails.tsx
+++ b/src/features/customerList/customerDetails/CustomerDetails.tsx
@@ -49,6 +49,11 @@ const CustomerDetails = ({
   const { t, i18n } = useTranslation();
   const customerGroupKey = getCustomerGroupKey(customerGroup);
 
+  const activeBerthList = berths.reduce<React.ReactNode[]>((acc, berth) => {
+    if (berth.isActive) return acc.concat(<div key={berth.id}>{berth.title}</div>);
+    return acc;
+  }, []);
+
   return (
     <div>
       <Grid colsCount={4}>
@@ -69,9 +74,8 @@ const CustomerDetails = ({
         </div>
         <div>
           <Section title={t('common.terminology.berths').toUpperCase()}>
-            {berths.map((berth) => (
-              <div key={berth.id}>{berth.title}</div>
-            ))}
+            {activeBerthList}
+            {activeBerthList.length < berths.length && <hr />}
           </Section>
           <Section title={t('common.terminology.winterStoragePlaces').toUpperCase()}>
             {winterStoragePlaces.map((place) => (

--- a/src/features/customerList/customerDetails/__mocks__/mockData.ts
+++ b/src/features/customerList/customerDetails/__mocks__/mockData.ts
@@ -28,6 +28,6 @@ export const customerListApplications: CustomerListApplication[] = [{ id: '123',
 export const customerListInvoices: CustomerListInvoice[] = [{ id: '123', date: '2020-01-21' }];
 
 export const customerListBerthLeases: CustomerListBerthLeases[] = [
-  { id: '123', title: 'Pursilahdenranta B31' },
-  { id: '321', title: 'Strömsinlahdenranta B31' },
+  { id: '123', isActive: true, title: 'Pursilahdenranta B31' },
+  { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
 ];

--- a/src/features/customerList/customerDetails/__tests__/CustomerDetails.test.tsx
+++ b/src/features/customerList/customerDetails/__tests__/CustomerDetails.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
-import CustomerDetails from '../CustomerDetails';
+import CustomerDetails, { CustomerDetailsProps } from '../CustomerDetails';
 import {
   customerListApplications,
   customerListBerthLeases,
@@ -10,30 +10,49 @@ import {
   customerListEntry,
   customerListWinterStoragePlaces,
 } from '../__mocks__/mockData';
+import { CustomerListBerthLeases } from '../../types';
+
+const mockProps = {
+  ...customerListEntry,
+  berths: customerListBerthLeases,
+  winterStoragePlaces: customerListWinterStoragePlaces,
+  boats: customerListBoats,
+  applications: customerListApplications,
+  invoices: customerListInvoices,
+};
 
 describe('CustomerDetails', () => {
-  const getWrapper = () =>
-    mount(
-      <CustomerDetails
-        name={customerListEntry.name}
-        address={customerListEntry.address}
-        postalCode={customerListEntry.postalCode}
-        city={customerListEntry.city}
-        phone={customerListEntry.phone}
-        email={customerListEntry.email}
-        berths={customerListBerthLeases}
-        winterStoragePlaces={customerListWinterStoragePlaces}
-        boats={customerListBoats}
-        applications={customerListApplications}
-        invoices={customerListInvoices}
-        comment={customerListEntry.comment}
-        customerGroup={customerListEntry.customerGroup}
-      />
-    );
+  const getWrapper = (props?: Partial<CustomerDetailsProps>) => mount(<CustomerDetails {...mockProps} {...props} />);
 
   it('renders normally', () => {
     const wrapper = getWrapper();
 
     expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('renders a horizontal rule if there are inactive berth leases', () => {
+    const berths: CustomerListBerthLeases[] = [
+      { id: '123', isActive: false, title: 'Pursilahdenranta B31' },
+      { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
+    ];
+
+    const wrapper = getWrapper({
+      berths,
+    });
+
+    expect(wrapper.find('hr').exists()).toEqual(true);
+  });
+
+  it('renders no horizontal rule if there are no inactive berth leases', () => {
+    const berths: CustomerListBerthLeases[] = [
+      { id: '123', isActive: true, title: 'Pursilahdenranta B31' },
+      { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
+    ];
+
+    const wrapper = getWrapper({
+      berths,
+    });
+
+    expect(wrapper.find('hr').exists()).toEqual(false);
   });
 });

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -84,6 +84,7 @@ export const CUSTOMERS_QUERY = gql`
             edges {
               node {
                 id
+                isActive
                 berth {
                   number
                   pier {

--- a/src/features/customerList/types.ts
+++ b/src/features/customerList/types.ts
@@ -29,6 +29,7 @@ export interface CustomerData {
 
 export interface CustomerListBerthLeases {
   id: string;
+  isActive: boolean;
   title: string;
 }
 

--- a/src/features/customerList/utils.ts
+++ b/src/features/customerList/utils.ts
@@ -1,4 +1,9 @@
-import { CUSTOMERS, CUSTOMERS_profiles_edges_node as ProfileNode } from './__generated__/CUSTOMERS';
+import {
+  CUSTOMERS,
+  CUSTOMERS_profiles_edges_node as ProfileNode,
+  CUSTOMERS_profiles_edges_node_berthLeases_edges as BerthLeaseEdge,
+  CUSTOMERS_profiles_edges_node_berthLeases_edges_node as BerthLeaseNode,
+} from './__generated__/CUSTOMERS';
 import { CustomerData, CustomerListApplication, CustomerListBerthLeases, CustomerListBoat } from './types';
 
 const getBoats = (profile: ProfileNode): CustomerListBoat[] | undefined => {
@@ -25,18 +30,19 @@ const getApplications = (profile: ProfileNode): CustomerListApplication[] | unde
 
 function getBerthLeases(profile: ProfileNode): CustomerListBerthLeases[] | undefined {
   return profile.berthLeases?.edges
-    .filter((edge) => edge && edge.node)
-    .map((edge) => {
-      const id = edge?.node?.id ?? '';
+    .filter((edge: BerthLeaseEdge | null): edge is BerthLeaseEdge & { node: BerthLeaseNode } => !!(edge && edge.node))
+    .map(({ node }) => {
+      const { id, isActive } = node;
 
-      const berth = edge?.node?.berth;
-      const berthNumber = berth?.number ?? '';
-      const harborName = berth?.pier.properties?.harbor?.properties?.name ?? '';
-      const pierIdentifier = berth?.pier?.properties?.identifier ?? '';
+      const berth = node.berth;
+      const berthNumber = berth.number;
+      const harborName = berth.pier.properties?.harbor?.properties?.name ?? '';
+      const pierIdentifier = berth.pier?.properties?.identifier ?? '';
       const title = `${harborName} ${pierIdentifier} ${berthNumber}`;
 
       return {
         id,
+        isActive,
         title,
       };
     });


### PR DESCRIPTION
## Description :sparkles:

1. Make text break in lines when it’s longer than the column.
2. Remove old berths info from customer table rows. Show ONLY current berth.
3. Accordion open. Add a horizontal line under current berth if there is previous berths

## Issues :bug:

### Closes :no_good_woman:

* [VEN-989](https://helsinkisolutionoffice.atlassian.net/browse/VEN-989): Fix venepaikat column in customer list table

## Testing :alembic:

### Automated tests :gear:️

* Added tests for new horizontal rule feature

### Manual testing :construction_worker_man:

* Customer list column contents for berths and applications should now wrap
* Customer list should only show active berths
* Expanded row in customer list should now show a horizontal rule if there are previous berths
