### PR TITLE
VEN-1027 | Disable 'edit additional services' button if invoice is sent

### DIFF
--- a/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
+++ b/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
@@ -84,6 +84,7 @@ const BerthOfferCard = ({
       className={className}
       customerEmail={customerEmail}
       invoicingDisabled={!berthInvoicingFeatureFlag()}
+      leaseStatus={status}
       order={order}
       placeDetails={
         <PlaceDetails

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -98,7 +98,13 @@ const InvoiceCard = ({
           ) : (
             <div /> // Grid spacer
           )}
-          {order && <OrderSection order={order} editAdditionalServices={editAdditionalServices} />}
+          {order && (
+            <OrderSection
+              applicationStatus={applicationStatus}
+              order={order}
+              editAdditionalServices={editAdditionalServices}
+            />
+          )}
         </Grid>
         <hr />
         <div className={styles.buttonRow}>

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -12,7 +12,7 @@ import Property from '../../common/property/Property';
 import OrderSection from './OrderSection';
 import { Order, PlaceProperty } from './types';
 import Button from '../../common/button/Button';
-import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
+import { ApplicationStatus, LeaseStatus } from '../../@types/__generated__/globalTypes';
 
 export interface InvoiceCardProps {
   applicationStatus: ApplicationStatus;
@@ -20,6 +20,7 @@ export interface InvoiceCardProps {
   className?: string;
   editAdditionalServices: () => void;
   invoicingDisabled?: boolean;
+  leaseStatus: LeaseStatus | null;
   order: Order | null;
   placeDetails?: React.ReactNode;
   placeName: React.ReactNode;
@@ -36,6 +37,7 @@ const InvoiceCard = ({
   className,
   editAdditionalServices,
   invoicingDisabled,
+  leaseStatus,
   order,
   placeDetails,
   placeName,
@@ -99,11 +101,7 @@ const InvoiceCard = ({
             <div /> // Grid spacer
           )}
           {order && (
-            <OrderSection
-              applicationStatus={applicationStatus}
-              order={order}
-              editAdditionalServices={editAdditionalServices}
-            />
+            <OrderSection order={order} leaseStatus={leaseStatus} editAdditionalServices={editAdditionalServices} />
           )}
         </Grid>
         <hr />

--- a/src/features/invoiceCard/OrderSection.tsx
+++ b/src/features/invoiceCard/OrderSection.tsx
@@ -6,16 +6,16 @@ import LabelValuePair from '../../common/labelValuePair/LabelValuePair';
 import { formatPrice } from '../../common/utils/format';
 import { getProductServiceTKey } from '../../common/utils/translations';
 import { Order } from './types';
-import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
+import { LeaseStatus } from '../../@types/__generated__/globalTypes';
 import Button from '../../common/button/Button';
 
 export interface OrderSectionProps {
-  applicationStatus: ApplicationStatus;
+  leaseStatus: LeaseStatus | null;
   order: Order;
   editAdditionalServices: () => void;
 }
 
-const OrderSection = ({ applicationStatus, order, editAdditionalServices }: OrderSectionProps) => {
+const OrderSection = ({ leaseStatus, order, editAdditionalServices }: OrderSectionProps) => {
   const {
     t,
     i18n: { language },
@@ -45,9 +45,7 @@ const OrderSection = ({ applicationStatus, order, editAdditionalServices }: Orde
             <Button
               size="small"
               onClick={() => editAdditionalServices()}
-              disabled={
-                applicationStatus === ApplicationStatus.OFFER_SENT || applicationStatus === ApplicationStatus.HANDLED
-              }
+              disabled={leaseStatus !== LeaseStatus.DRAFTED}
             >
               {t('common.edit')}
             </Button>

--- a/src/features/invoiceCard/OrderSection.tsx
+++ b/src/features/invoiceCard/OrderSection.tsx
@@ -7,13 +7,15 @@ import { formatPrice } from '../../common/utils/format';
 import { getProductServiceTKey } from '../../common/utils/translations';
 import Text from '../../common/text/Text';
 import { Order } from './types';
+import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
 
 export interface OrderSectionProps {
+  applicationStatus: ApplicationStatus;
   order: Order;
   editAdditionalServices: () => void;
 }
 
-const OrderSection = ({ order, editAdditionalServices }: OrderSectionProps) => {
+const OrderSection = ({ applicationStatus, order, editAdditionalServices }: OrderSectionProps) => {
   const {
     t,
     i18n: { language },
@@ -40,7 +42,10 @@ const OrderSection = ({ order, editAdditionalServices }: OrderSectionProps) => {
         <LabelValuePair
           label={t('offer.invoicing.additionalServices')}
           value={
-            <button onClick={() => editAdditionalServices()}>
+            <button
+              onClick={() => editAdditionalServices()}
+              disabled={applicationStatus === ApplicationStatus.OFFER_SENT}
+            >
               <Text color="brand">{t('common.edit')}</Text>
             </button>
           }

--- a/src/features/invoiceCard/OrderSection.tsx
+++ b/src/features/invoiceCard/OrderSection.tsx
@@ -45,7 +45,9 @@ const OrderSection = ({ applicationStatus, order, editAdditionalServices }: Orde
             <Button
               size="small"
               onClick={() => editAdditionalServices()}
-              disabled={applicationStatus === ApplicationStatus.OFFER_SENT}
+              disabled={
+                applicationStatus === ApplicationStatus.OFFER_SENT || applicationStatus === ApplicationStatus.HANDLED
+              }
             >
               {t('common.edit')}
             </Button>

--- a/src/features/invoiceCard/OrderSection.tsx
+++ b/src/features/invoiceCard/OrderSection.tsx
@@ -5,9 +5,9 @@ import Section from '../../common/section/Section';
 import LabelValuePair from '../../common/labelValuePair/LabelValuePair';
 import { formatPrice } from '../../common/utils/format';
 import { getProductServiceTKey } from '../../common/utils/translations';
-import Text from '../../common/text/Text';
 import { Order } from './types';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
+import Button from '../../common/button/Button';
 
 export interface OrderSectionProps {
   applicationStatus: ApplicationStatus;
@@ -42,12 +42,13 @@ const OrderSection = ({ applicationStatus, order, editAdditionalServices }: Orde
         <LabelValuePair
           label={t('offer.invoicing.additionalServices')}
           value={
-            <button
+            <Button
+              size="small"
               onClick={() => editAdditionalServices()}
               disabled={applicationStatus === ApplicationStatus.OFFER_SENT}
             >
-              <Text color="brand">{t('common.edit')}</Text>
-            </button>
+              {t('common.edit')}
+            </Button>
           }
           align={'right'}
         />

--- a/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
+++ b/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 import InvoiceCard, { InvoiceCardProps } from '../InvoiceCard';
-import { ApplicationStatus } from '../../../@types/__generated__/globalTypes';
+import { ApplicationStatus, LeaseStatus } from '../../../@types/__generated__/globalTypes';
 
 describe('InvoiceCard', () => {
-  const defaultProps = {
+  const defaultProps: InvoiceCardProps = {
     editAdditionalServices: jest.fn(),
     sendInvoice: jest.fn(),
     order: {
@@ -20,6 +20,7 @@ describe('InvoiceCard', () => {
     placeName: 'place name',
     placeProperties: [],
     title: 'title',
+    leaseStatus: LeaseStatus.DRAFTED,
     applicationStatus: ApplicationStatus.OFFER_GENERATED,
   };
 

--- a/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
+++ b/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
@@ -103,9 +103,12 @@ exports[`InvoiceCard renders normally 1`] = `
                 <span
                   class="value right"
                 >
-                  <button>
+                  <button
+                    class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 Button-module_size-small__2u97E button_hds-button--small__2NFef"
+                    type="button"
+                  >
                     <span
-                      class="text brand span"
+                      class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
                     >
                       Muokkaa
                     </span>

--- a/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeView.tsx
+++ b/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeView.tsx
@@ -117,6 +117,7 @@ const UnmarkedWsNoticeView = ({
           }
           className={styles.fullWidth}
           customerEmail={customerProfile?.primaryEmail ?? null}
+          leaseStatus={leaseStatus}
           order={order}
           placeDetails={<p>{t('common.terminology.unmarkedWinterStoragePlace')}</p>}
           placeName={noticeDetails.choice.winterStorageAreaName}


### PR DESCRIPTION
## Description :sparkles:

* Disable 'edit additional services' button if invoice is sent

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1027](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1027): Invoice 'edit additional services' button should be inactive if invoice is sent

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man: