### PR TITLE
VEN-1032 | Fix customer list accordion open shows unpaid invoice as history

### DIFF
--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { CustomerGroup, ServiceType, ContactMethod } from "./../../../@types/__generated__/globalTypes";
+import { CustomerGroup, ServiceType, ContactMethod, LeaseStatus } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: CUSTOMERS
@@ -124,6 +124,7 @@ export interface CUSTOMERS_profiles_edges_node_berthLeases_edges_node {
   __typename: "BerthLeaseNode";
   id: string;
   isActive: boolean;
+  status: LeaseStatus;
   berth: CUSTOMERS_profiles_edges_node_berthLeases_edges_node_berth;
 }
 

--- a/src/features/customerList/__mocks__/customersMockResponse.ts
+++ b/src/features/customerList/__mocks__/customersMockResponse.ts
@@ -1,5 +1,5 @@
 import { CUSTOMERS } from '../__generated__/CUSTOMERS';
-import { ContactMethod, CustomerGroup, ServiceType } from '../../../@types/__generated__/globalTypes';
+import { ContactMethod, CustomerGroup, LeaseStatus, ServiceType } from '../../../@types/__generated__/globalTypes';
 
 export const customersResponse: CUSTOMERS = {
   profiles: {
@@ -70,6 +70,7 @@ export const customersResponse: CUSTOMERS = {
                 node: {
                   id: 'QmVydGhMZWFzZU5vZGU6YThhNGNkOGEtMDcxYy00ZGU3LThkMGYtYTE5NmIyMDVmMWZi',
                   isActive: true,
+                  status: LeaseStatus.PAID,
                   berth: {
                     number: '37',
                     pier: {
@@ -93,6 +94,7 @@ export const customersResponse: CUSTOMERS = {
                 node: {
                   id: 'QmVydGhMZWFzZU5vZGU6MWE1ZTRkOGItNDQ2Yy00NTA1LThiMDgtNDc4NTkxYTFmZTQ3',
                   isActive: true,
+                  status: LeaseStatus.PAID,
                   berth: {
                     number: '6',
                     pier: {

--- a/src/features/customerList/customerDetails/CustomerDetails.tsx
+++ b/src/features/customerList/customerDetails/CustomerDetails.tsx
@@ -4,12 +4,12 @@ import { useTranslation } from 'react-i18next';
 import Grid from '../../../common/grid/Grid';
 import Section from '../../../common/section/Section';
 import Text from '../../../common/text/Text';
-import { CustomerGroup } from '../../../@types/__generated__/globalTypes';
+import { CustomerGroup, LeaseStatus } from '../../../@types/__generated__/globalTypes';
 import {
   CustomerListApplication,
   CustomerListBerthLeases,
-  CustomerListInvoice,
   CustomerListBoat,
+  CustomerListInvoice,
   CustomerListWinterStoragePlaces,
 } from '../types';
 import { formatDate } from '../../../common/utils/format';
@@ -49,8 +49,9 @@ const CustomerDetails = ({
   const { t, i18n } = useTranslation();
   const customerGroupKey = getCustomerGroupKey(customerGroup);
 
-  const activeBerths = berths.filter((berth) => berth.isActive);
-  const previousBerths = berths.filter((berth) => !berth.isActive);
+  const filterActiveBerths = (berth: CustomerListBerthLeases) => berth.isActive || berth.status === LeaseStatus.OFFERED;
+  const activeBerths = berths.filter(filterActiveBerths);
+  const pastBerths = berths.filter((berth) => !filterActiveBerths(berth));
   const renderBerthLine = (berth: CustomerListBerthLeases) => <div key={berth.id}>{berth.title}</div>;
 
   return (
@@ -72,13 +73,10 @@ const CustomerDetails = ({
           </Section>
         </div>
         <div>
-          <Section title={t('common.terminology.berths').toUpperCase()}>
-            <>
-              {activeBerths.map(renderBerthLine)}
-              {previousBerths.length > 0 && <hr />}
-              {previousBerths.map(renderBerthLine)}
-            </>
-          </Section>
+          <Section title={t('common.terminology.berths').toUpperCase()}>{activeBerths.map(renderBerthLine)}</Section>
+          {pastBerths.length > 0 && (
+            <Section title={t('customerList.pastBerths').toUpperCase()}>{pastBerths.map(renderBerthLine)}</Section>
+          )}
           <Section title={t('common.terminology.winterStoragePlaces').toUpperCase()}>
             {winterStoragePlaces.map((place) => (
               <div key={place.id}>{place.title}</div>

--- a/src/features/customerList/customerDetails/__mocks__/mockData.ts
+++ b/src/features/customerList/customerDetails/__mocks__/mockData.ts
@@ -1,5 +1,5 @@
-import { CustomerListApplication, CustomerListBerthLeases, CustomerListInvoice, CustomerListBoat } from '../../types';
-import { CustomerGroup } from '../../../../@types/__generated__/globalTypes';
+import { CustomerListApplication, CustomerListBerthLeases, CustomerListBoat, CustomerListInvoice } from '../../types';
+import { CustomerGroup, LeaseStatus } from '../../../../@types/__generated__/globalTypes';
 import { CustomerDetailsProps } from '../CustomerDetails';
 
 export const customerListEntry: Omit<
@@ -28,6 +28,6 @@ export const customerListApplications: CustomerListApplication[] = [{ id: '123',
 export const customerListInvoices: CustomerListInvoice[] = [{ id: '123', date: '2020-01-21' }];
 
 export const customerListBerthLeases: CustomerListBerthLeases[] = [
-  { id: '123', isActive: true, title: 'Pursilahdenranta B31' },
-  { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
+  { id: '123', isActive: true, status: LeaseStatus.PAID, title: 'Pursilahdenranta B31' },
+  { id: '321', isActive: true, status: LeaseStatus.PAID, title: 'Strömsinlahdenranta B31' },
 ];

--- a/src/features/customerList/customerDetails/__tests__/CustomerDetails.test.tsx
+++ b/src/features/customerList/customerDetails/__tests__/CustomerDetails.test.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 
 import CustomerDetails, { CustomerDetailsProps } from '../CustomerDetails';
 import {
   customerListApplications,
   customerListBerthLeases,
-  customerListInvoices,
   customerListBoats,
   customerListEntry,
+  customerListInvoices,
   customerListWinterStoragePlaces,
 } from '../__mocks__/mockData';
 import { CustomerListBerthLeases } from '../../types';
+import { LeaseStatus } from '../../../../@types/__generated__/globalTypes';
 
 const mockProps = {
   ...customerListEntry,
@@ -30,29 +31,31 @@ describe('CustomerDetails', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('renders a horizontal rule if there are inactive berth leases', () => {
+  const pastBerthsTitleSelector = (wrapper: ReactWrapper) => wrapper.find('Section').at(4).find('h4').at(0).text();
+
+  it('renders past berths if there are inactive berth leases', () => {
     const berths: CustomerListBerthLeases[] = [
-      { id: '123', isActive: false, title: 'Pursilahdenranta B31' },
-      { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
+      { id: '123', isActive: false, status: LeaseStatus.PAID, title: 'Pursilahdenranta B31' },
+      { id: '321', isActive: true, status: LeaseStatus.PAID, title: 'Strömsinlahdenranta B31' },
     ];
 
     const wrapper = getWrapper({
       berths,
     });
 
-    expect(wrapper.find('hr').exists()).toEqual(true);
+    expect(pastBerthsTitleSelector(wrapper)).toEqual('AIEMMAT VENEPAIKAT');
   });
 
-  it('renders no horizontal rule if there are no inactive berth leases', () => {
+  it('renders no past berths if there are no inactive berth leases', () => {
     const berths: CustomerListBerthLeases[] = [
-      { id: '123', isActive: true, title: 'Pursilahdenranta B31' },
-      { id: '321', isActive: true, title: 'Strömsinlahdenranta B31' },
+      { id: '123', isActive: true, status: LeaseStatus.PAID, title: 'Pursilahdenranta B31' },
+      { id: '321', isActive: true, status: LeaseStatus.PAID, title: 'Strömsinlahdenranta B31' },
     ];
 
     const wrapper = getWrapper({
       berths,
     });
 
-    expect(wrapper.find('hr').exists()).toEqual(false);
+    expect(pastBerthsTitleSelector(wrapper)).not.toEqual('AIEMMAT VENEPAIKAT');
   });
 });

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -85,6 +85,7 @@ export const CUSTOMERS_QUERY = gql`
               node {
                 id
                 isActive
+                status
                 berth {
                   number
                   pier {

--- a/src/features/customerList/types.ts
+++ b/src/features/customerList/types.ts
@@ -1,4 +1,4 @@
-import { CustomerGroup } from '../../@types/__generated__/globalTypes';
+import { CustomerGroup, LeaseStatus } from '../../@types/__generated__/globalTypes';
 
 export interface Organization {
   name: string;
@@ -31,6 +31,7 @@ export interface CustomerListBerthLeases {
   id: string;
   isActive: boolean;
   title: string;
+  status: LeaseStatus;
 }
 
 export interface CustomerListWinterStoragePlaces {

--- a/src/features/customerList/utils.ts
+++ b/src/features/customerList/utils.ts
@@ -34,6 +34,7 @@ function getBerthLeases(profile: ProfileNode): CustomerListBerthLeases[] | undef
     .map(({ node }) => {
       const { id, isActive } = node;
 
+      const status = node.status;
       const berth = node.berth;
       const berthNumber = berth.number;
       const harborName = berth.pier.properties?.harbor?.properties?.name ?? '';
@@ -44,6 +45,7 @@ function getBerthLeases(profile: ProfileNode): CustomerListBerthLeases[] | undef
         id,
         isActive,
         title,
+        status,
       };
     });
 }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -472,6 +472,7 @@
   "customerList": {
     "title": "Asiakkaat",
     "addNewCustomer": "Lisää uusi asiakas",
+    "pastBerths": "Aiemmat venepaikat",
     "tableHeaders": {
       "name": "Nimi",
       "group": "Asiakasryhmä",


### PR DESCRIPTION
## Description :sparkles:

* Change logic for customer details to show inactive but offered berths as active
* Change horizontal rule to "AIEMMAT VENEPAIKAT" title

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1032](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1032): Customer list accordion open shows unpaid invoice as history

## Testing :alembic:

### Automated tests :gear:️

* Updated test selector
  * We could look into using React Testing Library to make more sane selectors

### Manual testing :construction_worker_man:

* [This customer](http://localhost:3000/customers/UHJvZmlsZU5vZGU6NGRmNmQzMGMtYWU4Mi00ZWNkLTkyNGEtYjE0MjBiMDIwZTRm) has an offered berth that has not yet been paid
  * It should be visible under "VENEPAIKAT" and not "AIEMMAT VENEPAIKAT" on the customer list
* "AIEMMAT VENEPAIKAT" should be visible for some other customers, check the last page on default sorting