### PR TITLE
VEN-1235 | Change "delete notice" to "delete application" for applications

### DIFF
--- a/src/common/applicationHeader/ApplicationHeader.tsx
+++ b/src/common/applicationHeader/ApplicationHeader.tsx
@@ -11,23 +11,25 @@ import DeleteButton from '../deleteButton/DeleteButton';
 import styles from './applicationHeader.module.scss';
 
 interface ApplicationHeaderProps {
-  text: string;
   createdAt: string;
-  status: ApplicationStatus;
   customerId?: string;
+  deleteApplicationLabel?: string;
   isDeletingApplication?: boolean;
+  status: ApplicationStatus;
+  text: string;
   handleUnlinkCustomer?(): void;
   handleDeleteApplication?(): void;
 }
 
 const ApplicationHeader = ({
-  text,
   createdAt,
-  status,
   customerId,
-  isDeletingApplication,
+  deleteApplicationLabel,
   handleDeleteApplication,
   handleUnlinkCustomer,
+  isDeletingApplication,
+  status,
+  text,
 }: ApplicationHeaderProps) => {
   const { t, i18n } = useTranslation();
   return (
@@ -48,7 +50,7 @@ const ApplicationHeader = ({
         )}
         {canDeleteApplication(status) && handleDeleteApplication && (
           <DeleteButton
-            buttonText={t('unmarkedWsNotices.view.deleteNotice')}
+            buttonText={deleteApplicationLabel ?? t('common.deleteApplication')}
             onConfirm={handleDeleteApplication}
             disabled={isDeletingApplication}
           />

--- a/src/common/applicationHeader/__tests__/__snapshots__/ApplicationHeader.test.tsx.snap
+++ b/src/common/applicationHeader/__tests__/__snapshots__/ApplicationHeader.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`ApplicationHeader renders correctly 1`] = `
       <span
         class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
       >
-        Poista ilmoitus
+        Poista hakemus
       </span>
     </button>
   </div>

--- a/src/features/applicationView/__tests__/__snapshots__/ApplicationView.test.tsx.snap
+++ b/src/features/applicationView/__tests__/__snapshots__/ApplicationView.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ApplicationView renders normally with minimum props 1`] = `
         <span
           class="Button-module_label__2zMLC button_hds-button__label__2EQa-"
         >
-          Poista ilmoitus
+          Poista hakemus
         </span>
       </button>
     </div>

--- a/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeView.tsx
+++ b/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeView.tsx
@@ -70,6 +70,7 @@ const UnmarkedWsNoticeView = ({
 
       <ApplicationHeader
         text={t('applicationList.applicationType.notice')}
+        deleteApplicationLabel={t('unmarkedWsNotices.view.deleteNotice')}
         createdAt={noticeDetails.createdAt}
         status={noticeDetails.status}
         customerId={noticeDetails.customerId}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -41,6 +41,7 @@
     "select": "Valitse",
     "total": "Yhteensä",
     "yes": "Kyllä",
+    "deleteApplication": "Poista hakemus",
     "table": {
       "minimizeAll": "Pienennä kaikki",
       "all": "Kaikki",


### PR DESCRIPTION
## Description :sparkles:

* Change "delete notice" to "delete application" for applications

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1235](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1235): Wrong label in "delete application" button

## Testing :alembic:

### Automated tests :gear:️

* Updated snapshots

### Manual testing :construction_worker_man:

* Delete button on application view should now say "Delete application"
* Delete button on nmarked winter storage notice view should still say "Delete notice"
