### PR TITLE
VEN-1264 | Disable offer button for inactive berths

### DIFF
--- a/src/features/offer/Offer.tsx
+++ b/src/features/offer/Offer.tsx
@@ -63,7 +63,7 @@ const Offer = ({
 
             return setIsBerthChosen(row.original);
           }, [row])}
-          disabled={isSubmitting}
+          disabled={!row.original.isActive || isSubmitting}
         >
           {t('offer.tableCells.select')}
         </Button>

--- a/src/features/offer/__fixtures__/mockData.ts
+++ b/src/features/offer/__fixtures__/mockData.ts
@@ -72,14 +72,11 @@ export const OfferQueryData: OFFER = {
                       __typename: 'BerthNodeEdge',
                       node: {
                         __typename: 'BerthNode',
-                        id: '1',
-                        number: '1',
-                        width: 5,
-                        length: 10,
-                        depth: 5,
-                        mooringType: BerthMooringType.DINGHY_PLACE,
                         comment: 'No comments',
+                        depth: 5,
+                        id: '1',
                         isAccessible: true,
+                        isActive: true,
                         leases: {
                           __typename: 'BerthLeaseNodeConnection',
                           edges: [
@@ -99,6 +96,10 @@ export const OfferQueryData: OFFER = {
                             },
                           ],
                         },
+                        length: 10,
+                        mooringType: BerthMooringType.DINGHY_PLACE,
+                        number: '1',
+                        width: 5,
                       },
                     },
                   ],

--- a/src/features/offer/__generated__/OFFER.ts
+++ b/src/features/offer/__generated__/OFFER.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { ApplicationStatus, BerthMooringType, LeaseStatus } from "./../../../@types/__generated__/globalTypes";
+import { ApplicationStatus, LeaseStatus, BerthMooringType } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: OFFER
@@ -74,15 +74,16 @@ export interface OFFER_harborByServicemapId_properties_piers_edges_node_properti
 
 export interface OFFER_harborByServicemapId_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
+  comment: string;
+  depth: number | null;
   id: string;
+  isAccessible: boolean | null;
+  isActive: boolean;
+  leases: OFFER_harborByServicemapId_properties_piers_edges_node_properties_berths_edges_node_leases | null;
+  length: number;
+  mooringType: BerthMooringType;
   number: string;
   width: number;
-  length: number;
-  depth: number | null;
-  mooringType: BerthMooringType;
-  comment: string;
-  isAccessible: boolean | null;
-  leases: OFFER_harborByServicemapId_properties_piers_edges_node_properties_berths_edges_node_leases | null;
 }
 
 export interface OFFER_harborByServicemapId_properties_piers_edges_node_properties_berths_edges {

--- a/src/features/offer/__generated__/OFFER_WITHOUT_APPLICATION_HARBOR.ts
+++ b/src/features/offer/__generated__/OFFER_WITHOUT_APPLICATION_HARBOR.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BerthMooringType, LeaseStatus } from "./../../../@types/__generated__/globalTypes";
+import { LeaseStatus, BerthMooringType } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: OFFER_WITHOUT_APPLICATION_HARBOR
@@ -41,15 +41,16 @@ export interface OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_
 
 export interface OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
+  comment: string;
+  depth: number | null;
   id: string;
+  isAccessible: boolean | null;
+  isActive: boolean;
+  leases: OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases | null;
+  length: number;
+  mooringType: BerthMooringType;
   number: string;
   width: number;
-  length: number;
-  depth: number | null;
-  mooringType: BerthMooringType;
-  comment: string;
-  isAccessible: boolean | null;
-  leases: OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases | null;
 }
 
 export interface OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges {

--- a/src/features/offer/__generated__/OfferPiers.ts
+++ b/src/features/offer/__generated__/OfferPiers.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { BerthMooringType, LeaseStatus } from "./../../../@types/__generated__/globalTypes";
+import { LeaseStatus, BerthMooringType } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL fragment: OfferPiers
@@ -35,15 +35,16 @@ export interface OfferPiers_edges_node_properties_berths_edges_node_leases {
 
 export interface OfferPiers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
+  comment: string;
+  depth: number | null;
   id: string;
+  isAccessible: boolean | null;
+  isActive: boolean;
+  leases: OfferPiers_edges_node_properties_berths_edges_node_leases | null;
+  length: number;
+  mooringType: BerthMooringType;
   number: string;
   width: number;
-  length: number;
-  depth: number | null;
-  mooringType: BerthMooringType;
-  comment: string;
-  isAccessible: boolean | null;
-  leases: OfferPiers_edges_node_properties_berths_edges_node_leases | null;
 }
 
 export interface OfferPiers_edges_node_properties_berths_edges {

--- a/src/features/offer/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/offer/__tests__/__snapshots__/utils.test.ts.snap
@@ -48,6 +48,7 @@ Array [
     "harbor": "Pajalahden venesatama (Meripuistotie) / Venesatama",
     "harborId": "SGFyYm9yTm9kZTpmN2M2YTQwZjAtOWViMi0zZjgyMTI0YjY0OGI=",
     "id": "1",
+    "isActive": true,
     "leases": Array [
       Object {
         "customer": Object {

--- a/src/features/offer/fragments.ts
+++ b/src/features/offer/fragments.ts
@@ -36,14 +36,11 @@ export const OFFER_PIERS_FRAGMENT = gql`
           berths(isAvailable: true) {
             edges {
               node {
-                id
-                number
-                width
-                length
-                depth
-                mooringType
                 comment
+                depth
+                id
                 isAccessible
+                isActive
                 leases {
                   edges {
                     node {
@@ -57,6 +54,10 @@ export const OFFER_PIERS_FRAGMENT = gql`
                     }
                   }
                 }
+                length
+                mooringType
+                number
+                width
               }
             }
           }

--- a/src/features/offer/types.ts
+++ b/src/features/offer/types.ts
@@ -17,18 +17,18 @@ export type Lease = {
 };
 
 export type BerthData = {
-  id: string;
-  harborId: string;
-  harbor: string;
-  pier: string;
   berth: string | number;
   berthId: string;
-  width: number | null;
-  length: number | null;
-  draught: number | null;
-  mooringType: string;
-  leases: Lease[];
   comment: string;
+  draught: number | null;
+  harbor: string;
+  harborId: string;
+  id: string;
+  isActive: boolean;
+  leases: Lease[];
+  length: number | null;
+  mooringType: string;
+  pier: string;
   properties: {
     lighting: boolean | null;
     water: boolean | null;
@@ -37,6 +37,7 @@ export type BerthData = {
     wasteCollection: boolean | null;
     isAccessible: boolean | null;
   };
+  width: number | null;
 };
 
 export type PierTab = {

--- a/src/features/offer/utils.ts
+++ b/src/features/offer/utils.ts
@@ -37,18 +37,18 @@ export const getOfferData = (data: HarborData | null | undefined): BerthData[] =
       return [
         ...acc,
         {
-          id: berth.node.id,
-          harborId,
-          harbor,
-          pier: properties.identifier,
           berth: berth.node.number,
           berthId: berth.node.id,
-          width: berth.node.width,
-          length: berth.node.length,
-          draught: berth.node.depth,
-          mooringType: berth.node.mooringType,
-          leases,
           comment: berth.node.comment,
+          draught: berth.node.depth,
+          harbor,
+          harborId,
+          id: berth.node.id,
+          isActive: berth.node.isActive,
+          leases,
+          length: berth.node.length,
+          mooringType: berth.node.mooringType,
+          pier: properties.identifier,
           properties: {
             lighting: properties.lighting,
             water: properties.water,
@@ -57,6 +57,7 @@ export const getOfferData = (data: HarborData | null | undefined): BerthData[] =
             wasteCollection: properties.wasteCollection,
             isAccessible: berth.node.isAccessible,
           },
+          width: berth.node.width,
         },
       ];
     }, []);


### PR DESCRIPTION
## Description :sparkles:

* Disable offer button for inactive berths

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1264](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1264): Don't show "Not in use" berths for admin during application handling

## Testing :alembic:

### Automated tests :gear:️

* Updated mock data and snapshot

### Manual testing :construction_worker_man:

* Mark a berth as inactive
* "Valitse" button for that berth should be disabled
