### PR TITLE
VEN-1031 | Fix refreshing of table data when sticker number changes

### DIFF
--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -242,6 +242,7 @@ const Table = <D extends { id: string }>({
       autoResetSortBy: !skipPageResetRef.current,
       autoResetSelectedRows: !skipPageResetRef.current,
       autoResetFilters: !skipPageResetRef.current,
+      autoResetExpanded: !skipPageResetRef.current,
       getRowId: useCallback((row: D, relativeIndex: number) => {
         return row.id ? row.id : `${relativeIndex}`;
       }, []),

--- a/src/features/unmarkedWsNoticeDetails/UnmarkedWsNoticeDetails.tsx
+++ b/src/features/unmarkedWsNoticeDetails/UnmarkedWsNoticeDetails.tsx
@@ -39,6 +39,7 @@ export interface UnmarkedWsNoticeDetailsProps {
   status: ApplicationStatus;
   leaseStatus?: LeaseStatus;
   summaryInformation?: SummaryInformation;
+  onStickerChange?(): void;
 }
 
 const UnmarkedWsNoticeDetails = ({
@@ -57,6 +58,7 @@ const UnmarkedWsNoticeDetails = ({
   summaryInformation,
   leaseStatus,
   leaseId,
+  onStickerChange,
 }: UnmarkedWsNoticeDetailsProps) => {
   return (
     <>
@@ -77,7 +79,9 @@ const UnmarkedWsNoticeDetails = ({
         />
         <SummaryDetails summaryInformation={summaryInformation} />
       </div>
-      {leaseId && leaseStatus && <StickerDetails leaseId={leaseId} leaseStatus={leaseStatus} />}
+      {leaseId && leaseStatus && (
+        <StickerDetails leaseId={leaseId} leaseStatus={leaseStatus} onStickerChange={onStickerChange} />
+      )}
     </>
   );
 };

--- a/src/features/unmarkedWsNoticeDetails/__tests__/UnmarkedWsNoticeDetails.test.tsx
+++ b/src/features/unmarkedWsNoticeDetails/__tests__/UnmarkedWsNoticeDetails.test.tsx
@@ -14,6 +14,7 @@ const minimumProps: UnmarkedWsNoticeDetailsProps = {
   createdAt: '2020-09-10T11:01:55Z',
   id: '1',
   status: ApplicationStatus.PENDING,
+  onStickerChange: jest.fn(),
 };
 
 const applicant = {

--- a/src/features/unmarkedWsNoticeDetails/fragments/stickerDetails/StickerDetailsContainer.tsx
+++ b/src/features/unmarkedWsNoticeDetails/fragments/stickerDetails/StickerDetailsContainer.tsx
@@ -18,9 +18,10 @@ import hdsToast from '../../../../common/toast/hdsToast';
 interface StickerDetailsContainerProps {
   leaseId: string;
   leaseStatus: LeaseStatus;
+  onStickerChange?(): void;
 }
 
-const StickerDetailsContainer = ({ leaseId, leaseStatus }: StickerDetailsContainerProps) => {
+const StickerDetailsContainer = ({ leaseId, leaseStatus, onStickerChange }: StickerDetailsContainerProps) => {
   const { data, loading } = useQuery<UNMARKED_WINTER_STORAGE_STICKER, UNMARKED_WINTER_STORAGE_STICKER_VARS>(
     UNMARKED_WINTER_STORAGE_STICKER_QUERY,
     {
@@ -43,14 +44,16 @@ const StickerDetailsContainer = ({ leaseId, leaseStatus }: StickerDetailsContain
   const handleAssignNewStickerNumber =
     leaseStatus === LeaseStatus.PAID
       ? () =>
-          assignNewStickerNumber({ variables: { input: { leaseId: leaseId } } }).then(() => {
-            hdsToast({
-              translated: true,
-              labelText: 'toast.stickerNumChanged.label',
-              text: 'toast.stickerNumChanged.description',
-              type: 'success',
-            });
-          })
+          assignNewStickerNumber({ variables: { input: { leaseId: leaseId } } })
+            .then(() => {
+              hdsToast({
+                translated: true,
+                labelText: 'toast.stickerNumChanged.label',
+                text: 'toast.stickerNumChanged.description',
+                type: 'success',
+              });
+            })
+            .then(() => onStickerChange?.())
       : undefined;
 
   return (

--- a/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
+++ b/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
@@ -50,6 +50,7 @@ export interface UnmarkedWsNoticeListProps {
   onStatusFilterChange(statusFilter?: ApplicationStatus): void;
   onNameFilterChange(nameFilter: string | undefined): void;
   onSavePdf(customers: CustomerInfo[]): void;
+  onStickerChange(): void;
 }
 
 type ColumnType = Column<UnmarkedWinterStorageNotice>;
@@ -70,6 +71,7 @@ const UnmarkedWsNoticeList = ({
   nameFilter,
   onNameFilterChange,
   onSavePdf,
+  onStickerChange,
 }: UnmarkedWsNoticeListProps) => {
   const { t, i18n } = useTranslation();
   const columns: ColumnType[] = [
@@ -133,7 +135,7 @@ const UnmarkedWsNoticeList = ({
         initialState={{ sortBy }}
         renderSubComponent={(row) => (
           <Grid colsCount={3}>
-            <UnmarkedWsNoticeDetails {...row.original} />
+            <UnmarkedWsNoticeDetails {...row.original} onStickerChange={onStickerChange} />
           </Grid>
         )}
         renderMainHeader={() => t('unmarkedWsNotices.list.title')}

--- a/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeListContainer.tsx
+++ b/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeListContainer.tsx
@@ -56,17 +56,19 @@ const UnmarkedWsNoticeListContainer = () => {
   const [statusFilter, setStatusFilter] = useRecoilState(statusFilterAtom);
   const [nameFilter, setNameFilter] = useRecoilState(nameFilterAtom);
 
-  const { loading, data } = useQuery<UNMARKED_WINTER_STORAGE_NOTICES, UNMARKED_WINTER_STORAGE_NOTICES_VARS>(
+  const queryVariables = {
+    first: pageSize,
+    after: cursor,
+    orderBy,
+    statuses: statusFilter ? [statusFilter] : undefined,
+    nameFilter,
+  };
+
+  const { loading, data, refetch } = useQuery<UNMARKED_WINTER_STORAGE_NOTICES, UNMARKED_WINTER_STORAGE_NOTICES_VARS>(
     UNMARKED_WINTER_STORAGE_NOTICES_QUERY,
     {
       fetchPolicy: 'no-cache',
-      variables: {
-        first: pageSize,
-        after: cursor,
-        orderBy,
-        statuses: statusFilter ? [statusFilter] : undefined,
-        nameFilter,
-      },
+      variables: queryVariables,
     }
   );
 
@@ -148,6 +150,7 @@ const UnmarkedWsNoticeListContainer = () => {
         goToPage(0);
       }}
       onSavePdf={onSavePdf}
+      onStickerChange={() => refetch(queryVariables)}
     />
   );
 };

--- a/src/features/unmarkedWsNoticeList/printAllStickersButton/PrintAllStickersButton.tsx
+++ b/src/features/unmarkedWsNoticeList/printAllStickersButton/PrintAllStickersButton.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import Button from '../../../common/button/Button';
 import { UNMARKED_WINTER_STORAGE_NOTICES_STICKERS_QUERY } from './queries';
-import { generateAndSaveStickerPDF, getCustomersWithStickers } from '../utils';
+import { generateAndSaveStickerPDF, getCustomersWithUnsentStickers } from '../utils';
 import { UNMARKED_WINTER_STORAGE_NOTICES_STICKERS } from './__generated__/UNMARKED_WINTER_STORAGE_NOTICES_STICKERS';
 import styles from './printAllStickersButton.module.scss';
 import {
@@ -21,7 +21,7 @@ const PrintAllStickersButton = () => {
   const [setStickersPosted] = useMutation<SET_STICKERS_POSTED, SET_STICKERS_POSTED_VARS>(SET_STICKERS_POSTED_MUTATION);
 
   const onClick = () => {
-    const customers = getCustomersWithStickers(data);
+    const customers = getCustomersWithUnsentStickers(data);
     generateAndSaveStickerPDF(customers);
     setStickersPosted({
       variables: {

--- a/src/features/unmarkedWsNoticeList/printAllStickersButton/__generated__/UNMARKED_WINTER_STORAGE_NOTICES_STICKERS.ts
+++ b/src/features/unmarkedWsNoticeList/printAllStickersButton/__generated__/UNMARKED_WINTER_STORAGE_NOTICES_STICKERS.ts
@@ -15,6 +15,7 @@ export interface UNMARKED_WINTER_STORAGE_NOTICES_STICKERS_winterStorageNotices_e
   status: LeaseStatus;
   stickerNumber: number | null;
   stickerSeason: string | null;
+  stickerPosted: any | null;
 }
 
 export interface UNMARKED_WINTER_STORAGE_NOTICES_STICKERS_winterStorageNotices_edges_node {

--- a/src/features/unmarkedWsNoticeList/printAllStickersButton/queries.ts
+++ b/src/features/unmarkedWsNoticeList/printAllStickersButton/queries.ts
@@ -16,6 +16,7 @@ export const UNMARKED_WINTER_STORAGE_NOTICES_STICKERS_QUERY = gql`
             status
             stickerNumber
             stickerSeason
+            stickerPosted
           }
         }
       }

--- a/src/features/unmarkedWsNoticeList/utils.ts
+++ b/src/features/unmarkedWsNoticeList/utils.ts
@@ -112,12 +112,15 @@ export const getDraftedOffers = (applications: UnmarkedWinterStorageNotice[]) =>
     ];
   }, []);
 
-export const getCustomersWithStickers = (
+export const getCustomersWithUnsentStickers = (
   data: UNMARKED_WINTER_STORAGE_NOTICES_STICKERS | undefined
 ): CustomerInfo[] => {
   return (
     data?.winterStorageNotices?.edges.reduce<CustomerInfo[]>((acc, edge) => {
       if (!edge?.node?.lease?.stickerNumber || edge.node.lease.status !== LeaseStatus.PAID) {
+        return acc;
+      }
+      if (edge.node.lease.stickerPosted) {
         return acc;
       }
       const { firstName, lastName, address, municipality, zipCode, lease } = edge.node;

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -709,7 +709,7 @@
         "onClick": "Tulosta tarrakirjeet"
       },
       "allStickerPrint": {
-        "label": "Tulosta kaikki tarrakirjeet",
+        "label": "Tulosta tulostamattomat tarrakirjeet",
         "buttonText": "Tulosta",
         "loading": "Ladataan asiakastietoja"
       },


### PR DESCRIPTION
## Description :sparkles:

Table contents need to be refetched when changing sticker numbers through the unmarked ws notices list details component, as the data to print is taken from the selected row data.

Additionally, prevents data changes from resetting expanded state in Table.

## Issues :bug:

[VEN-1031](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1031)

## Testing :alembic:

### Manual testing :construction_worker_man:

- Go to unmarked ws list page
- Select a customer with an assigned sticker number
- Expand the row details for that customer and change sticker number
- Print out the sticker for the selected row
- The pdf should contain the newly changed sticker number
