### PR TITLE
VEN-949, VEN-1066 | Resend invoice that has been already sent

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,8 +57,8 @@
       {
         "code": 120,
         "ignorePattern":
-          "d=\"([\\s\\S]*?)\"|^import\\W.*"
-
+          "d=\"([\\s\\S]*?)\"|^import\\W.*",
+        "ignoreStrings": true
       }
     ],
     "no-console": "warn",

--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -402,6 +402,13 @@ export interface RejectBerthApplicationMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface ResendOrderMutationInput {
+  orderId: string;
+  dueDate: any;
+  profileToken: string;
+  clientMutationId?: string | null;
+}
+
 export interface SendExistingBerthInvoicesMutationInput {
   dueDate?: any | null;
   profileToken: string;

--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -403,9 +403,9 @@ export interface RejectBerthApplicationMutationInput {
 }
 
 export interface ResendOrderMutationInput {
-  orderId: string;
-  dueDate: any;
-  profileToken: string;
+  orders?: string[] | null;
+  dueDate?: any | null;
+  profileToken?: string | null;
   clientMutationId?: string | null;
 }
 

--- a/src/common/invoiceInstructions/InvoiceInstructions.tsx
+++ b/src/common/invoiceInstructions/InvoiceInstructions.tsx
@@ -5,19 +5,22 @@ import styles from '../../features/invoiceCard/sendInvoiceForm/sendInvoiceForm.m
 
 interface Props {
   email?: string | null;
+  isResend?: boolean;
 }
 
-export const InvoiceInstructions = ({ email }: Props) => {
+export const InvoiceInstructions = ({ email, isResend }: Props) => {
   const { t } = useTranslation();
 
   return (
     <>
       <p className={styles.instructions}>
-        {t('invoiceInstructions.paragraph1', {
+        {t(isResend ? 'invoiceInstructions.resendParagraph1' : 'invoiceInstructions.paragraph1', {
           email: email,
         })}
       </p>
-      <p className={styles.instructions}>{t('invoiceInstructions.paragraph2')}</p>
+      <p className={styles.instructions}>
+        {t(isResend ? 'invoiceInstructions.resendParagraph2' : 'invoiceInstructions.paragraph2')}
+      </p>
     </>
   );
 };

--- a/src/common/mutations/__generated__/RESEND_ORDER.ts
+++ b/src/common/mutations/__generated__/RESEND_ORDER.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ResendOrderMutationInput } from "./../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: RESEND_ORDER
+// ====================================================
+
+export interface RESEND_ORDER_resendOrder {
+  __typename: "ResendOrderMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface RESEND_ORDER {
+  resendOrder: RESEND_ORDER_resendOrder | null;
+}
+
+export interface RESEND_ORDERVariables {
+  input: ResendOrderMutationInput;
+}

--- a/src/common/mutations/resendOrder.ts
+++ b/src/common/mutations/resendOrder.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag';
+
+export const RESEND_ORDER_MUTATION = gql`
+  mutation RESEND_ORDER($input: ResendOrderMutationInput!) {
+    resendOrder(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/features/applicationList/ApplicationList.tsx
+++ b/src/features/applicationList/ApplicationList.tsx
@@ -9,7 +9,7 @@ import ApplicationDetails from '../../common/applicationDetails/ApplicationDetai
 import TableFilters from '../../common/tableFilters/TableFilters';
 import Pagination from '../../common/pagination/Pagination';
 import Table, { Column, COLUMN_WIDTH } from '../../common/table/Table';
-import { ApplicationData, getDraftedOffers } from './utils';
+import { ApplicationData, getDraftedOffers, getSentOffers } from './utils';
 import { BERTH_APPLICATIONS } from './__generated__/BERTH_APPLICATIONS';
 import InternalLink from '../../common/internalLink/InternalLink';
 import { formatDate } from '../../common/utils/format';
@@ -45,7 +45,7 @@ export interface ApplicationListProps {
   sortBy: SortingRule<ApplicationData>[];
   statusFilter?: ApplicationStatus;
   tableData: ApplicationData[];
-  handleApproveOrders(orders: Order[]): Promise<void>;
+  handleSendOffers(draftedOffers: Order[], sentOffers: Order[], dueDate: string): Promise<void>;
   onNameFilterChange(nameFilter: string | undefined): void;
   onStatusFilterChange(statusFilter?: ApplicationStatus): void;
 }
@@ -62,7 +62,7 @@ const ApplicationList = ({
   data,
   getPageCount,
   goToPage,
-  handleApproveOrders,
+  handleSendOffers,
   handleDeleteLease,
   handleNoPlacesAvailable,
   isDeleting,
@@ -226,7 +226,8 @@ const ApplicationList = ({
                       clearSelectedRows={resetSelectedRows}
                       filterUnhandledApplications={(row) => !row.lease}
                       getDraftedOffers={getDraftedOffers}
-                      handleApproveOffers={handleApproveOrders}
+                      getSentOffers={getSentOffers}
+                      handleSendOffers={handleSendOffers}
                       isSubmitting={isSubmittingApproveOrders}
                       selectedRows={selectedRows}
                     />

--- a/src/features/applicationList/utils.ts
+++ b/src/features/applicationList/utils.ts
@@ -158,3 +158,17 @@ export const getDraftedOffers = (applications: ApplicationData[]) =>
       },
     ];
   }, []);
+
+export const getSentOffers = (applications: ApplicationData[]) =>
+  applications.reduce<Offer[]>((acc, application) => {
+    if (application.status !== ApplicationStatus.OFFER_SENT || !application.lease?.orderId || !application.email)
+      return acc;
+
+    return [
+      ...acc,
+      {
+        orderId: application.lease.orderId,
+        email: application.email,
+      },
+    ];
+  }, []);

--- a/src/features/applicationListTools/SendOffersListTool.tsx
+++ b/src/features/applicationListTools/SendOffersListTool.tsx
@@ -15,14 +15,16 @@ export interface SendOffersListToolProps<A, O> {
   clearSelectedRows(): void;
   filterUnhandledApplications(offer: A): boolean;
   getDraftedOffers(rows: A[]): O[];
-  handleApproveOffers(offers: O[]): void;
+  getSentOffers(rows: A[]): O[];
+  handleSendOffers(draftedOffers: O[], sentOffers: O[], date: string): void;
 }
 
 const SendOffersListTool = <A, O>({
   clearSelectedRows,
   filterUnhandledApplications,
   getDraftedOffers,
-  handleApproveOffers,
+  getSentOffers,
+  handleSendOffers,
   isSubmitting,
   selectedRows,
 }: SendOffersListToolProps<A, O>) => {
@@ -30,7 +32,8 @@ const SendOffersListTool = <A, O>({
   const [sendInvoiceModalOpen, setSendInvoiceModalOpen] = useState(false);
   const toastId = 'multiApplicationsError';
 
-  const offers = getDraftedOffers(selectedRows);
+  const draftedOffers = getDraftedOffers(selectedRows);
+  const sentOffers = getSentOffers(selectedRows);
   const unhandledApplicationsCount = selectedRows.filter(filterUnhandledApplications).length;
   const noSelection = selectedRows.length === 0;
 
@@ -50,8 +53,8 @@ const SendOffersListTool = <A, O>({
     setSendInvoiceModalOpen(true);
   };
 
-  const handleSubmit = () => {
-    handleApproveOffers(offers);
+  const handleSubmit = (values: { dueDate: string }) => {
+    handleSendOffers(draftedOffers, sentOffers, values.dueDate);
     clearSelectedRows();
     setSendInvoiceModalOpen(false);
   };
@@ -71,7 +74,8 @@ const SendOffersListTool = <A, O>({
       </div>
       <Modal isOpen={sendInvoiceModalOpen} toggleModal={() => setSendInvoiceModalOpen(false)}>
         <SendMultiOffersForm
-          offersCount={offers.length}
+          sentOffersCount={sentOffers.length}
+          draftedOffersCount={draftedOffers.length}
           onSubmit={handleSubmit}
           onCancel={() => setSendInvoiceModalOpen(false)}
           isSubmitting={isSubmitting}

--- a/src/features/applicationListTools/__tests__/SendOffersListTool.test.tsx
+++ b/src/features/applicationListTools/__tests__/SendOffersListTool.test.tsx
@@ -25,7 +25,8 @@ describe('SendOffersListTool', () => {
           orderId: String(i),
         };
       }),
-    handleApproveOffers: jest.fn(),
+    getSentOffers: () => [],
+    handleSendOffers: jest.fn(),
     isSubmitting: false,
     selectedRows: [
       { id: 'UNO', leaseId: 'EINS' },

--- a/src/features/customerView/CustomerView.tsx
+++ b/src/features/customerView/CustomerView.tsx
@@ -28,6 +28,7 @@ export interface CustomerViewProps {
   openInvoices: Invoice[];
   setBoatToEdit: (boat: Boat | null) => void;
   setOpenInvoice: (invoice: Invoice | undefined) => void;
+  setOpenResendInvoice: (invoice: Invoice | undefined) => void;
 }
 
 const CustomerView = ({
@@ -43,6 +44,7 @@ const CustomerView = ({
   openInvoices,
   setBoatToEdit,
   setOpenInvoice,
+  setOpenResendInvoice,
 }: CustomerViewProps) => {
   const { t } = useTranslation();
   return (
@@ -55,7 +57,11 @@ const CustomerView = ({
 
         <ApplicationsCard applications={applications} handleNoPlacesAvailable={handleNoPlacesAvailable} />
 
-        <OpenInvoicesCard invoices={openInvoices} handleShowInvoice={(invoice) => setOpenInvoice(invoice)} />
+        <OpenInvoicesCard
+          invoices={openInvoices}
+          handleShowInvoice={(invoice) => setOpenInvoice(invoice)}
+          handleResendInvoice={(invoice) => setOpenResendInvoice(invoice)}
+        />
 
         <InvoicingHistoryCard
           invoices={invoices}

--- a/src/features/customerView/CustomerView.tsx
+++ b/src/features/customerView/CustomerView.tsx
@@ -59,8 +59,8 @@ const CustomerView = ({
 
         <OpenInvoicesCard
           invoices={openInvoices}
-          handleShowInvoice={(invoice) => setOpenInvoice(invoice)}
-          handleResendInvoice={(invoice) => setOpenResendInvoice(invoice)}
+          handleShowInvoice={setOpenInvoice}
+          handleResendInvoice={setOpenResendInvoice}
         />
 
         <InvoicingHistoryCard

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -31,6 +31,7 @@ import {
 import { REJECT_BERTH_APPLICATION_MUTATION } from '../applicationView/mutations';
 import { BERTH_APPLICATIONS_QUERY } from '../applicationList/queries';
 import CreateAdditionalInvoiceContainer from '../createAdditionalInvoice/CreateAdditionalInvoiceContainer';
+import SendInvoiceFormContainer from '../invoiceCard/sendInvoiceForm/SendInvoiceFormContainer';
 
 const CustomerViewContainer = () => {
   const [boatToEdit, setBoatToEdit] = useState<Boat | null>();
@@ -38,9 +39,10 @@ const CustomerViewContainer = () => {
   const [creatingBoat, setCreatingBoat] = useState<boolean>(false);
   const [creatingAdditionalInvoice, setCreatingAdditionalInvoice] = useState<boolean>(false);
   const [openInvoice, setOpenInvoice] = useState<Invoice>();
+  const [openResendInvoice, setOpenResendInvoice] = useState<Invoice>();
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
-  const { loading, data } = useQuery<INDIVIDUAL_CUSTOMER>(INDIVIDUAL_CUSTOMER_QUERY, {
+  const { loading, data, refetch } = useQuery<INDIVIDUAL_CUSTOMER>(INDIVIDUAL_CUSTOMER_QUERY, {
     variables: { id },
     fetchPolicy: 'no-cache',
   });
@@ -96,6 +98,7 @@ const CustomerViewContainer = () => {
         openInvoices={openInvoices}
         setBoatToEdit={setBoatToEdit}
         setOpenInvoice={setOpenInvoice}
+        setOpenResendInvoice={setOpenResendInvoice}
       />
 
       <Modal isOpen={editCustomer} toggleModal={() => setEditCustomer(false)}>
@@ -141,6 +144,20 @@ const CustomerViewContainer = () => {
           berthLeases={berthLeases as BerthLease[]}
           closeModal={() => setCreatingAdditionalInvoice(false)}
           refetchQueries={[{ query: INDIVIDUAL_CUSTOMER_QUERY, variables: { id } }]}
+        />
+      </Modal>
+
+      <Modal isOpen={!!openResendInvoice} toggleModal={() => setOpenResendInvoice(undefined)}>
+        <SendInvoiceFormContainer
+          orderId={openResendInvoice?.orderId ?? ''}
+          email={'aleksi@identio.fi'}
+          isResend={true}
+          refetchQueries={[]}
+          onCancel={() => setOpenResendInvoice(undefined)}
+          onSubmit={() => {
+            refetch();
+            setOpenResendInvoice(undefined);
+          }}
         />
       </Modal>
 

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -34,14 +34,16 @@ import CreateAdditionalInvoiceContainer from '../createAdditionalInvoice/CreateA
 import SendInvoiceFormContainer from '../invoiceCard/sendInvoiceForm/SendInvoiceFormContainer';
 
 const CustomerViewContainer = () => {
+  const { t } = useTranslation();
+  const { id } = useParams<{ id: string }>();
+
   const [boatToEdit, setBoatToEdit] = useState<Boat | null>();
   const [editCustomer, setEditCustomer] = useState<boolean>(false);
   const [creatingBoat, setCreatingBoat] = useState<boolean>(false);
   const [creatingAdditionalInvoice, setCreatingAdditionalInvoice] = useState<boolean>(false);
   const [openInvoice, setOpenInvoice] = useState<Invoice>();
   const [openResendInvoice, setOpenResendInvoice] = useState<Invoice>();
-  const { t } = useTranslation();
-  const { id } = useParams<{ id: string }>();
+
   const { loading, data, refetch } = useQuery<INDIVIDUAL_CUSTOMER>(INDIVIDUAL_CUSTOMER_QUERY, {
     variables: { id },
     fetchPolicy: 'no-cache',
@@ -105,8 +107,11 @@ const CustomerViewContainer = () => {
         <EditCustomerForm
           customerId={id}
           onCancel={() => setEditCustomer(false)}
-          onSubmit={() => setEditCustomer(false)}
-          refetchQueries={[{ query: INDIVIDUAL_CUSTOMER_QUERY, variables: { id } }]}
+          onSubmit={() => {
+            refetch();
+            setEditCustomer(false);
+          }}
+          refetchQueries={[]}
         />
       </Modal>
 
@@ -116,9 +121,15 @@ const CustomerViewContainer = () => {
             boatTypes={boatTypes}
             initialValues={boatToEdit}
             onCancel={() => setBoatToEdit(null)}
-            onDelete={() => setBoatToEdit(null)}
-            onSubmit={() => setBoatToEdit(null)}
-            refetchQueries={[{ query: INDIVIDUAL_CUSTOMER_QUERY, variables: { id } }]}
+            onDelete={() => {
+              refetch();
+              setBoatToEdit(null);
+            }}
+            onSubmit={() => {
+              refetch();
+              setBoatToEdit(null);
+            }}
+            refetchQueries={[]}
           />
         </Modal>
       )}
@@ -128,8 +139,11 @@ const CustomerViewContainer = () => {
           ownerId={data.profile.id}
           boatTypes={boatTypes}
           onCancel={() => setCreatingBoat(false)}
-          onSubmit={() => setCreatingBoat(false)}
-          refetchQueries={[{ query: INDIVIDUAL_CUSTOMER_QUERY, variables: { id } }]}
+          onSubmit={() => {
+            refetch();
+            setCreatingBoat(false);
+          }}
+          refetchQueries={[]}
         />
       </Modal>
 
@@ -142,8 +156,11 @@ const CustomerViewContainer = () => {
           customerId={id}
           email={customerProfile.primaryEmail}
           berthLeases={berthLeases as BerthLease[]}
-          closeModal={() => setCreatingAdditionalInvoice(false)}
-          refetchQueries={[{ query: INDIVIDUAL_CUSTOMER_QUERY, variables: { id } }]}
+          closeModal={() => {
+            refetch();
+            setCreatingAdditionalInvoice(false);
+          }}
+          refetchQueries={[]}
         />
       </Modal>
 

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -150,7 +150,7 @@ const CustomerViewContainer = () => {
       <Modal isOpen={!!openResendInvoice} toggleModal={() => setOpenResendInvoice(undefined)}>
         <SendInvoiceFormContainer
           orderId={openResendInvoice?.orderId ?? ''}
-          email={'aleksi@identio.fi'}
+          email={customerProfile?.primaryEmail ?? ''}
           isResend={true}
           refetchQueries={[]}
           onCancel={() => setOpenResendInvoice(undefined)}

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -167,7 +167,7 @@ const CustomerViewContainer = () => {
       <Modal isOpen={!!openResendInvoice} toggleModal={() => setOpenResendInvoice(undefined)}>
         <SendInvoiceFormContainer
           orderId={openResendInvoice?.orderId ?? ''}
-          email={customerProfile?.primaryEmail ?? ''}
+          email={customerProfile.primaryEmail ?? null}
           isResend={true}
           refetchQueries={[]}
           onCancel={() => setOpenResendInvoice(undefined)}

--- a/src/features/customerView/__fixtures__/mockData.ts
+++ b/src/features/customerView/__fixtures__/mockData.ts
@@ -25,6 +25,7 @@ export const emptyMockProfile: CUSTOMER_PROFILE = {
 export const mockInvoices: (BerthInvoice | WinterStorageInvoice)[] = [
   {
     leaseId: 'MOCK-LEASE-ID',
+    orderId: 'MOCK-ORDER-ID',
     orderNumber: 'MOCK-INVOICE',
     orderType: OrderOrderType.LEASE_ORDER,
     status: OrderStatus.WAITING,

--- a/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
+++ b/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
@@ -320,6 +320,7 @@ export type INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease = INDIVIDUAL_CUS
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node {
   __typename: "OrderNode";
+  id: string;
   orderNumber: string;
   orderType: OrderOrderType;
   dueDate: any;

--- a/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
+++ b/src/features/customerView/__generated__/INDIVIDUAL_CUSTOMER.ts
@@ -47,6 +47,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_boats_edges_node_boatType {
 
 export interface INDIVIDUAL_CUSTOMER_profile_boats_edges_node_certificates {
   __typename: "BoatCertificateNode";
+  id: string;
   file: string | null;
   certificateType: BoatCertificateType;
   validUntil: any | null;
@@ -100,11 +101,13 @@ export interface INDIVIDUAL_CUSTOMER_profile_berthLeases_edges_node_berth_pier_p
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthLeases_edges_node_berth_pier {
   __typename: "PierNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_berthLeases_edges_node_berth_pier_properties | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthLeases_edges_node_berth {
   __typename: "BerthNode";
+  id: string;
   number: string;
   length: number;
   width: number;
@@ -152,11 +155,13 @@ export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_plac
 
 export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_place_winterStorageSection {
   __typename: "WinterStorageSectionNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_place_winterStorageSection_properties | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_place {
   __typename: "WinterStoragePlaceNode";
+  id: string;
   number: number;
   winterStorageSection: INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_place_winterStorageSection;
 }
@@ -179,6 +184,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_sect
 
 export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_section {
   __typename: "WinterStorageSectionNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_winterStorageLeases_edges_node_section_properties | null;
 }
 
@@ -204,6 +210,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_winterStorageLeases {
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_orderLines_edges_node_product {
   __typename: "AdditionalProductNode";
+  id: string;
   service: ProductServiceType;
   priceUnit: PriceUnits;
   priceValue: any;
@@ -211,6 +218,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_orderLines_edges_
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_orderLines_edges_node {
   __typename: "OrderLineNode";
+  id: string;
   product: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_orderLines_edges_node_product | null;
   price: any;
 }
@@ -232,6 +240,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseN
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth_pier_properties_harbor {
   __typename: "HarborNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth_pier_properties_harbor_properties | null;
 }
 
@@ -243,11 +252,13 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseN
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth_pier {
   __typename: "PierNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth_pier_properties | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth {
   __typename: "BerthNode";
+  id: string;
   number: string;
   pier: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_BerthLeaseNode_berth_pier;
 }
@@ -278,11 +289,13 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStora
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_place_winterStorageSection {
   __typename: "WinterStorageSectionNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_place_winterStorageSection_properties | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_place {
   __typename: "WinterStoragePlaceNode";
+  id: string;
   winterStorageSection: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_place_winterStorageSection;
 }
 
@@ -304,6 +317,7 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStora
 
 export interface INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_section {
   __typename: "WinterStorageSectionNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_orders_edges_node_lease_WinterStorageLeaseNode_section_properties | null;
 }
 
@@ -344,15 +358,16 @@ export interface INDIVIDUAL_CUSTOMER_profile_orders {
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_berthSwitch_reason {
   __typename: "BerthSwitchReasonType";
+  id: string;
   title: string | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_berthSwitch {
   __typename: "BerthSwitchType";
+  id: string;
   berthNumber: string;
   harbor: string;
   harborName: string;
-  id: string;
   pier: string;
   reason: INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_berthSwitch_reason | null;
 }
@@ -376,11 +391,13 @@ export interface INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_lease_
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_lease_berth_pier {
   __typename: "PierNode";
+  id: string;
   properties: INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_lease_berth_pier_properties | null;
 }
 
 export interface INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_lease_berth {
   __typename: "BerthNode";
+  id: string;
   number: string;
   pier: INDIVIDUAL_CUSTOMER_profile_berthApplications_edges_node_lease_berth_pier;
 }
@@ -430,11 +447,11 @@ export interface INDIVIDUAL_CUSTOMER_profile_berthApplications {
 
 export interface INDIVIDUAL_CUSTOMER_profile {
   __typename: "ProfileNode";
+  id: string;
   comment: string | null;
   firstName: string;
   invoicingType: InvoicingType | null;
   lastName: string;
-  id: string;
   customerGroup: CustomerGroup | null;
   organization: INDIVIDUAL_CUSTOMER_profile_organization | null;
   primaryAddress: INDIVIDUAL_CUSTOMER_profile_primaryAddress | null;

--- a/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
+++ b/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
@@ -19,9 +19,10 @@ import WinterStorageContractDetails from '../../contractDetails/WinterStorageCon
 export interface OpenInvoicesCardProps {
   invoices: Invoice[];
   handleShowInvoice(invoice: Invoice): void;
+  handleResendInvoice(invoice: Invoice): void;
 }
 
-const OpenInvoicesCard = ({ invoices, handleShowInvoice }: OpenInvoicesCardProps) => {
+const OpenInvoicesCard = ({ invoices, handleShowInvoice, handleResendInvoice }: OpenInvoicesCardProps) => {
   const { t, i18n } = useTranslation();
 
   const renderInvoice = (invoice: Invoice, id: number) => {
@@ -94,9 +95,14 @@ const OpenInvoicesCard = ({ invoices, handleShowInvoice }: OpenInvoicesCardProps
         </Section>
         {isBerthInvoice(invoice) && <BerthContractDetails leaseId={invoice.leaseId} />}
         {isWinterStorageInvoice(invoice) && <WinterStorageContractDetails leaseId={invoice.leaseId} />}
-        <Button variant="secondary" theme="coat" onClick={() => handleShowInvoice(invoice)} className={styles.button}>
-          {t('customerView.customerInvoice.showInvoice')}
-        </Button>
+        <div className={styles.buttons}>
+          <Button variant="secondary" theme="coat" onClick={() => handleShowInvoice(invoice)} className={styles.button}>
+            {t('customerView.customerInvoice.showInvoice')}
+          </Button>
+          <Button variant="primary" theme="coat" onClick={() => handleResendInvoice(invoice)} className={styles.button}>
+            {t('customerView.customerInvoice.resendInvoice')}
+          </Button>
+        </div>
       </CardBody>
     );
   };

--- a/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
+++ b/src/features/customerView/openInvoicesCard/OpenInvoicesCard.tsx
@@ -96,10 +96,10 @@ const OpenInvoicesCard = ({ invoices, handleShowInvoice, handleResendInvoice }: 
         {isBerthInvoice(invoice) && <BerthContractDetails leaseId={invoice.leaseId} />}
         {isWinterStorageInvoice(invoice) && <WinterStorageContractDetails leaseId={invoice.leaseId} />}
         <div className={styles.buttons}>
-          <Button variant="secondary" theme="coat" onClick={() => handleShowInvoice(invoice)} className={styles.button}>
+          <Button variant="secondary" onClick={() => handleShowInvoice(invoice)} className={styles.button}>
             {t('customerView.customerInvoice.showInvoice')}
           </Button>
-          <Button variant="primary" theme="coat" onClick={() => handleResendInvoice(invoice)} className={styles.button}>
+          <Button variant="primary" onClick={() => handleResendInvoice(invoice)} className={styles.button}>
             {t('customerView.customerInvoice.resendInvoice')}
           </Button>
         </div>

--- a/src/features/customerView/openInvoicesCard/__tests__/OpenInvoicesCard.test.tsx
+++ b/src/features/customerView/openInvoicesCard/__tests__/OpenInvoicesCard.test.tsx
@@ -3,18 +3,20 @@ import { mount } from 'enzyme';
 import { MockedProvider } from '@apollo/react-testing';
 
 import Button from '../../../../common/button/Button';
-import OpenInvoicesCard from '../OpenInvoicesCard';
+import OpenInvoicesCard, { OpenInvoicesCardProps } from '../OpenInvoicesCard';
 import { mockInvoices } from '../../__fixtures__/mockData';
 
-const mockProps = {
+const mockProps: OpenInvoicesCardProps = {
   invoices: mockInvoices,
   handleShowInvoice: jest.fn(),
+  handleResendInvoice: jest.fn(),
 };
 
 describe('OpenInvoicesCard', () => {
   beforeEach(() => {
     jest.resetAllMocks();
   });
+
   const getWrapper = (props = mockProps) =>
     mount(
       <MockedProvider>
@@ -30,8 +32,15 @@ describe('OpenInvoicesCard', () => {
 
   it('invokes handleShowInvoice method when the user clicks on the Show Invoice button', () => {
     const wrapper = getWrapper();
-    wrapper.find(Button).simulate('click');
+    wrapper.find(Button).at(0).simulate('click');
 
     expect(mockProps.handleShowInvoice).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes handleShowInvoice method when the user clicks on the Resend Invoice button', () => {
+    const wrapper = getWrapper();
+    wrapper.find(Button).at(1).simulate('click');
+
+    expect(mockProps.handleResendInvoice).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/customerView/openInvoicesCard/__tests__/__snapshots__/OpenInvoicesCard.test.tsx.snap
+++ b/src/features/customerView/openInvoicesCard/__tests__/__snapshots__/OpenInvoicesCard.test.tsx.snap
@@ -129,16 +129,30 @@ exports[`OpenInvoicesCard renders normally 1`] = `
         </div>
       </section>
     </article>
-    <button
-      class="Button-module_button__3wgee button_hds-button__2A0je Button-module_secondary__399Vd button_hds-button--secondary__1NOWS Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 button"
-      type="button"
+    <div
+      class="buttons"
     >
-      <span
-        class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
+      <button
+        class="Button-module_button__3wgee button_hds-button__2A0je Button-module_secondary__399Vd button_hds-button--secondary__1NOWS Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 button"
+        type="button"
       >
-        Näytä lasku
-      </span>
-    </button>
+        <span
+          class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
+        >
+          Näytä lasku
+        </span>
+      </button>
+      <button
+        class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0 button"
+        type="button"
+      >
+        <span
+          class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
+        >
+          Lähetä lasku uudelleen
+        </span>
+      </button>
+    </div>
   </div>
    
 </div>

--- a/src/features/customerView/openInvoicesCard/openInvoicesCard.module.scss
+++ b/src/features/customerView/openInvoicesCard/openInvoicesCard.module.scss
@@ -11,3 +11,8 @@
 .gridItem {
   margin-bottom: units(1.5);
 }
+
+.buttons {
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/features/customerView/queries.ts
+++ b/src/features/customerView/queries.ts
@@ -3,11 +3,11 @@ import gql from 'graphql-tag';
 export const INDIVIDUAL_CUSTOMER_QUERY = gql`
   query INDIVIDUAL_CUSTOMER($id: ID!) {
     profile(id: $id, serviceType: BERTH) {
+      id
       comment
       firstName
       invoicingType
       lastName
-      id
       customerGroup
       organization {
         id
@@ -51,6 +51,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             hullMaterial
             intendedUse
             certificates {
+              id
               file
               certificateType
               validUntil
@@ -69,12 +70,14 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             endDate
             isActive
             berth {
+              id
               number
               length
               width
               depth
               mooringType
               pier {
+                id
                 properties {
                   identifier
                   harbor {
@@ -97,8 +100,10 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             startDate
             endDate
             place {
+              id
               number
               winterStorageSection {
+                id
                 properties {
                   identifier
                   area {
@@ -111,6 +116,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
               }
             }
             section {
+              id
               properties {
                 area {
                   id
@@ -137,7 +143,9 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
             orderLines {
               edges {
                 node {
+                  id
                   product {
+                    id
                     service
                     priceUnit
                     priceValue
@@ -152,11 +160,14 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
                 startDate
                 endDate
                 berth {
+                  id
                   number
                   pier {
+                    id
                     properties {
                       identifier
                       harbor {
+                        id
                         properties {
                           name
                         }
@@ -170,7 +181,9 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
                 startDate
                 endDate
                 place {
+                  id
                   winterStorageSection {
+                    id
                     properties {
                       area {
                         id
@@ -182,6 +195,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
                   }
                 }
                 section {
+                  id
                   properties {
                     area {
                       id
@@ -201,12 +215,13 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
           node {
             id
             berthSwitch {
+              id
               berthNumber
               harbor
               harborName
-              id
               pier
               reason {
+                id
                 title
               }
             }
@@ -216,8 +231,10 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
               id
               status
               berth {
+                id
                 number
                 pier {
+                  id
                   properties {
                     identifier
                     harbor {

--- a/src/features/customerView/queries.ts
+++ b/src/features/customerView/queries.ts
@@ -126,6 +126,7 @@ export const INDIVIDUAL_CUSTOMER_QUERY = gql`
       orders {
         edges {
           node {
+            id
             orderNumber
             orderType
             dueDate

--- a/src/features/customerView/types.ts
+++ b/src/features/customerView/types.ts
@@ -115,6 +115,7 @@ export type OrderLine = {
 export type Invoice = {
   leaseId: string;
   orderNumber?: string;
+  orderId: string;
   orderType: OrderOrderType;
   status: OrderStatus;
   contractPeriod: {

--- a/src/features/customerView/utils.ts
+++ b/src/features/customerView/utils.ts
@@ -239,6 +239,7 @@ export const getInvoices = (profile: CUSTOMER_PROFILE): (BerthInvoice | WinterSt
         const { lease } = orderNode;
         const invoice = {
           leaseId: lease.id,
+          orderId: orderNode.id,
           orderNumber: orderNode.orderNumber,
           orderType: orderNode.orderType,
           status: orderNode.status,

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -72,7 +72,7 @@ const InvoiceCard = ({
       return null;
     }
     return (
-      <Button theme="coat" onClick={sendInvoice} disabled={order === null}>
+      <Button onClick={sendInvoice} disabled={order === null}>
         {applicationStatus === ApplicationStatus.OFFER_GENERATED
           ? sendButtonLabel ?? t('invoiceCard.sendInvoice.title')
           : t('invoiceCard.resendInvoice')}

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -72,14 +72,10 @@ const InvoiceCard = ({
       return null;
     }
     return (
-      <Button
-        theme="coat"
-        onClick={sendInvoice}
-        disabled={order === null || applicationStatus !== ApplicationStatus.OFFER_GENERATED}
-      >
+      <Button theme="coat" onClick={sendInvoice} disabled={order === null}>
         {applicationStatus === ApplicationStatus.OFFER_GENERATED
           ? sendButtonLabel ?? t('invoiceCard.sendInvoice.title')
-          : t('invoiceCard.invoiceSent')}
+          : t('invoiceCard.resendInvoice')}
       </Button>
     );
   };

--- a/src/features/invoiceCard/InvoiceCardContainer.tsx
+++ b/src/features/invoiceCard/InvoiceCardContainer.tsx
@@ -6,6 +6,7 @@ import SendInvoiceForm from './sendInvoiceForm/SendInvoiceFormContainer';
 import EditForm from './editForm/EditForm';
 import InvoiceCard, { InvoiceCardProps } from './InvoiceCard';
 import { SelectedProduct } from './types';
+import { LeaseStatus } from '../../@types/__generated__/globalTypes';
 
 export interface InvoiceCardContainerProps extends Omit<InvoiceCardProps, 'sendInvoice' | 'editAdditionalServices'> {
   customerEmail: string | null;
@@ -40,6 +41,7 @@ const InvoiceCardContainer = ({
           <Modal isOpen={sendInvoiceModalOpen} toggleModal={() => setSendInvoiceModalOpen(false)}>
             <SendInvoiceForm
               orderId={order.id}
+              isResend={invoiceCardProps.leaseStatus === LeaseStatus.OFFERED}
               email={customerEmail}
               refetchQueries={refetchQueries}
               onSubmit={() => setSendInvoiceModalOpen(false)}

--- a/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
+++ b/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
@@ -50,11 +50,11 @@ describe('InvoiceCard', () => {
       expect(sendButton.props().disabled).toBeFalsy();
     });
 
-    it('is displayed but disabled when application status is "sent"', () => {
+    it('is displayed but with a different text when application status is "sent"', () => {
       const wrapper = getWrapper({ ...defaultProps, applicationStatus: ApplicationStatus.OFFER_SENT });
       const sendButton = findSendButton(wrapper);
       expect(sendButton.length).toBe(1);
-      expect(sendButton.props().disabled).toBeTruthy();
+      expect(sendButton.text()).toEqual('Lähetä tarjous uudelleen');
     });
 
     it('calls sendInvoice on click', () => {

--- a/src/features/invoiceCard/sendInvoiceForm/SendInvoiceForm.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/SendInvoiceForm.tsx
@@ -18,11 +18,12 @@ type FormValues = {
 export type SendInvoiceFormProps = {
   email: string | null;
   isSubmitting: boolean;
+  isResend?: boolean;
   onCancel: () => void;
   onSubmit: (data: FormValues) => void;
 };
 
-const SendInvoiceForm = ({ email, onSubmit, onCancel, isSubmitting }: SendInvoiceFormProps) => {
+const SendInvoiceForm = ({ email, onSubmit, onCancel, isSubmitting, isResend }: SendInvoiceFormProps) => {
   const { t } = useTranslation();
 
   const validationSchema = useMemo(() => {
@@ -45,9 +46,11 @@ const SendInvoiceForm = ({ email, onSubmit, onCancel, isSubmitting }: SendInvoic
     >
       {({ values, errors, handleChange }) => (
         <Form className={styles.form}>
-          <FormHeader title={t('invoiceCard.sendInvoice.title').toUpperCase()} />
+          <FormHeader
+            title={t(isResend ? 'invoiceCard.sendInvoice.resendTitle' : 'invoiceCard.sendInvoice.title').toUpperCase()}
+          />
 
-          <InvoiceInstructions email={email} />
+          <InvoiceInstructions email={email} isResend={isResend} />
 
           <div className={styles.dueDate}>
             <TextInput

--- a/src/features/invoiceCard/sendInvoiceForm/SendInvoiceFormContainer.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/SendInvoiceFormContainer.tsx
@@ -56,7 +56,7 @@ const SendInvoiceFormContainer = ({
           input: {
             dueDate: values.dueDate,
             profileToken: getProfileToken(),
-            orderId,
+            orders: [orderId],
           },
         },
       }).then((res) => {

--- a/src/features/invoiceCard/sendInvoiceForm/SendInvoiceFormContainer.tsx
+++ b/src/features/invoiceCard/sendInvoiceForm/SendInvoiceFormContainer.tsx
@@ -10,11 +10,17 @@ import {
   APPROVE_ORDERSVariables as APPROVE_ORDERS_VARS,
 } from '../../../common/mutations/__generated__/APPROVE_ORDERS';
 import { getProfileToken } from '../../../common/utils/auth';
+import {
+  RESEND_ORDER,
+  RESEND_ORDERVariables as RESEND_ORDER_VARS,
+} from '../../../common/mutations/__generated__/RESEND_ORDER';
+import { RESEND_ORDER_MUTATION } from '../../../common/mutations/resendOrder';
 
 export type SendInvoiceFormContainerProps = {
   orderId: string;
   email: string | null;
   refetchQueries: PureQueryOptions[] | string[];
+  isResend?: boolean;
   onCancel: () => void;
   onSubmit: () => void;
 };
@@ -23,18 +29,50 @@ const SendInvoiceFormContainer = ({
   orderId,
   email,
   refetchQueries,
+  isResend,
   onSubmit,
   onCancel,
 }: SendInvoiceFormContainerProps) => {
-  const [approveOrder, { loading: isSubmitting }] = useMutation<APPROVE_ORDERS, APPROVE_ORDERS_VARS>(
+  const [approveOrder, { loading: isApproveOrderSubmitting }] = useMutation<APPROVE_ORDERS, APPROVE_ORDERS_VARS>(
     APPROVE_ORDERS_MUTATION,
     {
       refetchQueries,
     }
   );
 
+  const [resendOrder, { loading: isResendOrderSubmitting }] = useMutation<RESEND_ORDER, RESEND_ORDER_VARS>(
+    RESEND_ORDER_MUTATION,
+    { refetchQueries }
+  );
+
+  const isSubmitting = isApproveOrderSubmitting || isResendOrderSubmitting;
+
   const handleSubmit = async (values: { dueDate: string }) => {
     if (email === null) return false;
+
+    if (isResend) {
+      await resendOrder({
+        variables: {
+          input: {
+            dueDate: values.dueDate,
+            profileToken: getProfileToken(),
+            orderId,
+          },
+        },
+      }).then((res) => {
+        if (!res.errors) {
+          hdsToast({
+            type: 'success',
+            labelText: 'toast.invoiceSent.label',
+            text: 'toast.invoiceSent.description',
+            translated: true,
+          });
+        }
+      });
+      onSubmit();
+      return;
+    }
+
     await approveOrder({
       variables: {
         input: {
@@ -61,7 +99,15 @@ const SendInvoiceFormContainer = ({
     onSubmit();
   };
 
-  return <SendInvoiceForm email={email} onSubmit={handleSubmit} onCancel={onCancel} isSubmitting={isSubmitting} />;
+  return (
+    <SendInvoiceForm
+      email={email}
+      onSubmit={handleSubmit}
+      onCancel={onCancel}
+      isSubmitting={isSubmitting}
+      isResend={isResend}
+    />
+  );
 };
 
 export default SendInvoiceFormContainer;

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`SendInvoiceForm renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lasku lähetetään asiakkaan sähköpostiosoitteeseen (test@example.com) ja siihen merkitään alla oleva eräpäivä.
+    Lasku lähetetään asiakkaalle ja siihen merkitään alla oleva eräpäivä.
   </p>
   <p
     class="instructions"

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SendInvoiceForm renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.
+    Lähetetyn laskun voi lähettää uudelleen ja perua.
   </p>
   <div
     class="dueDate"

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceForm.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SendInvoiceForm renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lähetettyä laskua ei voi enää muuttaa, mutta sen voi perua. Perumisesta lähetetään ilmoitus asiakkaalle
+    Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.
   </p>
   <div
     class="dueDate"

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SendInvoiceFormContainer renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.
+    Lähetetyn laskun voi lähettää uudelleen ja perua.
   </p>
   <div
     class="dueDate"

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`SendInvoiceFormContainer renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lasku lähetetään asiakkaan sähköpostiosoitteeseen (test@example.com) ja siihen merkitään alla oleva eräpäivä.
+    Lasku lähetetään asiakkaalle ja siihen merkitään alla oleva eräpäivä.
   </p>
   <p
     class="instructions"

--- a/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
+++ b/src/features/invoiceCard/sendInvoiceForm/__tests__/__snapshots__/SendInvoiceFormContainer.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`SendInvoiceFormContainer renders normally 1`] = `
   <p
     class="instructions"
   >
-    Lähetettyä laskua ei voi enää muuttaa, mutta sen voi perua. Perumisesta lähetetään ilmoitus asiakkaalle
+    Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.
   </p>
   <div
     class="dueDate"

--- a/src/features/offer/OfferContainer.tsx
+++ b/src/features/offer/OfferContainer.tsx
@@ -60,7 +60,7 @@ const OfferContainer = () => {
 
   const applicationDate = formatDate(data.berthApplication?.createdAt, i18n.language);
   const applicationStatus = data.berthApplication.status;
-  const handleReturn = () => history.push('/applications');
+  const handleReturn = () => history.goBack();
   const applicationType = getApplicationType(!!data.berthApplication.berthSwitch);
   const piersIdentifiers = getAllPiersIdentifiers(data);
   const harbor = getHarbor(data);
@@ -75,7 +75,7 @@ const OfferContainer = () => {
         },
       },
     }).then(() => {
-      history.push('/applications');
+      history.goBack();
       hdsToast({
         type: 'success',
         autoDismiss: true,

--- a/src/features/sendMultiOffersForm/SendMultiOffersForm.tsx
+++ b/src/features/sendMultiOffersForm/SendMultiOffersForm.tsx
@@ -9,6 +9,7 @@ import FormHeader from '../../common/formHeader/FormHeader';
 import Button from '../../common/button/Button';
 import Text from '../../common/text/Text';
 import { getDefaultDueDate, getDueDateValidation } from '../../common/utils/dates';
+import Grid from '../../common/grid/Grid';
 
 type FormValues = {
   dueDate: string;
@@ -16,12 +17,19 @@ type FormValues = {
 
 export type SendMultiOffersFormProps = {
   isSubmitting: boolean;
-  offersCount: number;
+  sentOffersCount: number;
+  draftedOffersCount: number;
   onCancel: () => void;
   onSubmit: (data: FormValues) => void;
 };
 
-const SendMultiOffersForm = ({ isSubmitting, offersCount, onSubmit, onCancel }: SendMultiOffersFormProps) => {
+const SendMultiOffersForm = ({
+  isSubmitting,
+  draftedOffersCount,
+  onSubmit,
+  onCancel,
+  sentOffersCount,
+}: SendMultiOffersFormProps) => {
   const { t } = useTranslation();
 
   const validationSchema = useMemo(
@@ -47,12 +55,20 @@ const SendMultiOffersForm = ({ isSubmitting, offersCount, onSubmit, onCancel }: 
       {({ values, errors, handleChange }) => (
         <Form className={styles.form}>
           <FormHeader title={t('forms.sendMultiOffers.title').toUpperCase()} />
-          <div className={styles.column}>
-            <Text as="strong" className={styles.header}>
-              {t('forms.sendMultiOffers.berthOffers')}
-            </Text>
-            <Text size="xl">{offersCount}</Text>
-          </div>
+          <Grid colsCount={2}>
+            <div className={styles.column}>
+              <Text as="strong" className={styles.header}>
+                {t('forms.sendMultiOffers.draftedOffers')}
+              </Text>
+              <Text size="xl">{draftedOffersCount}</Text>
+            </div>
+            <div className={styles.column}>
+              <Text as="strong" className={styles.header}>
+                {t('forms.sendMultiOffers.sentOffers')}
+              </Text>
+              <Text size="xl">{sentOffersCount}</Text>
+            </div>
+          </Grid>
 
           <div className={styles.instructions}>
             <p className={styles.paragraph}>{t('forms.sendMultiOffers.instructions.paragraph1')}</p>

--- a/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
+++ b/src/features/unmarkedWsNoticeList/UnmarkedWsNoticeList.tsx
@@ -11,7 +11,7 @@ import { formatDate } from '../../common/utils/format';
 import StatusLabel from '../../common/statusLabel/StatusLabel';
 import { APPLICATION_STATUS } from '../../common/utils/constants';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
-import { getDraftedOffers, UnmarkedWinterStorageNotice } from './utils';
+import { getDraftedOffers, getSentOffers, UnmarkedWinterStorageNotice } from './utils';
 import UnmarkedWsNoticeDetails from '../unmarkedWsNoticeDetails/UnmarkedWsNoticeDetails';
 import Pagination from '../../common/pagination/Pagination';
 import Grid from '../../common/grid/Grid';
@@ -47,7 +47,7 @@ export interface UnmarkedWsNoticeListProps {
   statusFilter?: ApplicationStatus;
   nameFilter?: string;
   goToPage(page: number): void;
-  handleApproveOrders(orders: Order[]): Promise<void>;
+  handleSendOffers(draftedOffers: Order[], sentOffers: Order[], dueDate: string): Promise<void>;
   onSortedColsChange(sortedCol: SortingRule<UnmarkedWinterStorageNotice>[]): void;
   onStatusFilterChange(statusFilter?: ApplicationStatus): void;
   onNameFilterChange(nameFilter: string | undefined): void;
@@ -74,7 +74,7 @@ const UnmarkedWsNoticeList = ({
   onStatusFilterChange,
   onSortedColsChange,
   sortBy,
-  handleApproveOrders,
+  handleSendOffers,
   nameFilter,
   onNameFilterChange,
   onSavePdf,
@@ -182,7 +182,8 @@ const UnmarkedWsNoticeList = ({
                       clearSelectedRows={resetSelectedRows}
                       filterUnhandledApplications={(row) => !row.leaseId}
                       getDraftedOffers={getDraftedOffers}
-                      handleApproveOffers={handleApproveOrders}
+                      getSentOffers={getSentOffers}
+                      handleSendOffers={handleSendOffers}
                       isSubmitting={isSubmittingApproveOrders}
                       selectedRows={selectedRows}
                     />

--- a/src/features/unmarkedWsNoticeList/utils.ts
+++ b/src/features/unmarkedWsNoticeList/utils.ts
@@ -113,14 +113,13 @@ export const getDraftedOffers = (applications: UnmarkedWinterStorageNotice[]) =>
   }, []);
 
 export const getSentOffers = (applications: UnmarkedWinterStorageNotice[]) =>
-  applications.reduce<Offer[]>((acc, application) => {
-    if (application.status !== ApplicationStatus.OFFER_SENT || !application.orderId || !application.email) return acc;
-
+  applications.reduce<Offer[]>((acc, { status, orderId, email }) => {
+    if (status !== ApplicationStatus.OFFER_SENT || !orderId || !email) return acc;
     return [
       ...acc,
       {
-        orderId: application.orderId,
-        email: application.email,
+        orderId,
+        email,
       },
     ];
   }, []);

--- a/src/features/unmarkedWsNoticeList/utils.ts
+++ b/src/features/unmarkedWsNoticeList/utils.ts
@@ -112,6 +112,19 @@ export const getDraftedOffers = (applications: UnmarkedWinterStorageNotice[]) =>
     ];
   }, []);
 
+export const getSentOffers = (applications: UnmarkedWinterStorageNotice[]) =>
+  applications.reduce<Offer[]>((acc, application) => {
+    if (application.status !== ApplicationStatus.OFFER_SENT || !application.orderId || !application.email) return acc;
+
+    return [
+      ...acc,
+      {
+        orderId: application.orderId,
+        email: application.email,
+      },
+    ];
+  }, []);
+
 export const getCustomersWithUnsentStickers = (
   data: UNMARKED_WINTER_STORAGE_NOTICES_STICKERS | undefined
 ): CustomerInfo[] => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -283,7 +283,8 @@
     "sendMultiOffers": {
       "title": "Lähetä tarjous",
       "dueDate": "Tarjousten eräpäivä",
-      "berthOffers": "Venepaikkatarjouksia",
+      "draftedOffers": "Venepaikkatarjouksia",
+      "sentOffers": "Uudelleen lähetettäviä tarjouksia",
       "instructions": {
         "paragraph1": "Tarjoukset lähetetään asiakkaiden sähköpostiosoitteisiin ja niihin merkitään alla oleva eräpäivä.",
         "paragraph2": "Lähetettyä tarjousta ei voi enää muuttaa, mutta sen voi perua. Perumisesta lähetetään ilmoitus asiakkaalle.",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -283,7 +283,7 @@
     "sendMultiOffers": {
       "title": "Lähetä tarjous",
       "dueDate": "Tarjousten eräpäivä",
-      "draftedOffers": "Venepaikkatarjouksia",
+      "draftedOffers": "Uusia tarjouksia",
       "sentOffers": "Uudelleen lähetettäviä tarjouksia",
       "instructions": {
         "paragraph1": "Tarjoukset lähetetään asiakkaiden sähköpostiosoitteisiin ja niihin merkitään alla oleva eräpäivä.",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -531,6 +531,7 @@
     },
     "customerInvoice": {
       "showInvoice": "Näytä lasku",
+      "resendInvoice": "Lähetä lasku uudelleen",
       "contractPeriod": "Sopimuskausi",
       "dueDate": "Eräpäivä",
       "paidAt": "Maksettu",
@@ -790,8 +791,10 @@
       "title": "Paikan tiedot"
     },
     "invoiceSent": "Tarjous lähetetty",
+    "resendInvoice": "Lähetä tarjous uudelleen",
     "sendInvoice": {
       "title": "Lähetä lasku",
+      "resendTitle": "Lähetä lasku uudelleen",
       "missingEmail": "Sähköpostiosoite puuttuu",
       "dueDate": "Laskun eräpäivä"
     }
@@ -841,6 +844,8 @@
   },
   "invoiceInstructions": {
     "paragraph1": "Lasku lähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen merkitään alla oleva eräpäivä.",
-    "paragraph2": "Lähetettyä laskua ei voi enää muuttaa, mutta sen voi perua. Perumisesta lähetetään ilmoitus asiakkaalle"
+    "paragraph2": "Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.",
+    "resendParagraph1": "Lasku uudelleenlähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
+    "resendParagraph2": "Uudelleenlähetetyn laskun voi edelleen uudelleenlähettää muokkauksien jälkeen ja sen voi perua."
   }
 }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -846,7 +846,7 @@
   "invoiceInstructions": {
     "paragraph1": "Lasku lähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen merkitään alla oleva eräpäivä.",
     "paragraph2": "Lähetetyn laskun voi lähettää uudelleen ja perua.",
-    "resendParagraph1": "Lasku uudelleenlähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
-    "resendParagraph2": "Uudelleenlähetetyn laskun voi edelleen uudelleenlähettää muokkauksien jälkeen ja sen voi perua."
+    "resendParagraph1": "Lasku lähetetään uudelleen asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
+    "resendParagraph2": "Laskun voi yhä lähettää uudelleen muokkauksien jälkeen ja sen voi perua."
   }
 }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -844,9 +844,9 @@
     }
   },
   "invoiceInstructions": {
-    "paragraph1": "Lasku lähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen merkitään alla oleva eräpäivä.",
+    "paragraph1": "Lasku lähetetään asiakkaalle ja siihen merkitään alla oleva eräpäivä.",
     "paragraph2": "Lähetetyn laskun voi lähettää uudelleen ja perua.",
-    "resendParagraph1": "Lasku lähetetään uudelleen asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
+    "resendParagraph1": "Lasku lähetetään uudelleen asiakkaalle ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
     "resendParagraph2": "Laskun voi yhä lähettää uudelleen muokkauksien jälkeen ja sen voi perua."
   }
 }

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -287,7 +287,7 @@
       "sentOffers": "Uudelleen lähetettäviä tarjouksia",
       "instructions": {
         "paragraph1": "Tarjoukset lähetetään asiakkaiden sähköpostiosoitteisiin ja niihin merkitään alla oleva eräpäivä.",
-        "paragraph2": "Lähetettyä tarjousta ei voi enää muuttaa, mutta sen voi perua. Perumisesta lähetetään ilmoitus asiakkaalle.",
+        "paragraph2": "Lähetetyn tarjouksen voi lähettää uudelleen ja perua.",
         "paragraph3": "Jos hakemukseen ei ole tarjottu venepaikkaa, asiakkaalle lähetetään ilmoitus paikatta jäämisestä."
       }
     }
@@ -845,7 +845,7 @@
   },
   "invoiceInstructions": {
     "paragraph1": "Lasku lähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen merkitään alla oleva eräpäivä.",
-    "paragraph2": "Lähetetyn laskun voi uudelleenlähettää ja sen voi perua.",
+    "paragraph2": "Lähetetyn laskun voi lähettää uudelleen ja perua.",
     "resendParagraph1": "Lasku uudelleenlähetetään asiakkaan sähköpostiosoitteeseen ({{email}}) ja siihen päivitetään alla oleva eräpäivä. Lisäksi laskun hinta lasketaan uudelleen mikäli valitun paikan hinnoitteluun on tehty muutoksia.",
     "resendParagraph2": "Uudelleenlähetetyn laskun voi edelleen uudelleenlähettää muokkauksien jälkeen ja sen voi perua."
   }


### PR DESCRIPTION
## Description :sparkles:

* Resend invoices that have already been sent, with a new due date. Implemented in:
  * Application list (in multi-invoicing)
  * Application view (in offer card)
  * Customer view (in open invoices card)
* Changed behavior so that completing the offer page returns to the application and back button returns to the application list

## Issues :bug:

### Closes :no_good_woman:

* [VEN-949](https://helsinkisolutionoffice.atlassian.net/browse/VEN-949): FE: Updating duedate already sent invoices
* [VEN-1066](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1066): Resend invoice that has been already sent

## Testing :alembic:

### Automated tests :gear:️

* Updated existing tests

### Manual testing :construction_worker_man:

* Resending an invoice should be possible via the three views listed in the description
* The due date should change for the invoice - confirm it in the customer view which shows the due date

## Screenshots :camera_flash:

![image](https://user-images.githubusercontent.com/15479131/107527794-d321cd00-6bc1-11eb-95c7-d40e51789f28.png)
![image](https://user-images.githubusercontent.com/15479131/107527937-fc425d80-6bc1-11eb-8348-15bf3aef64df.png)
![image](https://user-images.githubusercontent.com/15479131/107528019-0ebc9700-6bc2-11eb-89b3-d68d89586cb5.png)
![image](https://user-images.githubusercontent.com/15479131/107528120-298f0b80-6bc2-11eb-9679-061520afe7c8.png)

