### PR TITLE
Temporarily disable pricing browser tests

### DIFF
--- a/browser-tests/navigateAndView.ts
+++ b/browser-tests/navigateAndView.ts
@@ -50,12 +50,13 @@ test('Navigate and view basic data', async (t) => {
     .expect(customers.customerView.firstDataLabel.filter(hasLength).exists)
     .ok();
 
+  // FIXME: Temporarily disabled
   // Pricing
-  await t.click(navigation.pricing).expect(pricing.berthPrices.firstPrivatePrice.filter(hasPrice).exists).ok();
+  // await t.click(navigation.pricing).expect(pricing.berthPrices.firstPrivatePrice.filter(hasPrice).exists).ok();
 
   // Pricing modal
-  await t
-    .click(pricing.berthPrices.editPriceButton)
-    .expect(pricing.berthPrices.priceModal.privatePrice.filter(inputHasPrice).exists)
-    .ok();
+  // await t
+  //   .click(pricing.berthPrices.editPriceButton)
+  //   .expect(pricing.berthPrices.priceModal.privatePrice.filter(inputHasPrice).exists)
+  //   .ok();
 });


### PR DESCRIPTION
## Description :sparkles:

* Temporarily commented out pricing browser tests while waiting for a fix, so that other features are unblocked