### PR TITLE
VEN-1206 | Fixes to berth switch application handling

### DIFF
--- a/src/common/modal/modal.module.scss
+++ b/src/common/modal/modal.module.scss
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   max-height: 100%;
-  overflow-y: visible; // To allow dropdowns to overflow from small modals
+  overflow-y: auto;
   padding: units(3);
   position: relative;
   &:focus {

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -76,27 +76,27 @@ type OfferStatusType = {
 
 export const OFFER_STATUS: OfferStatusType = {
   ACCEPTED: {
-    label: 'common.orderStatus.accepted',
+    label: 'common.offerStatus.accepted',
     type: 'success',
   },
   CANCELLED: {
-    label: 'common.orderStatus.cancelled',
+    label: 'common.offerStatus.cancelled',
     type: 'error',
   },
   DRAFTED: {
-    label: 'common.orderStatus.drafted',
+    label: 'common.offerStatus.drafted',
     type: 'alert',
   },
   EXPIRED: {
-    label: 'common.orderStatus.expired',
+    label: 'common.offerStatus.expired',
     type: 'error',
   },
   OFFERED: {
-    label: 'common.orderStatus.offered',
+    label: 'common.offerStatus.offered',
     type: 'alert',
   },
   REJECTED: {
-    label: 'common.orderStatus.rejected',
+    label: 'common.offerStatus.rejected',
     type: 'error',
   },
 };

--- a/src/features/berthOffer/BerthSwitchOfferContainer.tsx
+++ b/src/features/berthOffer/BerthSwitchOfferContainer.tsx
@@ -110,7 +110,11 @@ const BerthSwitchOfferContainer = () => {
 
       {showSelectLease && (
         <SelectBerthLease
-          confirm={(oldLeaseId: string) => createBerthSwitchOffer(selectedBerth as BerthData, oldLeaseId)}
+          confirm={(oldLeaseId: string) => {
+            createBerthSwitchOffer(selectedBerth as BerthData, oldLeaseId).then(() => {
+              history.goBack();
+            });
+          }}
           closeModal={() => setShowSelectLease(false)}
           customerId={customerId}
           isSubmitting={isSubmitting}

--- a/src/features/berthOffer/components/BerthOfferTable.tsx
+++ b/src/features/berthOffer/components/BerthOfferTable.tsx
@@ -140,6 +140,7 @@ const BerthOfferTable = ({
       )}
       renderTableToolsTop={() => <TableTools application={application} handleReturn={handleReturn} />}
       renderEmptyStateRow={() => <p>{t('offer.berthDetails.noSuitableBerths')}</p>}
+      loading={isSubmitting}
     />
   );
 };

--- a/src/features/customerView/switchBerth/SwitchBerthModal.tsx
+++ b/src/features/customerView/switchBerth/SwitchBerthModal.tsx
@@ -27,8 +27,13 @@ const SwitchBerthModal = ({ closeModal, leaseId }: SwitchBerthModalProps) => {
   const openOfferForm = () => history.push(`/switch-berth?lease=${leaseId}&harbor=${selectedHarbor}`);
 
   return (
-    <Modal isOpen toggleModal={closeModal} label={t('customerView.switchBerth.title').toUpperCase()}>
-      <div className={styles.switchBerthModal}>
+    <Modal
+      className={styles.switchBerthModal}
+      isOpen
+      toggleModal={closeModal}
+      label={t('customerView.switchBerth.title').toUpperCase()}
+    >
+      <div className={styles.content}>
         <p className={styles.instructions}>{t('customerView.switchBerth.instructions')}</p>
 
         {loading ? (

--- a/src/features/customerView/switchBerth/switchBerthModal.module.scss
+++ b/src/features/customerView/switchBerth/switchBerthModal.module.scss
@@ -2,24 +2,28 @@
 @import 'spacings';
 
 .switchBerthModal {
+  overflow-y: visible;
+}
+
+.content {
   width: container(s);
+}
 
-  .instructions {
-    white-space: pre-wrap;
-    margin-bottom: units(2);
-  }
+.instructions {
+  white-space: pre-wrap;
+  margin-bottom: units(2);
+}
 
-  .spinnerWrapper {
-    margin-bottom: units(2);
-  }
+.spinnerWrapper {
+  margin-bottom: units(2);
+}
 
-  .select {
-    width: 100%;
-    margin-bottom: units(2);
-  }
+.select {
+  width: 100%;
+  margin-bottom: units(2);
+}
 
-  .buttons {
-    display: flex;
-    justify-content: space-between;
-  }
+.buttons {
+  display: flex;
+  justify-content: space-between;
 }


### PR DESCRIPTION
## Description :sparkles:

* Show BerthOfferTable as loading if isSubmitting
* Adjust modal overflows
  * Detected this while preparing for demo
* Fix offer status labels
* Return after creating berth switch offer via SelectBerthLease

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1206](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1206): FE - Send a berth switch offer

## Testing :alembic:

### Manual testing :construction_worker_man:

* When submitting offers, the table should change state into loading
* Both undersized and oversized modals should now behave correctly
* Offer status labels should now be correct
* Creating a switch offer where the lease has to be manually selected should now work correctly
