### PR TITLE
VEN-1257 | Support DRAFTED & OFFERED order statuses

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -120,13 +120,14 @@ export enum OrderOrderType {
 
 export enum OrderStatus {
   CANCELLED = "CANCELLED",
+  DRAFTED = "DRAFTED",
   ERROR = "ERROR",
   EXPIRED = "EXPIRED",
+  OFFERED = "OFFERED",
   PAID = "PAID",
   PAID_MANUALLY = "PAID_MANUALLY",
   REFUNDED = "REFUNDED",
   REJECTED = "REJECTED",
-  WAITING = "WAITING",
 }
 
 export enum OrganizationType {

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -33,6 +33,10 @@ export const ORDER_STATUS: OrderStatusType = {
     label: 'common.orderStatus.cancelled',
     type: 'error',
   },
+  DRAFTED: {
+    label: 'common.orderStatus.drafted',
+    type: 'warning',
+  },
   ERROR: {
     label: 'common.orderStatus.error',
     type: 'error',
@@ -40,6 +44,10 @@ export const ORDER_STATUS: OrderStatusType = {
   EXPIRED: {
     label: 'common.orderStatus.expired',
     type: 'error',
+  },
+  OFFERED: {
+    label: 'common.orderStatus.offered',
+    type: 'warning',
   },
   PAID: {
     label: 'common.orderStatus.paid',
@@ -56,10 +64,6 @@ export const ORDER_STATUS: OrderStatusType = {
   REJECTED: {
     label: 'common.orderStatus.rejected',
     type: 'error',
-  },
-  WAITING: {
-    label: 'common.orderStatus.waiting',
-    type: 'warning',
   },
 };
 

--- a/src/common/utils/translations.ts
+++ b/src/common/utils/translations.ts
@@ -86,10 +86,14 @@ export const getOrderStatusTKey = (orderStatus: OrderStatus): string => {
   switch (orderStatus) {
     case OrderStatus.CANCELLED:
       return 'common.orderStatus.cancelled';
+    case OrderStatus.DRAFTED:
+      return 'common.orderStatus.drafted';
     case OrderStatus.ERROR:
       return 'common.orderStatus.error';
     case OrderStatus.EXPIRED:
       return 'common.orderStatus.expired';
+    case OrderStatus.OFFERED:
+      return 'common.orderStatus.offered';
     case OrderStatus.PAID:
       return 'common.orderStatus.paid';
     case OrderStatus.PAID_MANUALLY:
@@ -98,8 +102,6 @@ export const getOrderStatusTKey = (orderStatus: OrderStatus): string => {
       return 'common.orderStatus.refunded';
     case OrderStatus.REJECTED:
       return 'common.orderStatus.rejected';
-    case OrderStatus.WAITING:
-      return 'common.orderStatus.waiting';
 
     default:
       return orderStatus;

--- a/src/features/applicationView/berthOfferCard/__fixtures__/mockData.ts
+++ b/src/features/applicationView/berthOfferCard/__fixtures__/mockData.ts
@@ -57,7 +57,7 @@ export const lease: BerthLease = {
     orderNumber: '123456',
     price: '96.67',
     totalPrice: '256.70',
-    status: OrderStatus.WAITING,
+    status: OrderStatus.OFFERED,
     orderLines: {
       edges: [
         {

--- a/src/features/applicationView/berthOfferCard/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/applicationView/berthOfferCard/__tests__/__snapshots__/utils.test.ts.snap
@@ -65,7 +65,7 @@ Object {
     ],
     "orderNumber": "123456",
     "price": "96.67",
-    "status": "WAITING",
+    "status": "OFFERED",
     "totalPrice": "256.70",
   },
   "pierIdentifier": "C",

--- a/src/features/customerView/CustomerViewContainer.tsx
+++ b/src/features/customerView/CustomerViewContainer.tsx
@@ -143,7 +143,7 @@ const CustomerViewContainer = () => {
   const berthLeases = getBerthLeases(data.profile);
   const leases = [...berthLeases, ...getWinterStorageLeases(data.profile)];
   const openInvoices = invoices.filter(
-    (invoice) => invoice.status === OrderStatus.WAITING && invoice.leaseStatus !== LeaseStatus.DRAFTED
+    (invoice) => invoice.status === OrderStatus.DRAFTED && invoice.leaseStatus !== LeaseStatus.DRAFTED
   );
   const offersData = data.profile.berthLeases?.edges.filter((edge) => edge?.node?.status === LeaseStatus.DRAFTED) ?? [];
   const offers = offersData.map((offerData) => getOfferDetailsData(offerData?.node));

--- a/src/features/customerView/__fixtures__/mockData.ts
+++ b/src/features/customerView/__fixtures__/mockData.ts
@@ -35,7 +35,7 @@ export const mockInvoices: (BerthInvoice | WinterStorageInvoice)[] = [
     orderId: 'MOCK-ORDER-ID',
     orderNumber: 'MOCK-INVOICE',
     orderType: OrderOrderType.LEASE_ORDER,
-    status: OrderStatus.WAITING,
+    status: OrderStatus.OFFERED,
     berthInformation: {
       number: '1',
       pierIdentifier: 'C',

--- a/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
+++ b/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
@@ -101,7 +101,7 @@ exports[`InvoiceModal renders correctly 1`] = `
           <span
             class="value left"
           >
-            Odottaa maksua
+            Tarjottu
           </span>
         </div>
       </section>

--- a/src/features/customerView/invoicingHistoryCard/__tests__/__snapshots__/InvoicingHistoryCard.test.tsx.snap
+++ b/src/features/customerView/invoicingHistoryCard/__tests__/__snapshots__/InvoicingHistoryCard.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`InvoicingHistoryCard renders correctly 1`] = `
             <span
               class="StatusLabel-module_statusLabel__3R2J2 status-label_hds-status-label__1L8YI StatusLabel-module_alert__2VR8r status-label_hds-status-label--alert__1ecsX warning"
             >
-              Odottaa maksua
+              Tarjottu
             </span>
           </div>
         </div>

--- a/src/features/invoiceCard/InvoiceCardContainer.tsx
+++ b/src/features/invoiceCard/InvoiceCardContainer.tsx
@@ -48,7 +48,7 @@ const InvoiceCardContainer = ({
     setSelectedInvoiceAction(null);
   };
 
-  const actionsDisabled = !(order?.status === OrderStatus.ERROR || order?.status === OrderStatus.WAITING);
+  const actionsDisabled = !(order?.status === OrderStatus.ERROR || order?.status === OrderStatus.OFFERED);
 
   return (
     <>

--- a/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
+++ b/src/features/invoiceCard/__tests__/InvoiceCard.test.tsx
@@ -15,7 +15,7 @@ describe('InvoiceCard', () => {
       totalPrice: 2,
       fixedProducts: [],
       optionalProducts: [],
-      status: OrderStatus.WAITING,
+      status: OrderStatus.OFFERED,
     },
     placeType: 'place type',
     placeName: 'place name',

--- a/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
+++ b/src/features/invoiceCard/__tests__/__snapshots__/InvoiceCard.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`InvoiceCard renders normally 1`] = `
       <span
         class="StatusLabel-module_statusLabel__3R2J2 status-label_hds-status-label__1L8YI StatusLabel-module_alert__2VR8r status-label_hds-status-label--alert__1ecsX warning"
       >
-        Odottaa maksua
+        Tarjottu
       </span>
     </div>
   </div>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -170,13 +170,14 @@
     },
     "orderStatus": {
       "cancelled": "Peruutettu",
+      "drafted": "Luotu",
       "error": "Virhe",
       "expired": "Erääntynyt",
+      "offered": "Tarjottu",
       "paid": "Maksettu",
       "paidManually": "Maksettu muualla",
       "refunded": "Maksu palautettu",
-      "rejected": "Hylätty",
-      "waiting": "Odottaa maksua"
+      "rejected": "Hylätty"
     },
     "unlinkCustomer": {
       "buttonText": "Poista asiakasliitos",


### PR DESCRIPTION
## Description :sparkles:
- Replace the depricated WAITING status with OFFERED and DRAFTED statuses 

## Issues :bug:

### Closes :no_good_woman:
[VEN-1257](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1257)

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
- Updated failing snapshots 

### Manual testing :construction_worker_man:
- Everything for handling applications should work as expected 
- New statuses have been introduced
  - Luotu: before the offer is sent
  - Tarjottu: after the offer is sent

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
