### PR TITLE
Add paidAt to invoice detail on CustomerView

### DIFF
--- a/src/features/customerView/__fixtures__/mockData.ts
+++ b/src/features/customerView/__fixtures__/mockData.ts
@@ -37,6 +37,7 @@ export const mockInvoices: (BerthInvoice | WinterStorageInvoice)[] = [
       endDate: '2020-09-14',
     },
     dueDate: '2020-07-10',
+    paidAt: '2020-07-01',
     basePrice: 96.67,
     totalPrice: 191.7,
     orderLines: [

--- a/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
+++ b/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
@@ -321,6 +321,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node {
   orderNumber: string;
   orderType: OrderOrderType;
   dueDate: any;
+  paidAt: any | null;
   totalPrice: any;
   price: any;
   status: OrderStatus;

--- a/src/features/customerView/invoiceModal/InvoiceModal.tsx
+++ b/src/features/customerView/invoiceModal/InvoiceModal.tsx
@@ -10,7 +10,7 @@ import { getOrderStatusTKey, getProductServiceTKey } from '../../../common/utils
 import Text from '../../../common/text/Text';
 import styles from './invoiceModal.module.scss';
 import { Invoice } from '../types';
-import { PriceUnits } from '../../../@types/__generated__/globalTypes';
+import { OrderStatus, PriceUnits } from '../../../@types/__generated__/globalTypes';
 import Button from '../../../common/button/Button';
 
 interface InvoiceModalProps extends Omit<ModalProps, 'children'> {
@@ -64,6 +64,12 @@ const InvoiceModal = ({ invoice, toggleModal, ...modalProps }: InvoiceModalProps
           label={t('customerView.customerInvoice.dueDate')}
           value={formatDate(invoice.dueDate, i18n.language)}
         />
+        {invoice.status === OrderStatus.PAID && (
+          <LabelValuePair
+            label={t('customerView.customerInvoice.paidAt')}
+            value={formatDate(invoice.paidAt, i18n.language)}
+          />
+        )}
         <LabelValuePair
           label={t('customerView.customerInvoice.status')}
           value={t(getOrderStatusTKey(invoice.status))}

--- a/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
+++ b/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
@@ -12,7 +12,7 @@ import { getInvoiceTypeKey, getProductServiceTKey } from '../../../common/utils/
 import { formatDate, formatPrice } from '../../../common/utils/format';
 import Button from '../../../common/button/Button';
 import { Invoice } from '../types';
-import { PriceUnits } from '../../../@types/__generated__/globalTypes';
+import { PriceUnits, OrderStatus } from '../../../@types/__generated__/globalTypes';
 
 export interface OpenInvoicesCardProps {
   invoices: Invoice[];
@@ -57,6 +57,12 @@ const OpenInvoicesCard = ({ invoices, handleShowInvoice }: OpenInvoicesCardProps
             label={t('customerView.customerInvoice.dueDate')}
             value={formatDate(invoice.dueDate, i18n.language)}
           />
+          {invoice.status === OrderStatus.PAID && (
+            <LabelValuePair
+              label={t('customerView.customerInvoice.paidAt')}
+              value={formatDate(invoice.paidAt, i18n.language)}
+            />
+          )}
         </Section>
         <Section className={styles.feesSection}>
           <LabelValuePair

--- a/src/features/customerView/queries.ts
+++ b/src/features/customerView/queries.ts
@@ -129,6 +129,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             orderNumber
             orderType
             dueDate
+            paidAt
             totalPrice
             price
             status

--- a/src/features/customerView/types.ts
+++ b/src/features/customerView/types.ts
@@ -121,6 +121,7 @@ export type Invoice = {
     endDate: string;
   };
   dueDate: string;
+  paidAt: string;
   totalPrice: number;
   basePrice: number;
   orderLines: OrderLine[];

--- a/src/features/customerView/utils.ts
+++ b/src/features/customerView/utils.ts
@@ -246,6 +246,7 @@ export const getInvoices = (profile: CUSTOMER_PROFILE): (BerthInvoice | WinterSt
             endDate: lease.endDate,
           },
           dueDate: orderNode.dueDate,
+          paidAt: orderNode.paidAt,
           basePrice: orderNode.price,
           totalPrice: orderNode.totalPrice,
           orderLines,

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -526,6 +526,7 @@
       "showInvoice": "Näytä lasku",
       "contractPeriod": "Sopimuskausi",
       "dueDate": "Eräpäivä",
+      "paidAt": "Maksettu",
       "noInvoice": "Ei avoimia laskuja",
       "invoiceType": "Laskun aihe",
       "status": "Laskun tila"
@@ -624,8 +625,8 @@
     "form": {
       "title": "Lähetä lasku",
       "description": "Seuraavan kauden laskut lähetetään asiakkaille joilla on voimassaoleva venepaikkasopimus edelliseltä kaudelta.",
-      "dueDate":"Laskun eräpäivä"
-    } 
+      "dueDate": "Laskun eräpäivä"
+    }
   },
   "customerProfile": {
     "title": "Asiakastiedot",


### PR DESCRIPTION
## Description :sparkles:
* Add the `paidAt` detail to the invoice modal when the order has been paid

### Related :handshake:
https://github.com/City-of-Helsinki/berth-reservations/pull/427

## Testing :alembic:
### Manual testing :construction_worker_man:
1. Go to a customer with invoices: http://localhost:3000/customers/UHJvZmlsZU5vZGU6YTVmZjEzZGEtNDJmMS00ODdkLWFlNzMtMWJkOGNlNjZhYzU2
2. On the `Laskuhistoria` section, click the invoice detail for a paid order, it will open the modal and show a new row: `Maksettu: 19.11.2020`
3. If you open an invoice which hasn't been paid, it won't show it

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/15201480/102983227-6de02280-4514-11eb-8b4f-c1646f4a5c4a.png)
