### PR TITLE
Remove running browser tests on Windows

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     env:
       BROWSER_TESTS_UID: ${{ secrets.BROWSER_TESTS_UID }}
       BROWSER_TESTS_PWD: ${{ secrets.BROWSER_TESTS_PWD }}


### PR DESCRIPTION
## Description :sparkles:

Solution for browser test issues. Since `windows-latest` is the only one with difficult timing issues in browser tests, let's just remove it.
