### PR TITLE
VEN-1260 | Enable Berth Invoicing in Production

### DIFF
--- a/src/common/utils/featureFlags.ts
+++ b/src/common/utils/featureFlags.ts
@@ -14,10 +14,6 @@ export const harborMooringFeatureFlag = () => {
   return process.env.NODE_ENV !== 'production';
 };
 
-export const berthInvoicingFeatureFlag = () => {
-  return process.env.REACT_APP_ENV !== 'production';
-};
-
 export const queueFeatureFlag = () => {
   return process.env.NODE_ENV !== 'production';
 };

--- a/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
+++ b/src/features/applicationView/berthOfferCard/BerthOfferCard.tsx
@@ -12,8 +12,6 @@ import PlaceDetails from './PlaceDetails';
 import { LeaseDetails } from './types';
 import DeleteButton from '../../../common/deleteButton/DeleteButton';
 import { canDeleteLease } from '../../../common/utils/leaseUtils';
-import { berthInvoicingFeatureFlag } from '../../../common/utils/featureFlags';
-
 export interface BerthOfferCardProps {
   className?: string;
   leaseDetails: LeaseDetails;
@@ -79,7 +77,6 @@ const BerthOfferCard = ({
       }
       className={className}
       customerEmail={customerEmail}
-      invoicingDisabled={!berthInvoicingFeatureFlag()}
       leaseStatus={status}
       order={order}
       placeDetails={


### PR DESCRIPTION
## Description :sparkles:
- Remove berthInvoicingFeatureFlag

## Issues :bug:

### Closes :no_good_woman:
- [VEN-1260](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1260): Enable berth invoicing in production

### Related :handshake:
- The issue raised by Joonas [in Slack](https://helsinkicity.slack.com/archives/CBA1QHTHN/p1617191906070600)

## Testing :alembic:

### Manual testing :construction_worker_man:
- In **production**, the offer card should show the `Lähetä tarjous` button
