### PR TITLE
VEN-1058 | Add empty name placeholders for applications, customers and recurring invoices

### DIFF
--- a/src/common/berthDetails/BerthDetails.tsx
+++ b/src/common/berthDetails/BerthDetails.tsx
@@ -59,7 +59,7 @@ const BerthDetails = ({
           <InternalLink to={`/customers/${customer.id}`}>
             {customer.firstName !== '' && customer.lastName !== ''
               ? `${customer.firstName} ${customer.lastName}`
-              : t('offer.berthDetails.emptyName')}
+              : t('common.emptyName')}
           </InternalLink>
         </div>
       );

--- a/src/common/berthDetails/__tests__/__snapshots__/BerthDetails.test.tsx.snap
+++ b/src/common/berthDetails/__tests__/__snapshots__/BerthDetails.test.tsx.snap
@@ -162,9 +162,9 @@ exports[`BerthDetails renders normally with all props 1`] = `
           <a
             class="internalLink brand"
             href="#/customers/0"
-            title="Ei nimeä"
+            title="Nimi puuttuu"
           >
-            Ei nimeä
+            Nimi puuttuu
           </a>
         </div>
         <div>

--- a/src/features/applicationList/ApplicationList.tsx
+++ b/src/features/applicationList/ApplicationList.tsx
@@ -85,7 +85,7 @@ const ApplicationList = ({
         },
       }) => (
         <InternalLink to={`/applications/${id}`}>
-          {firstName} {lastName}
+          {firstName !== '' && lastName !== '' ? `${firstName} ${lastName}` : t('common.emptyName')}
         </InternalLink>
       ),
       Header: t('common.name') as string,

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -349,6 +349,7 @@ exports[`ApplicationList renders normally with all props 1`] = `
                 <a
                   class="internalLink brand"
                   href="#/applications/MOCK-APPLICATION-0"
+                  title="Matti Meikäläinen"
                 >
                   Matti Meikäläinen
                 </a>
@@ -474,6 +475,7 @@ exports[`ApplicationList renders normally with all props 1`] = `
                 <a
                   class="internalLink brand"
                   href="#/applications/MOCK-APPLICATION-1"
+                  title="Maija Meikäläinen"
                 >
                   Maija Meikäläinen
                 </a>
@@ -599,6 +601,7 @@ exports[`ApplicationList renders normally with all props 1`] = `
                 <a
                   class="internalLink brand"
                   href="#/applications/MOCK-APPLICATION-2"
+                  title="Matti Möttönen"
                 >
                   Matti Möttönen
                 </a>

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -37,7 +37,11 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColsChang
   const { t, i18n } = useTranslation();
   const columns: ColumnType[] = [
     {
-      Cell: ({ cell }) => <InternalLink to={`/customers/${cell.row.original.id}`}>{cell.value}</InternalLink>,
+      Cell: ({ cell }) => (
+        <InternalLink to={`/customers/${cell.row.original.id}`}>
+          {cell.value.localeCompare(' ') !== 0 ? cell.value : t('common.emptyName')}
+        </InternalLink>
+      ),
       Header: t('customerList.tableHeaders.name') || '',
       accessor: 'name',
       sortType: 'toString',

--- a/src/features/recurringInvoices/RecurringInvoices.tsx
+++ b/src/features/recurringInvoices/RecurringInvoices.tsx
@@ -45,7 +45,7 @@ const RecurringInvoices = ({
       minWidth: COLUMN_WIDTH.M,
       Cell: ({ row, cell }) => (
         <InternalLink className={styles.marginLeft} to={`/customers/${row.original.customerId}`}>
-          {cell.value}
+          {cell.value.localeCompare(' ') !== 0 ? cell.value : t('common.emptyName')}
         </InternalLink>
       ),
     },

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -25,6 +25,7 @@
     "close": "Sulje",
     "edit": "Muokkaa",
     "email": "Sähköposti",
+    "emptyName": "Nimi puuttuu",
     "firstName": "Etunimi",
     "imageAltText": "Kuva kohteesta",
     "lastName": "Sukunimi",
@@ -441,8 +442,7 @@
     },
     "berthDetails": {
       "previousLeases": "Edelliset vuokralaiset",
-      "noSuitableBerths": "Ei sopivaa venepaikkaa",
-      "emptyName": "Ei nimeä"
+      "noSuitableBerths": "Ei sopivaa venepaikkaa"
     },
     "invoicing": {
       "additionalServices": "Lisäpalvelut",


### PR DESCRIPTION
## Description :sparkles:

* Add empty name placeholders for applications, customers and recurring invoices

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1058](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1058): customers without name can't be accessed
