### PR TITLE
VEN-1082 | Fix Invoice Actions Disabling Conditions

### DIFF
--- a/src/common/select/Select.tsx
+++ b/src/common/select/Select.tsx
@@ -25,6 +25,7 @@ export type SelectProps<T extends OptionValue = string> = {
   label?: string;
   onChange: (e: ConstructedChangeEvent<T>) => void;
   options: Option<T>[];
+  placeholder?: string;
   required?: boolean;
   value?: T | null;
   visibleOptions?: number;
@@ -37,6 +38,7 @@ const Select = <T extends OptionValue = string>({
   label,
   onChange,
   options,
+  placeholder,
   required,
   value,
   visibleOptions,
@@ -64,6 +66,7 @@ const Select = <T extends OptionValue = string>({
       label={label}
       onChange={handleChange}
       options={options}
+      placeholder={placeholder}
       required={required}
       value={selectedOption}
       visibleOptions={visibleOptions}

--- a/src/features/applicationView/berthOfferCard/__tests__/__snapshots__/BerthOfferCard.test.tsx.snap
+++ b/src/features/applicationView/berthOfferCard/__tests__/__snapshots__/BerthOfferCard.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`BerthOfferCard renders normally 1`] = `
 Array [
   <div
-    class="Select-module_root__Ka5uO select invoiceActions"
+    class="Select-module_root__Ka5uO Select-module_disabled__3MKDP select invoiceActions"
   >
     <div
       class="Select-module_wrapper__1WQXs"
@@ -14,9 +14,11 @@ Array [
         aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
         aria-owns="hds-select-1-menu"
         class="Select-module_button__1aIsm Select-module_placeholder__21c0j"
+        disabled=""
         id="hds-select-1-toggle-button"
         type="button"
       >
+        Laskun muokkaus
         <svg
           aria-hidden="true"
           class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
@@ -369,19 +371,7 @@ Array [
       <div
         class="buttonRow"
       >
-        <div>
-          <button
-            class="Button-module_button__3wgee button_hds-button__2A0je Button-module_primary__3bo_T button_hds-button--primary__2NVvO Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0"
-            disabled=""
-            type="button"
-          >
-            <span
-              class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
-            >
-              Hyväksy ja lähetä tarjous
-            </span>
-          </button>
-        </div>
+        <div />
         <div>
           <button
             class="Button-module_button__3wgee button_hds-button__2A0je Button-module_supplementary__3Epn- button_hds-button--supplementary__GcHcV Button-module_theme-coat__2xA5D button_hds-button--theme-coat__12cO0"

--- a/src/features/invoiceCard/InvoiceCardContainer.tsx
+++ b/src/features/invoiceCard/InvoiceCardContainer.tsx
@@ -41,10 +41,7 @@ const InvoiceCardContainer = ({
     setSelectedInvoiceAction(null);
   };
 
-  const actionsDisabled =
-    order?.status === OrderStatus.CANCELLED ||
-    order?.status === OrderStatus.REJECTED ||
-    order?.status === OrderStatus.PAID;
+  const actionsDisabled = !(order?.status === OrderStatus.ERROR || order?.status === OrderStatus.WAITING);
 
   return (
     <>

--- a/src/features/invoiceCard/invoiceActions/InvoiceActions.tsx
+++ b/src/features/invoiceCard/invoiceActions/InvoiceActions.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import Select from '../../../common/select/Select';
 import styles from './invoiceActions.module.scss';
@@ -16,8 +17,11 @@ export interface InvoiceActionsProps {
 }
 
 const InvoiceActions = ({ actions, disabled, selectedAction }: InvoiceActionsProps) => {
+  const { t } = useTranslation();
+
   return (
     <Select
+      placeholder={t('invoiceCard.edit')}
       className={styles.invoiceActions}
       disabled={disabled}
       options={actions}

--- a/src/features/invoiceCard/invoiceActions/__tests__/__snapshots__/InvoiceActions.test.tsx.snap
+++ b/src/features/invoiceCard/invoiceActions/__tests__/__snapshots__/InvoiceActions.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`InvoiceActions renders normally 1`] = `
       id="hds-select-1-toggle-button"
       type="button"
     >
+      Laskun muokkaus
       <svg
         aria-hidden="true"
         class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -796,6 +796,7 @@
     },
     "invoiceSent": "Tarjous lähetetty",
     "resendInvoice": "Lähetä tarjous uudelleen",
+    "edit": "Laskun muokkaus",
     "sendInvoice": {
       "title": "Lähetä lasku",
       "resendTitle": "Lähetä lasku uudelleen",


### PR DESCRIPTION
## Description :sparkles:
- Add placeholder text to InvoiceActions component
- Fix the conditions of disabling invoice actions

## Issues :bug:
(VEN-1082)[https://helsinkisolutionoffice.atlassian.net/browse/VEN-1082]:  Fix Invoice Actions Disabling Conditions

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:
- The actions of the invoices that have statuses other than `waiting` or `error` will be disabled

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
