### PR TITLE
VEN-1115 | Sort application status filters

### DIFF
--- a/src/common/tableTools/applicationTableTools/ApplicationTableTools.tsx
+++ b/src/common/tableTools/applicationTableTools/ApplicationTableTools.tsx
@@ -25,8 +25,8 @@ const ApplicationTableTools = ({
   const { t } = useTranslation();
   const options = [
     { label: t('common.all'), value: '' as ApplicationStatus },
-    ...Object.values(ApplicationStatus).map((status) => {
-      return { label: t(APPLICATION_STATUS[status].label), value: status };
+    ...Object.entries(APPLICATION_STATUS).map(([key, value]) => {
+      return { label: t(value.label), value: ApplicationStatus[key as ApplicationStatus] };
     }),
   ];
   return (

--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -9,6 +9,7 @@ type ApplicationStatusType = {
 };
 
 export const APPLICATION_STATUS: ApplicationStatusType = {
+  // Note: Changing the order affects the status filters in application list view
   PENDING: { label: 'applicationList.status.pending', type: 'alert' },
   OFFER_GENERATED: {
     label: 'applicationList.status.offerGenerated',
@@ -16,9 +17,9 @@ export const APPLICATION_STATUS: ApplicationStatusType = {
   },
   OFFER_SENT: { label: 'applicationList.status.offerSent', type: 'success' },
   HANDLED: { label: 'applicationList.status.handled', type: 'info' },
-  EXPIRED: { label: 'applicationList.status.expired', type: 'neutral' },
   NO_SUITABLE_BERTHS: { label: 'applicationList.status.noSuitable', type: 'error' },
   REJECTED: { label: 'applicationList.status.rejected', type: 'error' },
+  EXPIRED: { label: 'applicationList.status.expired', type: 'neutral' },
 };
 
 type OrderStatusType = {


### PR DESCRIPTION
## Description :sparkles:

* Sorted application status filters to represent the application flow better

## Issues :bug:

### Closes :no_good_woman:

* [VEN-1115](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1115): Filter dropdown items in unlogical order - Application list view

## Testing :alembic:

### Manual testing :construction_worker_man:

* The application status filters should now be in a logical order
