### PR TITLE
Fix recurring invoices due date selection

### DIFF
--- a/src/features/recurringInvoices/recurringInvoicesForm/RecurringInvoicesForm.tsx
+++ b/src/features/recurringInvoices/recurringInvoicesForm/RecurringInvoicesForm.tsx
@@ -48,7 +48,7 @@ const RecurringInvoicesForm = ({ onSubmit, onCancel, isSubmitting }: RecurringIn
 
           <div className={styles.centered}>
             <TextInput
-              id="RecurringInvoicesForm_dueDate"
+              id="dueDate"
               type="date"
               value={values.dueDate}
               onChange={handleChange}

--- a/src/features/recurringInvoices/recurringInvoicesForm/__tests__/__snapshots__/RecurringInvoicesForm.test.tsx.snap
+++ b/src/features/recurringInvoices/recurringInvoicesForm/__tests__/__snapshots__/RecurringInvoicesForm.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`RecurringInvoicesForm renders normally 1`] = `
     >
       <label
         class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-        for="RecurringInvoicesForm_dueDate"
+        for="dueDate"
       >
         Laskun eräpäivä
         <span
@@ -42,7 +42,7 @@ exports[`RecurringInvoicesForm renders normally 1`] = `
       >
         <input
           class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="RecurringInvoicesForm_dueDate"
+          id="dueDate"
           required=""
           type="date"
           value="2020-10-07"


### PR DESCRIPTION
## Description :sparkles:
- Rename the `id` of `dueDate` on the recurring invoices page

## Issues :bug:
The user is not able to change the due date on the recurring invoices page
