### PR TITLE
VEN-1029 | Refetch customer queries when new customer is created

### DIFF
--- a/src/common/hooks/useCreateNewCustomer.ts
+++ b/src/common/hooks/useCreateNewCustomer.ts
@@ -27,12 +27,15 @@ export type CustomerInfo = {
   zipCode: string;
 };
 
-const useCreateNewCustomer = (refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction) => {
+const useCreateNewCustomer = (
+  refetchQueries?: Array<string | PureQueryOptions> | RefetchQueriesFunction,
+  refetchFunction?: () => void
+) => {
   const [createNewCustomer] = useMutation<CREATE_NEW_PROFILE, CREATE_NEW_PROFILE_VARS>(CREATE_NEW_PROFILE_MUTATION);
 
   const [createNewBerthProfile] = useMutation<CREATE_BERTH_SERVICE_PROFILE, CREATE_BERTH_SERVICE_PROFILE_VARS>(
     CREATE_BERTH_SERVICE_PROFILE_MUTATION,
-    { refetchQueries }
+    { refetchQueries, onCompleted: () => refetchFunction?.() }
   );
 
   return (customerInfo: CustomerInfo) => {

--- a/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
+++ b/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
@@ -101,7 +101,7 @@ const LinkApplicationToCustomerContainer = ({
   const canCreateNewCustomer =
     !getFilteredCustomersData(exactlyFilteredCustomersData).length && !loadingExactlyFilteredCustomers;
 
-  const handleCreateCustomer = async () => {
+  const handleCreateCustomer = () => {
     createNewCustomer(application);
   };
 

--- a/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
+++ b/src/features/linkApplicationToCustomer/LinkApplicationToCustomerContainer.tsx
@@ -54,11 +54,12 @@ const LinkApplicationToCustomerContainer = ({
     orderBy,
     [searchBy]: prevSearchBy === searchBy ? debouncedSearchVal : searchVal,
   };
-  const [fetchFilteredCustomers, { data: customersData, called, loading: loadingCustomers }] = useLazyQuery<
-    FILTERED_CUSTOMERS,
-    FILTERED_CUSTOMERS_VARS
-  >(FILTERED_CUSTOMERS_QUERY, {
+  const [
+    fetchFilteredCustomers,
+    { data: customersData, called, loading: loadingCustomers, refetch: refetchCustomers },
+  ] = useLazyQuery<FILTERED_CUSTOMERS, FILTERED_CUSTOMERS_VARS>(FILTERED_CUSTOMERS_QUERY, {
     variables: filteredCustomersVars,
+    notifyOnNetworkStatusChange: true,
   });
 
   const exactlyFilteredCustomersVars: FILTERED_CUSTOMERS_VARS = {
@@ -67,23 +68,19 @@ const LinkApplicationToCustomerContainer = ({
     [SearchBy.LAST_NAME]: application.lastName,
     [SearchBy.EMAIL]: application.email,
   };
-  const { data: exactlyFilteredCustomersData, loading: loadingExactlyFilteredCustomers } = useQuery<
-    FILTERED_CUSTOMERS,
-    FILTERED_CUSTOMERS_VARS
-  >(FILTERED_CUSTOMERS_QUERY, {
+  const {
+    data: exactlyFilteredCustomersData,
+    loading: loadingExactlyFilteredCustomers,
+    refetch: refetchExactCustomers,
+  } = useQuery<FILTERED_CUSTOMERS, FILTERED_CUSTOMERS_VARS>(FILTERED_CUSTOMERS_QUERY, {
     variables: exactlyFilteredCustomersVars,
+    notifyOnNetworkStatusChange: true,
   });
 
-  const createNewCustomer = useCreateNewCustomer([
-    {
-      query: FILTERED_CUSTOMERS_QUERY,
-      variables: filteredCustomersVars,
-    },
-    {
-      query: FILTERED_CUSTOMERS_QUERY,
-      variables: exactlyFilteredCustomersVars,
-    },
-  ]);
+  const createNewCustomer = useCreateNewCustomer(undefined, async () => {
+    await refetchCustomers();
+    await refetchExactCustomers();
+  });
 
   useEffect(() => {
     setSearchVal(application[searchBy]);
@@ -104,7 +101,7 @@ const LinkApplicationToCustomerContainer = ({
   const canCreateNewCustomer =
     !getFilteredCustomersData(exactlyFilteredCustomersData).length && !loadingExactlyFilteredCustomers;
 
-  const handleCreateCustomer = () => {
+  const handleCreateCustomer = async () => {
     createNewCustomer(application);
   };
 


### PR DESCRIPTION
## Description :sparkles:

* Refetch customer queries when new customer is created

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1029](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1029): 'Create customer' button doesn’t do anything until page is refreshed

## Testing :alembic:

### Automated tests :gear:️

* No way to currently test this automatically

### Manual testing :construction_worker_man:

* When creating a customer profile for a new customer, the list should now display as loading and update correctly.