### PR TITLE
VEN-1240 | Show all berths regardless of the suitable boat length 

### DIFF
--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useCallback } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import {
+  Cell,
   useTable,
   useExpanded,
   useSortBy,
@@ -22,6 +23,7 @@ import {
   UseFiltersInstanceProps,
   UseGlobalFiltersOptions,
   actions,
+  TableCellProps,
 } from 'react-table';
 import { IconAngleDown, IconArrowLeft } from 'hds-react';
 import equal from 'fast-deep-equal';
@@ -47,10 +49,10 @@ type TableProps<D extends object> = {
   loading?: boolean;
   canSelectRows?: boolean;
   canSelectOneRow?: boolean;
-  cellClassName?: string;
   styleMainHeader?: boolean;
   theme?: 'basic' | 'primary';
   globalFilter?: UseGlobalFiltersOptions<D>['globalFilter'];
+  getCellProps?: (cell: Cell<D>) => Partial<TableCellProps>;
   renderTableToolsTop?: TableToolsFn<D>;
   renderTableToolsBottom?: TableToolsFn<D>;
   renderSubComponent?: (row: Row<D>) => React.ReactNode;
@@ -91,11 +93,11 @@ const Table = <D extends { id: string }>({
   loading,
   canSelectRows,
   canSelectOneRow,
-  cellClassName,
   styleMainHeader = true,
   theme = 'primary',
   globalFilter,
   initialState,
+  getCellProps = () => ({}),
   renderTableToolsTop,
   renderTableToolsBottom,
   renderSubComponent,
@@ -341,16 +343,16 @@ const Table = <D extends { id: string }>({
         <div {...row.getRowProps()}>
           {row.cells.map((cell) => (
             <div
-              {...cell.getCellProps()}
-              className={classNames(
-                styles.tableCell,
+              {...cell.getCellProps([
                 {
-                  [styles.selector]: cell.column.id === SELECTOR,
-                  [styles.radioSelector]: cell.column.id === RADIO_SELECTOR,
-                  [styles.expander]: cell.column.id === EXPANDER,
+                  className: classNames(styles.tableCell, {
+                    [styles.selector]: cell.column.id === SELECTOR,
+                    [styles.radioSelector]: cell.column.id === RADIO_SELECTOR,
+                    [styles.expander]: cell.column.id === EXPANDER,
+                  }),
                 },
-                cellClassName
-              )}
+                getCellProps(cell),
+              ])}
             >
               {loading ? <LoadingCell /> : cell.render('Cell')}
             </div>

--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
+import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
 import styles from './offer.module.scss';
@@ -15,6 +16,7 @@ import InternalLink from '../../common/internalLink/InternalLink';
 import { formatDimension } from '../../common/utils/format';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
 import { Boat } from '../../common/boatCard/types';
+import ConfirmationModal from '../../common/confirmationModal/ConfirmationModal';
 import { BerthData, PierTab } from './types';
 import { isSuitableBerthLength } from './utils';
 
@@ -47,10 +49,20 @@ const Offer = ({
 }: OfferProps) => {
   const { t, i18n } = useTranslation();
 
+  const [isBerthChosen, setIsBerthChosen] = useState<BerthData | null>(null);
+
   const columns: ColumnType[] = [
     {
       Cell: ({ row }) => (
-        <Button onClick={() => handleClickSelect(row.original)} disabled={isSubmitting}>
+        <Button
+          onClick={useCallback(() => {
+            if (isSuitableBerthLength(Number(row.original.length), Number(boat?.boatLength)))
+              return handleClickSelect(row.original);
+
+            return setIsBerthChosen(row.original);
+          }, [row])}
+          disabled={isSubmitting}
+        >
           {t('offer.tableCells.select')}
         </Button>
       ),
@@ -112,42 +124,57 @@ const Offer = ({
   ];
 
   return (
-    <PageContent className={styles.offer}>
-      <PageTitle title={t('offer.title')} />
-      {harbor && <HarborCard {...harbor} className={styles.card} />}
-      {boat && <BoatCard boat={boat} />}
-      <Table
-        data={tableData}
-        columns={columns}
-        renderSubComponent={(row) => {
-          const { properties, leases, comment } = row.original;
-          return <BerthDetails leases={leases} comment={comment} {...properties} />;
-        }}
+    <>
+      <PageContent className={styles.offer}>
+        <PageTitle title={t('offer.title')} />
+        {harbor && <HarborCard {...harbor} className={styles.card} />}
+        {boat && <BoatCard boat={boat} />}
+        <Table
+          data={tableData}
+          columns={columns}
+          renderSubComponent={(row) => {
+            const { properties, leases, comment } = row.original;
+            return <BerthDetails leases={leases} comment={comment} {...properties} />;
+          }}
           getCellProps={(cell) => ({
             className: classNames({
               [styles.highlight]:
                 cell.column.id === 'length' && !isSuitableBerthLength(Number(cell?.value), Number(boat?.boatLength)),
             }),
           })}
-        renderMainHeader={(props) => (
-          <TableFilters
-            activeFilters={props.state.filters.map((filter) => filter.value)}
-            filters={piersIdentifiers}
-            handleSetFilter={(filter) => props.setFilter('pier', filter)}
-            filterPrefix={t('common.terminology.pier')}
-          />
-        )}
-        renderTableToolsTop={() => (
-          <TableTools
-            applicationDate={applicationDate}
-            applicationType={applicationType}
-            applicationStatus={applicationStatus}
-            handleReturn={handleReturn}
-          />
-        )}
-        renderEmptyStateRow={() => <p>{t('offer.berthDetails.noSuitableBerths')}</p>}
+          renderMainHeader={(props) => (
+            <TableFilters
+              activeFilters={props.state.filters.map((filter) => filter.value)}
+              filters={piersIdentifiers}
+              handleSetFilter={(filter) => props.setFilter('pier', filter)}
+              filterPrefix={t('common.terminology.pier')}
+            />
+          )}
+          renderTableToolsTop={() => (
+            <TableTools
+              applicationDate={applicationDate}
+              applicationType={applicationType}
+              applicationStatus={applicationStatus}
+              handleReturn={handleReturn}
+            />
+          )}
+          renderEmptyStateRow={() => <p>{t('offer.berthDetails.noSuitableBerths')}</p>}
+        />
+      </PageContent>
+      <ConfirmationModal
+        isOpen={!!isBerthChosen}
+        title={t('offer.confirmation.title')}
+        infoText={t('offer.confirmation.info')}
+        confirmButtonVariant="primary"
+        onCancelText={t('common.cancel')}
+        onCancel={() => setIsBerthChosen(null)}
+        onConfirmText={t('common.yes')}
+        onConfirm={() => {
+          isBerthChosen && handleClickSelect(isBerthChosen);
+          setIsBerthChosen(null);
+        }}
       />
-    </PageContent>
+    </>
   );
 };
 

--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -16,6 +16,7 @@ import { formatDimension } from '../../common/utils/format';
 import { ApplicationStatus } from '../../@types/__generated__/globalTypes';
 import { Boat } from '../../common/boatCard/types';
 import { BerthData, PierTab } from './types';
+import { isSuitableBerthLength } from './utils';
 
 interface OfferProps {
   applicationDate: string;
@@ -122,6 +123,12 @@ const Offer = ({
           const { properties, leases, comment } = row.original;
           return <BerthDetails leases={leases} comment={comment} {...properties} />;
         }}
+          getCellProps={(cell) => ({
+            className: classNames({
+              [styles.highlight]:
+                cell.column.id === 'length' && !isSuitableBerthLength(Number(cell?.value), Number(boat?.boatLength)),
+            }),
+          })}
         renderMainHeader={(props) => (
           <TableFilters
             activeFilters={props.state.filters.map((filter) => filter.value)}

--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -33,7 +33,9 @@ interface OfferProps {
   tableData: BerthData[];
 }
 
-type ColumnType = Column<BerthData> & { accessor: keyof BerthData };
+type ColumnType = Column<BerthData>;
+
+const LENGTH_ACCESSOR = 'length';
 
 const Offer = ({
   applicationDate,
@@ -103,7 +105,7 @@ const Offer = ({
     {
       Cell: ({ cell }) => formatDimension(cell.value, i18n.language),
       Header: t('common.terminology.length') || '',
-      accessor: 'length',
+      accessor: LENGTH_ACCESSOR,
       width: COLUMN_WIDTH.XS,
       minWidth: COLUMN_WIDTH.XS,
     },
@@ -139,7 +141,8 @@ const Offer = ({
           getCellProps={(cell) => ({
             className: classNames({
               [styles.highlight]:
-                cell.column.id === 'length' && !isSuitableBerthLength(Number(cell?.value), Number(boat?.boatLength)),
+                cell.column.id === LENGTH_ACCESSOR &&
+                !isSuitableBerthLength(Number(cell?.value), Number(boat?.boatLength)),
             }),
           })}
           renderMainHeader={(props) => (

--- a/src/features/offer/OfferContainer.tsx
+++ b/src/features/offer/OfferContainer.tsx
@@ -8,7 +8,7 @@ import { getOperationName } from 'apollo-link';
 import LoadingSpinner from '../../common/spinner/LoadingSpinner';
 import { OFFER_QUERY } from './queries';
 import Offer from './Offer';
-import { OFFER } from './__generated__/OFFER';
+import { OFFER, OFFERVariables as OFFER_VARS } from './__generated__/OFFER';
 import { getOfferData, getAllPiersIdentifiers, getBoat, getHarbor } from './utils';
 import { formatDate } from '../../common/utils/format';
 import { CREATE_LEASE_MUTATION } from './mutations';
@@ -26,8 +26,8 @@ const OfferContainer = () => {
   const { applicationId } = useParams<{ applicationId: string }>();
   const history = useHistory();
 
-  const { loading, error, data } = useQuery<OFFER>(OFFER_QUERY, {
-    variables: { applicationId, servicemapId: routerQuery.get('harbor') },
+  const { loading, error, data } = useQuery<OFFER, OFFER_VARS>(OFFER_QUERY, {
+    variables: { applicationId, servicemapId: routerQuery.get('harbor') || '' },
   });
   const [createBerthLease, { loading: isSubmitting }] = useMutation<CREATE_LEASE, CREATE_LEASE_VARS>(
     CREATE_LEASE_MUTATION,

--- a/src/features/offer/offer.module.scss
+++ b/src/features/offer/offer.module.scss
@@ -8,3 +8,7 @@
 .card {
   margin: units(1) 0;
 }
+
+.highlight {
+  background-color: $error-light;
+}

--- a/src/features/offer/utils.ts
+++ b/src/features/offer/utils.ts
@@ -174,3 +174,5 @@ export const getBoat = (data: OFFER | undefined): Boat | null => {
     boatWeight,
   };
 };
+
+export const isSuitableBerthLength = (berthLength: number, boatLength: number) => berthLength >= boatLength;

--- a/src/features/pricing/berthPricing/BerthPricing.tsx
+++ b/src/features/pricing/berthPricing/BerthPricing.tsx
@@ -76,7 +76,9 @@ const BerthPricing = ({ data, loading, refetchQueries }: BerthPricingProps) => {
           data={getBerthsData(data)}
           loading={loading}
           theme="basic"
-          cellClassName={styles.tableCell}
+          getCellProps={() => ({
+            className: styles.tableCell,
+          })}
           renderEmptyStateRow={() => t('common.notification.noData.description')}
         />
       </CardBody>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -302,7 +302,7 @@
         "paragraph3": "Jos hakemukseen ei ole tarjottu venepaikkaa, asiakkaalle lähetetään ilmoitus paikatta jäämisestä."
       }
     }
-    },
+  },
   "harborList": {
     "title": "Venepaikat",
     "berthSummary": {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -302,7 +302,7 @@
         "paragraph3": "Jos hakemukseen ei ole tarjottu venepaikkaa, asiakkaalle lähetetään ilmoitus paikatta jäämisestä."
       }
     }
-  },
+    },
   "harborList": {
     "title": "Venepaikat",
     "berthSummary": {
@@ -456,6 +456,10 @@
     "title": "Tarjous",
     "tableCells": {
       "select": "Valitse"
+    },
+    "confirmation": {
+      "title": "Varmista venepaikka",
+      "info": "Venepaikka on lyhyempi kuin veneen pituus. Oletko varma etta haluat tarjota tata paikkaa?"
     },
     "tableTools": {
       "berths": "Venepaikat",


### PR DESCRIPTION
## Description :sparkles:
- Expose a prop to control cell props & highlight the cells of unsuitable lengths
- Add a confirmation modal to unsuitable berths

## Issues :bug:

### Closes :no_good_woman:
[VEN-1240](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1240): Application handling: show all the free berths even when they are shorter than the customer boat

### Related :handshake:
- [VEN-1251](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1251): `piers` query: don't filter the berths based on the length when `forApplication` param is passed

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to a single applications page
- Start the process of handling an application
- On the offer page, you should be able to see berths shorter than the applicant's boat
- Short berths should be highlighted in red and a confirmation modal will be shown when selecting a short berth

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/112478561-cfff2c80-8d7c-11eb-9b84-de66380a978d.png)
![image](https://user-images.githubusercontent.com/23040926/112478602-da212b00-8d7c-11eb-9391-4bd0950d27ce.png)

## Additional notes :spiral_notepad:
