### PR TITLE
VEN-970 | Enable the "Send invoice" button for berth applications

### DIFF
--- a/.env
+++ b/.env
@@ -1,11 +1,12 @@
 REACT_APP_API_URL=https://venepaikka-federation.test.kuva.hel.ninja/
+REACT_APP_ENV=development
 REACT_APP_SENTRY_DSN=https://id1@sentry.io/id2
 REACT_APP_SENTRY_ENVIRONMENT=development
 REACT_APP_SERVICE_MAP_URL=https://palvelukartta.hel.fi/unit/
 REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT=api-tokens
 REACT_APP_TUNNISTAMO_CLIENT_ID=https://api.hel.fi/auth/berths-admin-ui
+REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT=logout
 REACT_APP_TUNNISTAMO_SCOPE_BERTHS=https://api.hel.fi/auth/berths
 REACT_APP_TUNNISTAMO_SCOPE_PROFILE=https://api.hel.fi/auth/helsinkiprofile
-REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT=logout
 REACT_APP_TUNNISTAMO_URI=https://api.hel.fi/sso-test
 SASS_PATH=node_modules:src/assets/styles

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,6 +13,7 @@ build-review:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-review'
+    DOCKER_BUILD_ARG_REACT_APP_ENV: 'review'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.kuva.hel.ninja'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
@@ -30,6 +31,7 @@ build-staging:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-staging'
+    DOCKER_BUILD_ARG_REACT_APP_ENV: 'staging'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://api.hel.fi/sso-test'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
@@ -47,6 +49,7 @@ build-production:
   extends: .build
   variables:
     DOCKER_IMAGE_NAME: '$CI_PROJECT_NAME-production'
+    DOCKER_BUILD_ARG_REACT_APP_ENV: 'production'
     DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://api.hel.fi/berths-federation/'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://api.hel.fi/sso'
     DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ CMD ["react-scripts", "start"]
 FROM appbase as staticbuilder
 # ===================================
 
+ARG REACT_APP_ENV=development
+ENV REACT_APP_ENV $REACT_APP_ENV
+
 ARG REACT_APP_API_URL
 ARG REACT_APP_SENTRY_DSN
 ARG REACT_APP_SENTRY_ENVIRONMENT

--- a/src/common/utils/featureFlags.ts
+++ b/src/common/utils/featureFlags.ts
@@ -15,7 +15,7 @@ export const harborMooringFeatureFlag = () => {
 };
 
 export const berthInvoicingFeatureFlag = () => {
-  return process.env.NODE_ENV !== 'production';
+  return process.env.REACT_APP_ENV !== 'production';
 };
 
 export const queueFeatureFlag = () => {

--- a/src/features/auth/authService.ts
+++ b/src/features/auth/authService.ts
@@ -8,6 +8,10 @@ class AuthService {
   private userManager: UserManager;
 
   constructor() {
+    const {
+      REACT_APP_TUNNISTAMO_SCOPE_BERTHS: berthScope,
+      REACT_APP_TUNNISTAMO_SCOPE_PROFILE: profileScope,
+    } = process.env;
     const settings: UserManagerSettings = {
       /* eslint-disable @typescript-eslint/camelcase */
       authority: process.env.REACT_APP_TUNNISTAMO_URI,
@@ -17,7 +21,7 @@ class AuthService {
       post_logout_redirect_uri: origin,
       response_type: 'id_token token',
       silent_redirect_uri: `${origin}/silent-callback.html`,
-      scope: `openid ${process.env.REACT_APP_TUNNISTAMO_SCOPE_BERTHS} ${process.env.REACT_APP_TUNNISTAMO_SCOPE_PROFILE}`,
+      scope: `openid ${berthScope} ${profileScope}`,
       /* eslint-enable @typescript-eslint/camelcase */
     };
 


### PR DESCRIPTION
## Description :sparkles:

* Add new `REACT_APP_ENV` env var, which corresponds to the runtime environment (development, review, staging, production)
* Enable berth invoicing up to staging (all but `REACT_APP_ENV===production`)
* Fix authService long line lint issue

## Issues :bug:

### Closes :no_good_woman:

* [VEN-970](https://helsinkisolutionoffice.atlassian.net/browse/VEN-970): FE - Enable the "Send invoice" button for berth applications

## Testing :alembic:

### Manual testing :construction_worker_man:

* "Send invoice" for berths should be enabled in development and staging
* "Send invoice" for berths should _not_ be enabled in production
