### PR TITLE
VEN-1061 | Add contract details to OpenInvoicesCard

### DIFF
--- a/src/features/customerView/__fixtures__/mockData.ts
+++ b/src/features/customerView/__fixtures__/mockData.ts
@@ -24,6 +24,7 @@ export const emptyMockProfile: CUSTOMER_PROFILE = {
 
 export const mockInvoices: (BerthInvoice | WinterStorageInvoice)[] = [
   {
+    leaseId: 'MOCK-LEASE-ID',
     orderNumber: 'MOCK-INVOICE',
     orderType: OrderOrderType.LEASE_ORDER,
     status: OrderStatus.WAITING,

--- a/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
+++ b/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
@@ -254,6 +254,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseN
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode {
   __typename: "BerthLeaseNode";
+  id: string;
   startDate: any;
   endDate: any;
   berth: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth;
@@ -308,6 +309,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStora
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode {
   __typename: "WinterStorageLeaseNode";
+  id: string;
   startDate: any;
   endDate: any;
   place: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_place | null;

--- a/src/features/customerView/leasesCard/LeasesCard.test.tsx
+++ b/src/features/customerView/leasesCard/LeasesCard.test.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
-import { Button } from 'hds-react';
+import { shallow } from 'enzyme';
 import { HashRouter } from 'react-router-dom';
 
 import LeasesCard, { LeasesCardProps } from './LeasesCard';
 
 describe('LeasesCard', () => {
   const initialProps: LeasesCardProps = {
-    handleShowContract: jest.fn(),
     title: 'title',
     infoSectionTitle: 'infoSectionTitle',
     addressLabel: 'addressLabel',

--- a/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
+++ b/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
@@ -13,6 +13,8 @@ import { formatDate, formatPrice } from '../../../common/utils/format';
 import Button from '../../../common/button/Button';
 import { Invoice } from '../types';
 import { PriceUnits, OrderStatus } from '../../../@types/__generated__/globalTypes';
+import BerthContractDetails from '../../contractDetails/BerthContractDetailsContainer';
+import WinterStorageContractDetails from '../../contractDetails/WinterStorageContractDetailsContainer';
 
 export interface OpenInvoicesCardProps {
   invoices: Invoice[];
@@ -90,6 +92,8 @@ const OpenInvoicesCard = ({ invoices, handleShowInvoice }: OpenInvoicesCardProps
             value={formatPrice(invoice.totalPrice, i18n.language)}
           />
         </Section>
+        {isBerthInvoice(invoice) && <BerthContractDetails leaseId={invoice.leaseId} />}
+        {isWinterStorageInvoice(invoice) && <WinterStorageContractDetails leaseId={invoice.leaseId} />}
         <Button variant="secondary" theme="coat" onClick={() => handleShowInvoice(invoice)} className={styles.button}>
           {t('customerView.customerInvoice.showInvoice')}
         </Button>

--- a/src/features/customerView/openInvoicesCard/__tests__/OpenInvoicesCard.test.tsx
+++ b/src/features/customerView/openInvoicesCard/__tests__/OpenInvoicesCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
+import { MockedProvider } from '@apollo/react-testing';
 
 import Button from '../../../../common/button/Button';
 import OpenInvoicesCard from '../OpenInvoicesCard';
@@ -14,7 +15,12 @@ describe('OpenInvoicesCard', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
-  const getWrapper = (props = mockProps) => shallow(<OpenInvoicesCard {...props} />);
+  const getWrapper = (props = mockProps) =>
+    mount(
+      <MockedProvider>
+        <OpenInvoicesCard {...props} />
+      </MockedProvider>
+    );
 
   it('renders normally', () => {
     const wrapper = getWrapper();

--- a/src/features/customerView/queries.ts
+++ b/src/features/customerView/queries.ts
@@ -147,6 +147,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             }
             lease {
               ... on BerthLeaseNode {
+                id
                 startDate
                 endDate
                 berth {
@@ -164,6 +165,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
                 }
               }
               ... on WinterStorageLeaseNode {
+                id
                 startDate
                 endDate
                 place {

--- a/src/features/customerView/types.ts
+++ b/src/features/customerView/types.ts
@@ -113,6 +113,7 @@ export type OrderLine = {
 };
 
 export type Invoice = {
+  leaseId: string;
   orderNumber?: string;
   orderType: OrderOrderType;
   status: OrderStatus;

--- a/src/features/customerView/utils.ts
+++ b/src/features/customerView/utils.ts
@@ -238,6 +238,7 @@ export const getInvoices = (profile: CUSTOMER_PROFILE): (BerthInvoice | WinterSt
           }, []);
         const { lease } = orderNode;
         const invoice = {
+          leaseId: lease.id,
           orderNumber: orderNode.orderNumber,
           orderType: orderNode.orderType,
           status: orderNode.status,


### PR DESCRIPTION
## Description :sparkles:

Adds contract details to open invoices.

### Closes :no_good_woman:

[VEN-1061](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1061)

## Testing :alembic:

### Automated tests :gear:️

Updated relevant tests.

### Manual testing :construction_worker_man:

- Open a customer's page that has open invoices. For example http://localhost:3000/customers/UHJvZmlsZU5vZGU6YTVmZjEzZGEtNDJmMS00ODdkLWFlNzMtMWJkOGNlNjZhYzU2 in staging.
- The open invoices should have contract info displayed.
