### PR TITLE
VEN-1160 | Refund Orders

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -127,6 +127,12 @@ export enum OrderOrderType {
   LEASE_ORDER = "LEASE_ORDER",
 }
 
+export enum OrderRefundStatus {
+  ACCEPTED = "ACCEPTED",
+  PENDING = "PENDING",
+  REJECTED = "REJECTED",
+}
+
 export enum OrderStatus {
   CANCELLED = "CANCELLED",
   DRAFTED = "DRAFTED",
@@ -419,6 +425,12 @@ export interface OrganizationInput {
   address?: string | null;
   postalCode?: string | null;
   city?: string | null;
+}
+
+export interface RefundOrderMutationInput {
+  orderId: string;
+  profileToken?: string | null;
+  clientMutationId?: string | null;
 }
 
 export interface RejectBerthApplicationMutationInput {

--- a/src/features/invoiceCard/InvoiceCardContainer.tsx
+++ b/src/features/invoiceCard/InvoiceCardContainer.tsx
@@ -6,6 +6,7 @@ import Modal from '../../common/modal/Modal';
 import SendInvoiceForm from './sendInvoiceForm/SendInvoiceFormContainer';
 import MarkAsPaidForm from './markAsPaidForm/MarkAsPaidFormContainer';
 import CancelInvoice from './cancelInvoice/CancelInvoiceContainer';
+import RefundOrder from './refundOrder/RefundOrderContainer';
 import EditForm from './editForm/EditForm';
 import InvoiceCard, { InvoiceCardProps } from './InvoiceCard';
 import InvoiceActions from './invoiceActions/InvoiceActions';
@@ -30,6 +31,7 @@ const InvoiceCardContainer = ({
   const [sendInvoiceModalOpen, setSendInvoiceModalOpen] = useState(false);
   const [markAsPaidModalOpen, setMarkAsPaidModalOpen] = useState(false);
   const [cancelInvoiceModalOpen, setCancelInvoiceModalOpen] = useState(false);
+  const [refundModalOpen, setRefundModalOpen] = useState(false);
 
   const [selectedInvoiceAction, setSelectedInvoiceAction] = useState<number | null>(null);
 
@@ -40,6 +42,11 @@ const InvoiceCardContainer = ({
 
   const closeMarkAsPaidModal = () => {
     setMarkAsPaidModalOpen(false);
+    setSelectedInvoiceAction(null);
+  };
+
+  const closeRefundModal = () => {
+    setRefundModalOpen(false);
     setSelectedInvoiceAction(null);
   };
 
@@ -75,6 +82,15 @@ const InvoiceCardContainer = ({
               setSelectedInvoiceAction(1);
             },
           },
+          {
+            value: 2,
+            label: t('invoiceCard.refund.label'),
+            disabled: order?.status !== OrderStatus.PAID || invoiceCardProps.leaseStatus !== LeaseStatus.PAID,
+            onClick: () => {
+              setRefundModalOpen(true);
+              setSelectedInvoiceAction(2);
+            },
+          },
         ]}
       />
       <InvoiceCard
@@ -98,6 +114,14 @@ const InvoiceCardContainer = ({
           </Modal>
           <Modal isOpen={markAsPaidModalOpen} toggleModal={closeMarkAsPaidModal}>
             <MarkAsPaidForm orderId={order.id} onClose={closeMarkAsPaidModal} refetchQueries={refetchQueries} />
+          </Modal>
+          <Modal isOpen={refundModalOpen} toggleModal={closeRefundModal}>
+            <RefundOrder
+              amount={order.totalPrice}
+              orderId={order.id}
+              onClose={closeRefundModal}
+              refetchQueries={refetchQueries}
+            />
           </Modal>
           <Modal isOpen={sendInvoiceModalOpen} toggleModal={() => setSendInvoiceModalOpen(false)}>
             <SendInvoiceForm

--- a/src/features/invoiceCard/refundOrder/RefundOrder.tsx
+++ b/src/features/invoiceCard/refundOrder/RefundOrder.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Button from '../../../common/button/Button';
+import FormHeader from '../../../common/formHeader/FormHeader';
+import { formatPrice } from '../../../common/utils/format';
+import styles from './refundOrder.module.scss';
+
+export interface RefundOrderProps {
+  amount: number;
+  isSubmitting: boolean;
+  onClose(): void;
+  onSubmit(): void;
+}
+
+const RefundOrder = ({ amount, isSubmitting, onClose, onSubmit }: RefundOrderProps) => {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <div className={styles.refundOrder}>
+      <FormHeader title={t('invoiceCard.refund.title').toUpperCase()} />
+      <p className={styles.description}>
+        {t('invoiceCard.refund.description', { amount: formatPrice(amount, i18n.language) })}
+      </p>
+      <div className={styles.buttons}>
+        <Button variant="secondary" color={'supplementary'} onClick={onClose} disabled={isSubmitting}>
+          {t('forms.common.cancel')}
+        </Button>
+        <Button onClick={onSubmit} disabled={isSubmitting}>
+          {t('common.save')}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default RefundOrder;

--- a/src/features/invoiceCard/refundOrder/RefundOrderContainer.tsx
+++ b/src/features/invoiceCard/refundOrder/RefundOrderContainer.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useMutation } from '@apollo/react-hooks';
+import { PureQueryOptions } from 'apollo-client';
+
+import RefundOrder from './RefundOrder';
+import { REFUND_ORDER_MUTATION } from './mutations';
+import { REFUND_ORDER, REFUND_ORDERVariables as REFUND_ORDER_VARS } from './__generated__/REFUND_ORDER';
+
+export interface RefundOrderContainerProps {
+  orderId: string;
+  amount: number;
+  refetchQueries?: PureQueryOptions[] | string[];
+  onClose(): void;
+}
+
+const RefundOrderContainer = ({ amount, orderId, refetchQueries, onClose }: RefundOrderContainerProps) => {
+  const [refundOrder, { loading: isSubmitting }] = useMutation<REFUND_ORDER, REFUND_ORDER_VARS>(REFUND_ORDER_MUTATION, {
+    variables: {
+      input: { orderId },
+    },
+    refetchQueries: refetchQueries ?? [],
+  });
+
+  const handleSubmit = async () => {
+    await refundOrder();
+    onClose();
+  };
+
+  return <RefundOrder amount={amount} onSubmit={handleSubmit} onClose={onClose} isSubmitting={isSubmitting} />;
+};
+
+export default RefundOrderContainer;

--- a/src/features/invoiceCard/refundOrder/__generated__/REFUND_ORDER.ts
+++ b/src/features/invoiceCard/refundOrder/__generated__/REFUND_ORDER.ts
@@ -1,0 +1,35 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { RefundOrderMutationInput, OrderStatus, OrderRefundStatus } from "./../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: REFUND_ORDER
+// ====================================================
+
+export interface REFUND_ORDER_refundOrder_orderRefund_order {
+  __typename: "OrderNode";
+  status: OrderStatus;
+}
+
+export interface REFUND_ORDER_refundOrder_orderRefund {
+  __typename: "OrderRefundNode";
+  order: REFUND_ORDER_refundOrder_orderRefund_order;
+  status: OrderRefundStatus;
+  amount: any;
+}
+
+export interface REFUND_ORDER_refundOrder {
+  __typename: "RefundOrderMutationPayload";
+  orderRefund: REFUND_ORDER_refundOrder_orderRefund;
+}
+
+export interface REFUND_ORDER {
+  refundOrder: REFUND_ORDER_refundOrder | null;
+}
+
+export interface REFUND_ORDERVariables {
+  input: RefundOrderMutationInput;
+}

--- a/src/features/invoiceCard/refundOrder/__tests__/RefundOrderContainer.test.tsx
+++ b/src/features/invoiceCard/refundOrder/__tests__/RefundOrderContainer.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { MockedProvider, MockedResponse } from '@apollo/react-testing';
+import waitForExpect from 'wait-for-expect';
+import { act } from 'react-dom/test-utils';
+
+import RefundOrderContainer, { RefundOrderContainerProps } from '../RefundOrderContainer';
+import RefundOrder from '../RefundOrder';
+import { REFUND_ORDER_MUTATION } from '../mutations';
+import { OrderRefundStatus, OrderStatus } from '../../../../@types/__generated__/globalTypes';
+
+describe('RefundOrderContainer', () => {
+  const initialProps: RefundOrderContainerProps = {
+    orderId: '5999e366-6db6-46b0-a728-a150a8b5b8f3',
+    amount: 220,
+    refetchQueries: [],
+    onClose: jest.fn(),
+  };
+
+  const getWrapper = (props: Partial<RefundOrderContainerProps> = {}, queryMocks?: ReadonlyArray<MockedResponse>) =>
+    mount(
+      <MockedProvider mocks={queryMocks ?? []}>
+        <RefundOrderContainer {...initialProps} {...props} />
+      </MockedProvider>
+    );
+
+  it('renders RefundOrder', () => {
+    const wrapper = getWrapper();
+
+    expect(wrapper.find(RefundOrder)).toHaveLength(1);
+  });
+
+  it('calls the mutation correctly', async () => {
+    let mutationMockCalled = false;
+    const mutationMock = {
+      request: {
+        query: REFUND_ORDER_MUTATION,
+        variables: {
+          input: {
+            orderId: initialProps.orderId,
+          },
+        },
+      },
+      result: function () {
+        mutationMockCalled = true;
+        return {
+          data: {
+            refundOrder: {
+              __typename: 'RefundOrderMutationPayload',
+              orderRefund: {
+                __typename: 'OrderRefundNode',
+                order: {
+                  __typename: 'OrderNode',
+                  status: OrderStatus.PAID,
+                },
+                status: OrderRefundStatus.PENDING,
+                amount: initialProps.amount,
+              },
+            },
+          },
+        };
+      },
+    };
+
+    const wrapper = getWrapper(undefined, [mutationMock]);
+    await act(async () => {
+      const handleSubmit = wrapper.find(RefundOrder).prop('onSubmit');
+
+      handleSubmit();
+
+      await waitForExpect(() => {
+        wrapper.update();
+        expect(mutationMockCalled).toBe(true);
+      });
+    });
+  });
+});

--- a/src/features/invoiceCard/refundOrder/mutations.ts
+++ b/src/features/invoiceCard/refundOrder/mutations.ts
@@ -1,0 +1,15 @@
+import gql from 'graphql-tag';
+
+export const REFUND_ORDER_MUTATION = gql`
+  mutation REFUND_ORDER($input: RefundOrderMutationInput!) {
+    refundOrder(input: $input) {
+      orderRefund {
+        order {
+          status
+        }
+        status
+        amount
+      }
+    }
+  }
+`;

--- a/src/features/invoiceCard/refundOrder/refundOrder.module.scss
+++ b/src/features/invoiceCard/refundOrder/refundOrder.module.scss
@@ -1,6 +1,12 @@
+@import 'spacings';
+@import 'containers';
+
 .refundOrder {
+  width: container(s);
+
   .buttons {
     display: flex;
     justify-content: space-between;
+    margin-top: units(2.5);
   }
 }

--- a/src/features/invoiceCard/refundOrder/refundOrder.module.scss
+++ b/src/features/invoiceCard/refundOrder/refundOrder.module.scss
@@ -1,0 +1,6 @@
+.refundOrder {
+  .buttons {
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -896,6 +896,11 @@
       "title": "Muokkaa tarjous/lasku",
       "description": "Huom. Muokatun laskun tiedot lähetetään asiakkaalle uudelleen sähköpostitse.",
       "cancelInvoice": "Peru lasku"
+    },
+    "refund": {
+      "label": "Maksunpalautus",
+      "title": "Maksunpalautus",
+      "description": "Oletko varma että haluat palauttaa {{ amount }}?"
     }
   },
   "additionalInvoice": {


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

### Closes :no_good_woman:
[VEN-1160](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1160): Admin can refund full invoice amount to the customer

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
https://github.com/City-of-Helsinki/berth-reservations-admin/blob/c07156f5856575149c861ec52a559a629f65c81e/src/features/invoiceCard/refundOrder/__tests__/RefundOrderContainer.test.tsx

### Manual testing :construction_worker_man:
- After handling an application and sending an offer, the user should sign and pay the order
- From the single application view, click on the `Laskun muokkaus` dropdown and select `Maksunpalautus` 
- Submit the refund order 

NOTE: For technical reasons, the order status remains `PAID` for about five minutes after submitting the refund order, so only by refreshing the page after a while the admin would see the `REFUNDED` status.

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/116069497-1d303000-a694-11eb-9e02-ffc1217fe3db.png)

## Additional notes :spiral_notepad:
