### PR TITLE
Fix browser tests on GitHub CI

### DIFF
--- a/browser-tests/navigateAndView.ts
+++ b/browser-tests/navigateAndView.ts
@@ -17,6 +17,8 @@ test('Navigate and view basic data', async (t) => {
   await t
     .click(navigation.applicationsExpandable)
     .click(navigation.applications)
+    .expect(applications.applicationList.firstApplicationLink.exists)
+    .ok()
     .click(applications.applicationList.firstApplicationLink)
     .expect(applications.applicationView.firstName.filter(hasLength).exists)
     .ok();


### PR DESCRIPTION
## Description :sparkles:

* Added a simple .exists() check which makes the browser test wait a bit before clicking
