### PR TITLE
VEN-1132, VEN-1239 | Show success toast after SelectBerthLease, adjust wording

### DIFF
--- a/src/common/applicationDetails/__tests__/__snapshots__/ApplicationDetails.test.tsx.snap
+++ b/src/common/applicationDetails/__tests__/__snapshots__/ApplicationDetails.test.tsx.snap
@@ -778,7 +778,7 @@ exports[`ApplicationDetails renders normally with harborChoices and no customerI
       <h4
         class="text standard h4 m title"
       >
-        VALITUT SATAMAT
+        HAETUT SATAMAT
       </h4>
       <section
         class="body"
@@ -1574,7 +1574,7 @@ exports[`ApplicationDetails renders normally with organization customer applican
       <h4
         class="text standard h4 m title"
       >
-        VALITUT SATAMAT
+        HAETUT SATAMAT
       </h4>
       <section
         class="body"
@@ -2088,7 +2088,7 @@ exports[`ApplicationDetails renders normally with private customer applicant 1`]
       <h4
         class="text standard h4 m title"
       >
-        VALITUT SATAMAT
+        HAETUT SATAMAT
       </h4>
       <section
         class="body"

--- a/src/features/berthOffer/BerthSwitchOfferContainer.tsx
+++ b/src/features/berthOffer/BerthSwitchOfferContainer.tsx
@@ -82,13 +82,16 @@ const BerthSwitchOfferContainer = () => {
   const piersIdentifiers = getAllPiersIdentifiers(data?.properties?.piers);
 
   const handleReturn = () => history.goBack();
+  const onSuccess = (berth: BerthData) => {
+    history.goBack();
+    showBerthSuccessToast(berth, t);
+  };
   const handleClickSelect = (berth: BerthData) => {
     setSelectedBerth(berth);
     createBerthSwitchOffer(berth)
       .then((result) => {
         if (result.errors) return;
-        history.goBack();
-        showBerthSuccessToast(berth, t);
+        onSuccess(berth);
       })
       .catch(() => {
         setShowSelectLease(true);
@@ -111,8 +114,9 @@ const BerthSwitchOfferContainer = () => {
       {showSelectLease && (
         <SelectBerthLease
           confirm={(oldLeaseId: string) => {
-            createBerthSwitchOffer(selectedBerth as BerthData, oldLeaseId).then(() => {
-              history.goBack();
+            createBerthSwitchOffer(selectedBerth as BerthData, oldLeaseId).then((result) => {
+              if (result.errors) return;
+              onSuccess(selectedBerth as BerthData);
             });
           }}
           closeModal={() => setShowSelectLease(false)}

--- a/src/features/customerView/applicationsCard/__snapshots__/ApplicationsCard.test.tsx.snap
+++ b/src/features/customerView/applicationsCard/__snapshots__/ApplicationsCard.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`ApplicationsCard renders normally 1`] = `
           <h4
             class="text standard h4 m title"
           >
-            VALITUT SATAMAT
+            HAETUT SATAMAT
           </h4>
           <section
             class="body"

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -919,9 +919,9 @@
   "applicationDetails": {
     "applicationChoicesList": {
       "choice": "Toive",
-      "selectedPorts": "VALITUT SATAMAT",
+      "selectedPorts": "HAETUT SATAMAT",
       "selectedWinterStorageAreas": "VALITUT TALVISÄILYTYSPAIKAT",
-      "noPlaces": "Ei paikkoja",
+      "noPlaces": "Jätä ilman paikkaa",
       "noPlacesModalInfo": "Asiakkaalle lähetetään sähköpostitse ilmoitus ettei haettuja paikkoja ole saatavilla.",
       "noPlacesModalTitle": "Oletko varma että haluat jättää ilman paikkaa?"
     }


### PR DESCRIPTION
## Description :sparkles:

* Adjust wording on ApplicationDetails
* Show success toast after succesfully creating an offer using SelectBerthLease

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1132](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1132): Change terminology in application view offer card
* [VEN-1239](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1239): Add dialog for exchange application handling when the system can't match pier/berth data

## Testing :alembic:

### Manual testing :construction_worker_man:

* Create an offer for a customer with an existing lease and a switch application that has an incorrect current berth
* There should be a success toast after creating the offer
