### PR TITLE
VEN-839, VEN-968 | Improve lease and offer tables

### DIFF
--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -138,6 +138,7 @@ const Offer = ({
             handleReturn={handleReturn}
           />
         )}
+        renderEmptyStateRow={() => <p>{t('offer.berthDetails.noSuitableBerths')}</p>}
       />
     </PageContent>
   );

--- a/src/features/winterStorageAreaView/utils.ts
+++ b/src/features/winterStorageAreaView/utils.ts
@@ -209,7 +209,7 @@ export const getMarkedWinterStorage = (
 export const getUnmarkedWinterStorage = (
   data: INDIVIDUAL_WINTER_STORAGE_AREA | undefined
 ): UnmarkedWinterStorage | undefined => {
-  const leases = getUnmarkedWinterStorageLeases(data);
+  const leases = getUnmarkedWinterStorageLeases(data).filter((lease) => lease.isActive);
 
   if (leases.length === 0) return undefined;
   return {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -438,6 +438,7 @@
     },
     "berthDetails": {
       "previousLeases": "Edelliset vuokralaiset",
+      "noSuitableBerths": "Ei sopivaa venepaikkaa",
       "emptyName": "Ei nimeä"
     },
     "invoicing": {


### PR DESCRIPTION
## Description :sparkles:

* Filter inactive unmarked winter storage leases
* Add message for empty berth list

## Issues :bug:

### Closes :no_good_woman:

* [VEN-839](https://helsinkisolutionoffice.atlassian.net/browse/VEN-839): FE - Winter storage list page: filter invalid (refused) leases
* [VEN-968](https://helsinkisolutionoffice.atlassian.net/browse/VEN-968): FE - Message for empty berth list

## Testing :alembic:

### Manual testing :construction_worker_man:

* Inactive unmarked winter storage leases should no longer be visible in winter storage view
* Berth offer page should show a message in the empty table if there are no suitable berths
