### PR TITLE
VEN-1038 | Disable changing time period for existing additional invoice pricing row

### DIFF
--- a/src/features/pricing/additionalServicePricing/form/AdditionalServicesForm.tsx
+++ b/src/features/pricing/additionalServicePricing/form/AdditionalServicesForm.tsx
@@ -165,6 +165,7 @@ const AdditionalServicesForm = ({
                 id="period"
                 name="period"
                 label={t('pricing.additionalServices.period')}
+                disabled={initialValues?.period}
                 options={periodOptions.map((option) => ({
                   value: option,
                   label: t(getPeriodTKey(option)),

--- a/src/features/pricing/additionalServicePricing/form/__tests__/__snapshots__/AdditionalServicesForm.test.tsx.snap
+++ b/src/features/pricing/additionalServicePricing/form/__tests__/__snapshots__/AdditionalServicesForm.test.tsx.snap
@@ -254,7 +254,7 @@ exports[`AdditionalServicesForm renders normally 1`] = `
     class="grid cols3 row"
   >
     <div
-      class="Select-module_root__Ka5uO select"
+      class="Select-module_root__Ka5uO Select-module_disabled__3MKDP select"
     >
       <label
         class="FieldLabel-module_label__2tl-4 text-input_hds-text-input__label__pDw_W "
@@ -278,6 +278,7 @@ exports[`AdditionalServicesForm renders normally 1`] = `
           aria-labelledby="period-label period-toggle-button"
           aria-owns="period-menu"
           class="Select-module_button__1aIsm"
+          disabled=""
           id="period-toggle-button"
           type="button"
         >


### PR DESCRIPTION
## Description :sparkles:
* Disable changing time period for existing additional invoice pricing row

## Issues :bug:

### Closes :no_good_woman:
* [VEN-1038](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1038): Additional invoice edit error not showing

## Testing :alembic:

### Automated tests :gear:️
* Updated snapshots

### Manual testing :construction_worker_man:
* Changing the time period for an existing additional invoice pricing row should be disabled