### PR TITLE
VEN-1332 |  Replace Pier id with its identifier on the Lease Details card

### DIFF
--- a/src/features/applicationView/__fixtures__/mockData.ts
+++ b/src/features/applicationView/__fixtures__/mockData.ts
@@ -50,9 +50,10 @@ export const mockBerthSwitch: BERTH_SWITCH = {
     number: '1',
     pier: {
       __typename: 'PierNode',
-      id: 'A',
+      id: 'MOCK-PIER-0',
       properties: {
         __typename: 'PierProperties',
+        identifier: 'A',
         harbor: {
           __typename: 'HarborNode',
           id: 'MOCK-HARBOR',

--- a/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
+++ b/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
@@ -67,6 +67,7 @@ export interface INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_berth_pier_
 
 export interface INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_berth_pier_properties {
   __typename: "PierProperties";
+  identifier: string;
   harbor: INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_berth_pier_properties_harbor;
 }
 

--- a/src/features/applicationView/queries.ts
+++ b/src/features/applicationView/queries.ts
@@ -54,6 +54,7 @@ export const INDIVIDUAL_APPLICATION_QUERY = gql`
           pier {
             id
             properties {
+              identifier
               harbor {
                 id
                 properties {

--- a/src/features/applicationView/utils.ts
+++ b/src/features/applicationView/utils.ts
@@ -124,7 +124,7 @@ export const getApplicationDetailsData = (
         harborId: berthApplication.berthSwitch.berth.pier.properties?.harbor.id ?? '',
         harborName: berthApplication.berthSwitch.berth.pier.properties?.harbor.properties?.name ?? '',
         berthNum: berthApplication.berthSwitch.berth.number,
-        pierIdentifier: berthApplication.berthSwitch.berth.pier.id,
+        pierIdentifier: berthApplication.berthSwitch.berth.pier.properties?.identifier ?? '',
         reason: berthApplication.berthSwitch.reason?.title || null,
       }
     : null;


### PR DESCRIPTION
## Description :sparkles:
- Replace the Pier id with its identifier on the Lease Details card on the single application page

## Issues :bug:

### Closes :no_good_woman:
- [VEN-1332](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1332): Hakemus card is showing pier id instead of the "identifier"

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- Go to a single switch application page
- On the Hakemus card, the value of "Satama ja paikka" should show the pier identifier e.g. "A" instead of the id 

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/117440524-d4526400-af3c-11eb-9c2e-05eda0067970.png)

## Additional notes :spiral_notepad:
