### PR TITLE
VEN-986 | Pricing page improvements

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -312,7 +312,7 @@ export interface CreatePierMutationInput {
   wasteCollection?: boolean | null;
   lighting?: boolean | null;
   personalElectricity?: boolean | null;
-  priceTier: PriceTier;
+  priceTier?: PriceTier | null;
   clientMutationId?: string | null;
 }
 

--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -50,6 +50,7 @@ type TableProps<D extends object> = {
   loading?: boolean;
   canSelectRows?: boolean;
   canSelectOneRow?: boolean;
+  cellClassName?: string;
   styleMainHeader?: boolean;
   theme?: 'basic' | 'primary';
   globalFilter?: UseGlobalFiltersOptions<D>['globalFilter'];
@@ -92,6 +93,7 @@ const Table = <D extends { id: string }>({
   loading,
   canSelectRows,
   canSelectOneRow,
+  cellClassName,
   styleMainHeader = true,
   theme = 'primary',
   globalFilter,
@@ -338,11 +340,15 @@ const Table = <D extends { id: string }>({
           {row.cells.map((cell) => (
             <div
               {...cell.getCellProps()}
-              className={classNames(styles.tableCell, {
-                [styles.selector]: cell.column.id === SELECTOR,
-                [styles.radioSelector]: cell.column.id === RADIO_SELECTOR,
-                [styles.expander]: cell.column.id === EXPANDER,
-              })}
+              className={classNames(
+                styles.tableCell,
+                {
+                  [styles.selector]: cell.column.id === SELECTOR,
+                  [styles.radioSelector]: cell.column.id === RADIO_SELECTOR,
+                  [styles.expander]: cell.column.id === EXPANDER,
+                },
+                cellClassName
+              )}
             >
               {loading ? <div className={styles.placeholder} /> : cell.render('Cell')}
             </div>

--- a/src/features/harborView/forms/pierForm/PierCreateForm.tsx
+++ b/src/features/harborView/forms/pierForm/PierCreateForm.tsx
@@ -17,14 +17,12 @@ interface Props extends Omit<FormProps<Pier>, 'initialValues' | 'isSubmitting' |
 
 const PierCreateForm = ({ harborId, onCancel, onSubmit, refetchQueries }: Props) => {
   const { loading, error, data } = useQuery<BOAT_TYPES>(BOAT_TYPES_QUERY);
-  const [
-    // TODO: to be fixed in https://github.com/City-of-Helsinki/berth-reservations-admin/pull/357
-    // eslint-disable-next-line
-    createPier,
-    { loading: isSubmitting, error: createError },
-  ] = useMutation<CREATE_PIER, CREATE_PIER_VARS>(CREATE_PIER_MUTATION, {
-    refetchQueries: refetchQueries ?? [],
-  });
+  const [createPier, { loading: isSubmitting, error: createError }] = useMutation<CREATE_PIER, CREATE_PIER_VARS>(
+    CREATE_PIER_MUTATION,
+    {
+      refetchQueries: refetchQueries ?? [],
+    }
+  );
   const { t } = useTranslation();
 
   if (loading) return <LoadingSpinner isLoading={loading} />;
@@ -37,8 +35,7 @@ const PierCreateForm = ({ harborId, onCancel, onSubmit, refetchQueries }: Props)
       onSubmitText={t('forms.common.create')}
       onCancel={onCancel}
       onSubmit={(values) => {
-        // TODO: to be fixed in https://github.com/City-of-Helsinki/berth-reservations-admin/pull/357
-        // createPier({ variables: { input: { ...values, harborId } } }).then(() => onSubmit?.(values));
+        createPier({ variables: { input: { ...values, harborId } } }).then(() => onSubmit?.(values));
       }}
       isSubmitting={isSubmitting}
       suitableBoatTypeOptions={suitableBoatTypeOptions}

--- a/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
+++ b/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`PricingPage renders normally 1`] = `
     class="grid cols2 twoCols"
   >
     <div
-      class="card"
+      class="card berthPricing"
     >
       <div
         class="cardHeader"
@@ -194,32 +194,44 @@ exports[`PricingPage renders normally 1`] = `
                     style="display: flex; flex: 1 0 auto; min-width: 562.5px;"
                   >
                     <div
-                      class="tableCell"
+                      class="tableCell tableCell"
                       role="cell"
                       style="box-sizing: border-box; flex: 225 0 auto; min-width: 225px; width: 225px;"
                     >
                       3,0 m - 7,0 m
                     </div>
                     <div
-                      class="tableCell"
+                      class="tableCell tableCell"
                       role="cell"
                       style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                     >
-                      50,00 €
+                      <div
+                        class="grayCell"
+                      >
+                        50,00 €
+                      </div>
                     </div>
                     <div
-                      class="tableCell"
+                      class="tableCell tableCell"
                       role="cell"
                       style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                     >
-                      75,00 €
+                      <div
+                        class="grayCell"
+                      >
+                        75,00 €
+                      </div>
                     </div>
                     <div
-                      class="tableCell"
+                      class="tableCell tableCell"
                       role="cell"
                       style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                     >
-                      100,00 €
+                      <div
+                        class="grayCell"
+                      >
+                        100,00 €
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -252,7 +264,7 @@ exports[`PricingPage renders normally 1`] = `
             <div
               class="table basic noMainHeader"
               role="table"
-              style="min-width: 75px;"
+              style="min-width: 300px;"
             >
               <div
                 class="stickyHeaders"
@@ -260,13 +272,13 @@ exports[`PricingPage renders normally 1`] = `
                 <div
                   class="header"
                   role="row"
-                  style="display: flex; flex: 1 0 auto; min-width: 75px;"
+                  style="display: flex; flex: 1 0 auto; min-width: 300px;"
                 >
                   <div
                     class="headerCell"
                     colspan="1"
                     role="columnheader"
-                    style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
+                    style="box-sizing: border-box; flex: 225 0 auto; min-width: 225px; width: 225px; cursor: pointer;"
                     title="Toggle SortBy"
                   >
                     Satama
@@ -336,12 +348,12 @@ exports[`PricingPage renders normally 1`] = `
                 >
                   <div
                     role="row"
-                    style="display: flex; flex: 1 0 auto; min-width: 75px;"
+                    style="display: flex; flex: 1 0 auto; min-width: 300px;"
                   >
                     <div
                       class="tableCell"
                       role="cell"
-                      style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
+                      style="box-sizing: border-box; flex: 225 0 auto; min-width: 225px; width: 225px;"
                     >
                       <a
                         class="internalLink brand"

--- a/src/features/pricing/berthPricing/BerthPricing.tsx
+++ b/src/features/pricing/berthPricing/BerthPricing.tsx
@@ -12,6 +12,7 @@ import { BerthPricing as BerthPricingData } from './__generated__/BerthPricing';
 import { getBerthsData } from './utils';
 import { PriceTier } from '../../../@types/__generated__/globalTypes';
 import { getPriceTier } from '../../../common/utils/translations';
+import styles from './berthPricing.module.scss';
 
 export interface BerthPrice {
   id: string;
@@ -23,13 +24,12 @@ export interface BerthPrice {
 }
 
 export interface BerthPricingProps {
-  className?: string;
   data: BerthPricingData | undefined | null;
   loading: boolean;
   refetchQueries?: PureQueryOptions[] | string[];
 }
 
-const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricingProps) => {
+const BerthPricing = ({ data, loading, refetchQueries }: BerthPricingProps) => {
   const { t, i18n } = useTranslation();
 
   const berthPricesCols: Column<BerthPrice>[] = [
@@ -43,24 +43,30 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
       Header: getPriceTier(PriceTier.TIER_1),
       accessor: PriceTier.TIER_1,
       minWidth: COLUMN_WIDTH.S,
-      Cell: ({ cell: { value } }) => (value ? formatPrice(value, i18n.language) : '-'),
+      Cell: ({ cell: { value } }) => (
+        <div className={styles.grayCell}>{value ? formatPrice(value, i18n.language) : '-'}</div>
+      ),
     },
     {
       Header: getPriceTier(PriceTier.TIER_2),
       accessor: PriceTier.TIER_2,
       minWidth: COLUMN_WIDTH.S,
-      Cell: ({ cell: { value } }) => (value ? formatPrice(value, i18n.language) : '-'),
+      Cell: ({ cell: { value } }) => (
+        <div className={styles.grayCell}>{value ? formatPrice(value, i18n.language) : '-'}</div>
+      ),
     },
     {
       Header: getPriceTier(PriceTier.TIER_3),
       accessor: PriceTier.TIER_3,
       minWidth: COLUMN_WIDTH.S,
-      Cell: ({ cell: { value } }) => (value ? formatPrice(value, i18n.language) : '-'),
+      Cell: ({ cell: { value } }) => (
+        <div className={styles.grayCell}>{value ? formatPrice(value, i18n.language) : '-'}</div>
+      ),
     },
   ];
 
   return (
-    <Card className={className}>
+    <Card className={styles.berthPricing}>
       <CardHeader title={t('pricing.berths.title')} />
       <CardBody>
         <Section>{t('pricing.berths.description')}</Section>
@@ -70,6 +76,7 @@ const BerthPricing = ({ className, data, loading, refetchQueries }: BerthPricing
           data={getBerthsData(data)}
           loading={loading}
           theme="basic"
+          cellClassName={styles.tableCell}
           renderEmptyStateRow={() => t('common.notification.noData.description')}
         />
       </CardBody>

--- a/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
+++ b/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BerthPricing renders noData message when there is no data 1`] = `
 <div
-  class="card"
+  class="card berthPricing"
 >
   <div
     class="cardHeader"
@@ -196,7 +196,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
 
 exports[`BerthPricing renders normally 1`] = `
 <div
-  class="card"
+  class="card berthPricing"
 >
   <div
     class="cardHeader"
@@ -377,32 +377,44 @@ exports[`BerthPricing renders normally 1`] = `
                 style="display: flex; flex: 1 0 auto; min-width: 562.5px;"
               >
                 <div
-                  class="tableCell"
+                  class="tableCell tableCell"
                   role="cell"
                   style="box-sizing: border-box; flex: 225 0 auto; min-width: 225px; width: 225px;"
                 >
                   3,0 m - 7,0 m
                 </div>
                 <div
-                  class="tableCell"
+                  class="tableCell tableCell"
                   role="cell"
                   style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                 >
-                  50,00 €
+                  <div
+                    class="grayCell"
+                  >
+                    50,00 €
+                  </div>
                 </div>
                 <div
-                  class="tableCell"
+                  class="tableCell tableCell"
                   role="cell"
                   style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                 >
-                  75,00 €
+                  <div
+                    class="grayCell"
+                  >
+                    75,00 €
+                  </div>
                 </div>
                 <div
-                  class="tableCell"
+                  class="tableCell tableCell"
                   role="cell"
                   style="box-sizing: border-box; flex: 150 0 auto; min-width: 112.5px; width: 150px;"
                 >
-                  100,00 €
+                  <div
+                    class="grayCell"
+                  >
+                    100,00 €
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/features/pricing/berthPricing/berthPricing.module.scss
+++ b/src/features/pricing/berthPricing/berthPricing.module.scss
@@ -1,0 +1,14 @@
+@import 'colours';
+@import 'spacings';
+
+.berthPricing {
+  .tableCell {
+    padding: 0;
+  }
+
+  .grayCell {
+    padding: units(0.5);
+    width: 100%;
+    background: $black-5;
+  }
+}

--- a/src/features/pricing/harborTiers/HarborTiers.tsx
+++ b/src/features/pricing/harborTiers/HarborTiers.tsx
@@ -28,6 +28,8 @@ const HarborTiers = ({ className, loading, data }: HarborTiersProps) => {
     {
       Header: t('pricing.harborTiers.harbor') || '',
       accessor: 'name',
+      width: COLUMN_WIDTH.L,
+      minWidth: COLUMN_WIDTH.L,
       Cell: ({ cell }) => <InternalLink to={`/harbors/${cell.row.original.id}`}>{cell.value}</InternalLink>,
     },
     {


### PR DESCRIPTION
## Description :sparkles:
- Improve the styles of the pricing page
- Reenable `createPier` after updating the schema types

## Issues :bug:
### Closes :no_good_woman:
VEN-986: Update pricing page for new berth prices

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/102250474-4bdf1280-3f0c-11eb-898f-a12ea0218757.png)

## Additional notes :spiral_notepad:
