### PR TITLE
VEN-1097 | Add Invoice Status to Invoice Card Header

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -32,6 +32,7 @@ export enum ApplicationStatus {
   OFFER_GENERATED = "OFFER_GENERATED",
   OFFER_SENT = "OFFER_SENT",
   PENDING = "PENDING",
+  REJECTED = "REJECTED",
 }
 
 export enum BerthApplicationLanguage {

--- a/src/common/tableTools/applicationTableTools/__tests__/__snapshots__/ApplicationTableTools.test.tsx.snap
+++ b/src/common/tableTools/applicationTableTools/__tests__/__snapshots__/ApplicationTableTools.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`ApplicationTableTools renders correctly 1`] = `
           class="Select-module_menu__1H2aU"
           id="hds-select-1-menu"
           role="listbox"
-          style="max-height:468px"
+          style="max-height:520px"
           tabindex="-1"
         />
       </div>

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -1,5 +1,5 @@
 import { StatusLabelProps } from '../statusLabel/StatusLabel';
-import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
+import { ApplicationStatus, OrderStatus } from '../../@types/__generated__/globalTypes';
 
 type ApplicationStatusType = {
   [key in ApplicationStatus]: {
@@ -20,6 +20,44 @@ export const APPLICATION_STATUS: ApplicationStatusType = {
   NO_SUITABLE_BERTHS: { label: 'applicationList.status.noSuitable', type: 'error' },
   NO_SUITABLE_BERTHS_NOTIFIED: {
     label: 'applicationList.status.noSuitableNotified',
+    type: 'warning',
+  },
+};
+
+type OrderStatusType = {
+  [key in OrderStatus]: {
+    label: string;
+    type: StatusLabelProps['type'];
+  };
+};
+
+export const ORDER_STATUS: OrderStatusType = {
+  CANCELLED: {
+    label: 'common.orderStatus.cancelled',
+    type: 'error',
+  },
+  ERROR: {
+    label: 'common.orderStatus.error',
+    type: 'error',
+  },
+  EXPIRED: {
+    label: 'common.orderStatus.expired',
+    type: 'error',
+  },
+  PAID: {
+    label: 'common.orderStatus.paid',
+    type: 'success',
+  },
+  PAID_MANUALLY: {
+    label: 'common.orderStatus.paidManually',
+    type: 'success',
+  },
+  REJECTED: {
+    label: 'common.orderStatus.rejected',
+    type: 'error',
+  },
+  WAITING: {
+    label: 'common.orderStatus.waiting',
     type: 'warning',
   },
 };

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -22,6 +22,7 @@ export const APPLICATION_STATUS: ApplicationStatusType = {
     label: 'applicationList.status.noSuitableNotified',
     type: 'warning',
   },
+  REJECTED: { label: 'applicationList.status.rejected', type: 'error' },
 };
 
 type OrderStatusType = {

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -44,8 +44,8 @@ exports[`ApplicationList renders normally with all props 1`] = `
         >
           <label
             class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-            for="hds-select-1-toggle-button"
-            id="hds-select-1-label"
+            for="hds-select-7-toggle-button"
+            id="hds-select-7-label"
           >
             Hakemuksen tila
           </label>
@@ -55,10 +55,10 @@ exports[`ApplicationList renders normally with all props 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
-              aria-owns="hds-select-1-menu"
+              aria-labelledby="hds-select-7-label hds-select-7-toggle-button"
+              aria-owns="hds-select-7-menu"
               class="Select-module_button__1aIsm"
-              id="hds-select-1-toggle-button"
+              id="hds-select-7-toggle-button"
               type="button"
             >
               Kaikki
@@ -84,9 +84,9 @@ exports[`ApplicationList renders normally with all props 1`] = `
               </svg>
             </button>
             <ul
-              aria-labelledby="hds-select-1-label"
+              aria-labelledby="hds-select-7-label"
               class="Select-module_menu__1H2aU"
-              id="hds-select-1-menu"
+              id="hds-select-7-menu"
               role="listbox"
               style="max-height: 520px;"
               tabindex="-1"
@@ -107,10 +107,10 @@ exports[`ApplicationList renders normally with all props 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="hds-select-2-label hds-select-2-toggle-button"
-            aria-owns="hds-select-2-menu"
+            aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
+            aria-owns="hds-select-8-menu"
             class="Select-module_button__1aIsm"
-            id="hds-select-2-toggle-button"
+            id="hds-select-8-toggle-button"
             type="button"
           >
             Toiminnot
@@ -136,9 +136,9 @@ exports[`ApplicationList renders normally with all props 1`] = `
             </svg>
           </button>
           <ul
-            aria-labelledby="hds-select-2-label"
+            aria-labelledby="hds-select-8-label"
             class="Select-module_menu__1H2aU"
-            id="hds-select-2-menu"
+            id="hds-select-8-menu"
             role="listbox"
             style="max-height: 260px;"
             tabindex="-1"

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -44,8 +44,8 @@ exports[`ApplicationList renders normally with all props 1`] = `
         >
           <label
             class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-            for="hds-select-7-toggle-button"
-            id="hds-select-7-label"
+            for="hds-select-1-toggle-button"
+            id="hds-select-1-label"
           >
             Hakemuksen tila
           </label>
@@ -55,10 +55,10 @@ exports[`ApplicationList renders normally with all props 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="hds-select-7-label hds-select-7-toggle-button"
-              aria-owns="hds-select-7-menu"
+              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
+              aria-owns="hds-select-1-menu"
               class="Select-module_button__1aIsm"
-              id="hds-select-7-toggle-button"
+              id="hds-select-1-toggle-button"
               type="button"
             >
               Kaikki
@@ -84,11 +84,11 @@ exports[`ApplicationList renders normally with all props 1`] = `
               </svg>
             </button>
             <ul
-              aria-labelledby="hds-select-7-label"
+              aria-labelledby="hds-select-1-label"
               class="Select-module_menu__1H2aU"
-              id="hds-select-7-menu"
+              id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>
@@ -107,10 +107,10 @@ exports[`ApplicationList renders normally with all props 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
-            aria-owns="hds-select-8-menu"
+            aria-labelledby="hds-select-2-label hds-select-2-toggle-button"
+            aria-owns="hds-select-2-menu"
             class="Select-module_button__1aIsm"
-            id="hds-select-8-toggle-button"
+            id="hds-select-2-toggle-button"
             type="button"
           >
             Toiminnot
@@ -136,9 +136,9 @@ exports[`ApplicationList renders normally with all props 1`] = `
             </svg>
           </button>
           <ul
-            aria-labelledby="hds-select-8-label"
+            aria-labelledby="hds-select-2-label"
             class="Select-module_menu__1H2aU"
-            id="hds-select-8-menu"
+            id="hds-select-2-menu"
             role="listbox"
             style="max-height: 260px;"
             tabindex="-1"
@@ -855,7 +855,7 @@ exports[`ApplicationList renders normally with minimum props 1`] = `
               class="Select-module_menu__1H2aU"
               id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ApplicationListContainer renders normally 1`] = `
               class="Select-module_menu__1H2aU"
               id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>

--- a/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
+++ b/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
@@ -63,11 +63,11 @@ const InvoicingHistoryCard = ({ invoices, onClick, onClickCreateAdditionalInvoic
         {invoices.length > 0 ? (
           <Section>
             <Grid colsCount={5}>
-              <div className={styles.gridHeader}>Tyyppi</div>
-              <div className={styles.gridHeader}>Kausi</div>
-              <div className={styles.gridHeader}>Eräpäivä</div>
-              <div className={styles.gridHeader}>Summa</div>
-              <div className={styles.gridHeader}>Tila</div>
+              <div className={styles.gridHeader}>{t('customerView.invoicingHistory.type')}</div>
+              <div className={styles.gridHeader}>{t('customerView.invoicingHistory.season')}</div>
+              <div className={styles.gridHeader}>{t('customerView.invoicingHistory.dueDate')}</div>
+              <div className={styles.gridHeader}>{t('customerView.invoicingHistory.amount')}</div>
+              <div className={styles.gridHeader}>{t('customerView.invoicingHistory.status')}</div>
               {getRows()}
             </Grid>
           </Section>

--- a/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
+++ b/src/features/customerView/invoicingHistoryCard/InvoicingHistoryCard.tsx
@@ -10,11 +10,11 @@ import CardBody from '../../../common/cardBody/CardBody';
 import { formatDate, formatPrice } from '../../../common/utils/format';
 import Text from '../../../common/text/Text';
 import styles from './invoicingHistoryCard.module.scss';
-import StatusLabel, { StatusLabelProps } from '../../../common/statusLabel/StatusLabel';
-import { getInvoiceTypeKey, getOrderStatusTKey } from '../../../common/utils/translations';
-import { OrderStatus } from '../../../@types/__generated__/globalTypes';
+import StatusLabel from '../../../common/statusLabel/StatusLabel';
+import { getInvoiceTypeKey } from '../../../common/utils/translations';
 import { Invoice } from '../types';
 import Button from '../../../common/button/Button';
+import { ORDER_STATUS } from '../../../common/utils/constants';
 
 interface InvoicingHistoryProps {
   invoices: Invoice[];
@@ -24,23 +24,6 @@ interface InvoicingHistoryProps {
 
 const InvoicingHistoryCard = ({ invoices, onClick, onClickCreateAdditionalInvoice }: InvoicingHistoryProps) => {
   const { t, i18n } = useTranslation();
-
-  const invoiceStatusToType = (invoiceStatus: OrderStatus): StatusLabelProps['type'] => {
-    switch (invoiceStatus) {
-      case OrderStatus.WAITING:
-        return 'warning';
-      case OrderStatus.PAID:
-        return 'success';
-      case OrderStatus.EXPIRED:
-      case OrderStatus.ERROR:
-        return 'error';
-      case OrderStatus.REJECTED:
-      case OrderStatus.CANCELLED:
-        return 'neutral';
-      default:
-        return 'neutral';
-    }
-  };
 
   const getRows = () =>
     invoices.map((invoice, id) => (
@@ -65,7 +48,7 @@ const InvoicingHistoryCard = ({ invoices, onClick, onClickCreateAdditionalInvoic
           <Text>{formatPrice(invoice.totalPrice, i18n.language)}</Text>
         </div>
         <div className={styles.gridItem}>
-          <StatusLabel type={invoiceStatusToType(invoice.status)} label={t(getOrderStatusTKey(invoice.status))} />
+          <StatusLabel type={ORDER_STATUS[invoice.status].type} label={t(ORDER_STATUS[invoice.status].label)} />
         </div>
       </React.Fragment>
     ));

--- a/src/features/invoiceCard/InvoiceCard.tsx
+++ b/src/features/invoiceCard/InvoiceCard.tsx
@@ -12,7 +12,9 @@ import Property from '../../common/property/Property';
 import OrderSection from './OrderSection';
 import { Order, PlaceProperty } from './types';
 import Button from '../../common/button/Button';
+import StatusLabel from '../../common/statusLabel/StatusLabel';
 import { ApplicationStatus, LeaseStatus } from '../../@types/__generated__/globalTypes';
+import { ORDER_STATUS } from '../../common/utils/constants';
 
 export interface InvoiceCardProps {
   applicationStatus: ApplicationStatus;
@@ -82,7 +84,9 @@ const InvoiceCard = ({
 
   return (
     <Card className={classNames(styles.offerCard, className)}>
-      <CardHeader title={title} />
+      <CardHeader title={title}>
+        {order && <StatusLabel type={ORDER_STATUS[order.status].type} label={t(ORDER_STATUS[order.status].label)} />}
+      </CardHeader>
       <CardBody>
         <Grid colsCount={3}>
           <Section title={placeType}>

--- a/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
+++ b/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 import InvoiceCard, { InvoiceCardProps } from '../InvoiceCard';
-import { ApplicationStatus, LeaseStatus } from '../../../@types/__generated__/globalTypes';
+import { ApplicationStatus, LeaseStatus, OrderStatus } from '../../../@types/__generated__/globalTypes';
 
 describe('InvoiceCard', () => {
   const defaultProps: InvoiceCardProps = {
@@ -15,6 +15,7 @@ describe('InvoiceCard', () => {
       totalPrice: 2,
       fixedProducts: [],
       optionalProducts: [],
+      status: OrderStatus.WAITING,
     },
     placeType: 'place type',
     placeName: 'place name',

--- a/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
+++ b/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
@@ -12,6 +12,15 @@ exports[`InvoiceCard renders normally 1`] = `
     >
       title
     </span>
+    <div
+      class="widgets"
+    >
+      <span
+        class="StatusLabel-module_statusLabel__3R2J2 status-label_hds-status-label__1L8YI StatusLabel-module_alert__2VR8r status-label_hds-status-label--alert__1ecsX warning"
+      >
+        Odottaa maksua
+      </span>
+    </div>
   </div>
   <div
     class="cardBody"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`UnmarkedWsNoticeList renders normally with data 1`] = `
               class="Select-module_menu__1H2aU"
               id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>
@@ -1396,8 +1396,8 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
         >
           <label
             class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-            for="hds-select-7-toggle-button"
-            id="hds-select-7-label"
+            for="hds-select-1-toggle-button"
+            id="hds-select-1-label"
           >
             Hakemuksen tila
           </label>
@@ -1407,10 +1407,10 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="hds-select-7-label hds-select-7-toggle-button"
-              aria-owns="hds-select-7-menu"
+              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
+              aria-owns="hds-select-1-menu"
               class="Select-module_button__1aIsm"
-              id="hds-select-7-toggle-button"
+              id="hds-select-1-toggle-button"
               type="button"
             >
               Kaikki
@@ -1436,11 +1436,11 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
               </svg>
             </button>
             <ul
-              aria-labelledby="hds-select-7-label"
+              aria-labelledby="hds-select-1-label"
               class="Select-module_menu__1H2aU"
-              id="hds-select-7-menu"
+              id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>
@@ -1459,10 +1459,10 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
-            aria-owns="hds-select-8-menu"
+            aria-labelledby="hds-select-2-label hds-select-2-toggle-button"
+            aria-owns="hds-select-2-menu"
             class="Select-module_button__1aIsm"
-            id="hds-select-8-toggle-button"
+            id="hds-select-2-toggle-button"
             type="button"
           >
             Toiminnot
@@ -1488,9 +1488,9 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
             </svg>
           </button>
           <ul
-            aria-labelledby="hds-select-8-label"
+            aria-labelledby="hds-select-2-label"
             class="Select-module_menu__1H2aU"
-            id="hds-select-8-menu"
+            id="hds-select-2-menu"
             role="listbox"
             style="max-height: 260px;"
             tabindex="-1"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
@@ -1396,8 +1396,8 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
         >
           <label
             class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
-            for="hds-select-1-toggle-button"
-            id="hds-select-1-label"
+            for="hds-select-7-toggle-button"
+            id="hds-select-7-label"
           >
             Hakemuksen tila
           </label>
@@ -1407,10 +1407,10 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-labelledby="hds-select-1-label hds-select-1-toggle-button"
-              aria-owns="hds-select-1-menu"
+              aria-labelledby="hds-select-7-label hds-select-7-toggle-button"
+              aria-owns="hds-select-7-menu"
               class="Select-module_button__1aIsm"
-              id="hds-select-1-toggle-button"
+              id="hds-select-7-toggle-button"
               type="button"
             >
               Kaikki
@@ -1436,9 +1436,9 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
               </svg>
             </button>
             <ul
-              aria-labelledby="hds-select-1-label"
+              aria-labelledby="hds-select-7-label"
               class="Select-module_menu__1H2aU"
-              id="hds-select-1-menu"
+              id="hds-select-7-menu"
               role="listbox"
               style="max-height: 520px;"
               tabindex="-1"
@@ -1459,10 +1459,10 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
           <button
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="hds-select-2-label hds-select-2-toggle-button"
-            aria-owns="hds-select-2-menu"
+            aria-labelledby="hds-select-8-label hds-select-8-toggle-button"
+            aria-owns="hds-select-8-menu"
             class="Select-module_button__1aIsm"
-            id="hds-select-2-toggle-button"
+            id="hds-select-8-toggle-button"
             type="button"
           >
             Toiminnot
@@ -1488,9 +1488,9 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
             </svg>
           </button>
           <ul
-            aria-labelledby="hds-select-2-label"
+            aria-labelledby="hds-select-8-label"
             class="Select-module_menu__1H2aU"
-            id="hds-select-2-menu"
+            id="hds-select-8-menu"
             role="listbox"
             style="max-height: 260px;"
             tabindex="-1"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`UnmarkedWsNoticeListContainer renders normally 1`] = `
               class="Select-module_menu__1H2aU"
               id="hds-select-1-menu"
               role="listbox"
-              style="max-height: 468px;"
+              style="max-height: 520px;"
               tabindex="-1"
             />
           </div>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -543,7 +543,12 @@
     },
     "invoicingHistory": {
       "title": "LASKUHISTORIA",
-      "noInvoicingHistory": "Ei laskuhistoriaa"
+      "noInvoicingHistory": "Ei laskuhistoriaa",
+      "type": "Tyyppi",
+      "season": "Kausi",
+      "dueDate": "Eräpäivä",
+      "amount": "Summa",
+      "status": "Tila"
     },
     "customerBoats": {
       "title": "ASIAKKAAN VENEET",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -364,7 +364,8 @@
       "handled": "Tarjous maksettu",
       "expired": "Vanhentunut",
       "noSuitable": "Ei paikkaa",
-      "noSuitableNotified": "Ei paikkaa, lähetetty"
+      "noSuitableNotified": "Ei paikkaa, lähetetty",
+      "rejected": "Tarjous hylätty"
     },
     "applicationType": {
       "newApplication": "Uusi",


### PR DESCRIPTION
## Description :sparkles:
- Add ORDER_STATUS to constants file
- Replace status the `util` function with constant values & use translated text in the invoice history card
- Add status label to the invoice card header

## Issues :bug:

### Closes :no_good_woman:
[VEN-1097](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1097): Admin UI. Show if the customer has refused an offer or terminated a contract

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- From the applications list, go to a single application 
- The order status should be displayed on the `Tarjous` card 

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/109331318-5f401f80-7865-11eb-9a1f-26860f0b44dc.png)

## Additional notes :spiral_notepad:
