### PR TITLE
VEN-1334 | Winter Storage Areas: Display active leases that have no applications attached

### DIFF
--- a/src/common/tableTools/globalSearchTableTools/globalSearchTableTools.module.scss
+++ b/src/common/tableTools/globalSearchTableTools/globalSearchTableTools.module.scss
@@ -11,6 +11,6 @@
   input {
     background-color: $white;
   }
-  width: 25%;
+  width: 22em;
   min-width: units(12);
 }

--- a/src/features/harborView/HarborViewTable.tsx
+++ b/src/features/harborView/HarborViewTable.tsx
@@ -40,14 +40,11 @@ const HarborViewTable = ({ berths, piers, onAddBerth, onAddPier, onEditBerth, on
     {
       Cell: ({ cell }: { cell: Cell<Berth> }) => {
         const isBerthActive = cell.row.original.isActive;
-        if (!isBerthActive) {
-          return <StatusLabel type="error" label={t('harborView.berthProperties.inactive')} />;
-        }
-        const activeLease = cell.row.original.leases?.find((lease) => lease.isActive);
-        if (!activeLease) {
-          return cell.value;
-        }
-        return <CustomerName id={cell.value} />;
+        if (!isBerthActive) return <StatusLabel type="error" label={t('harborView.berthProperties.inactive')} />;
+
+        if (cell.value) return <CustomerName id={cell.value} />;
+
+        return '';
       },
       Header: t('harborView.tableHeaders.customer') || '',
       accessor: ({ leases }) => {

--- a/src/features/harborView/customerName/CustomerName.tsx
+++ b/src/features/harborView/customerName/CustomerName.tsx
@@ -9,9 +9,10 @@ import LoadingCell from '../../../common/table/loadingCell/LoadingCell';
 
 export interface CustomerNameProps {
   id: string;
+  customInternalLink?: string;
 }
 
-const CustomerName = ({ id }: CustomerNameProps) => {
+const CustomerName = ({ id, customInternalLink }: CustomerNameProps) => {
   const { t } = useTranslation();
   const { loading, data } = useQuery<CUSTOMER_NAME>(CUSTOMER_NAME_QUERY, {
     variables: {
@@ -20,9 +21,13 @@ const CustomerName = ({ id }: CustomerNameProps) => {
   });
 
   if (loading) return <LoadingCell />;
-  if (!data?.profile) return <InternalLink to={`/customers/${id}}`}>{t('common.emptyName')}</InternalLink>;
+  if (!data?.profile) return <InternalLink to={`/customers/${id}`}>{t('common.emptyName')}</InternalLink>;
 
-  return <InternalLink to={`/customers/${id}}`}>{`${data.profile.lastName} ${data.profile.firstName}`}</InternalLink>;
+  return (
+    <InternalLink
+      to={customInternalLink || `/customers/${id}`}
+    >{`${data.profile.lastName} ${data.profile.firstName}`}</InternalLink>
+  );
 };
 
 export default CustomerName;

--- a/src/features/harborView/customerName/CustomerName.tsx
+++ b/src/features/harborView/customerName/CustomerName.tsx
@@ -9,10 +9,10 @@ import LoadingCell from '../../../common/table/loadingCell/LoadingCell';
 
 export interface CustomerNameProps {
   id: string;
-  customInternalLink?: string;
+  linkTo?: string;
 }
 
-const CustomerName = ({ id, customInternalLink }: CustomerNameProps) => {
+const CustomerName = ({ id, linkTo }: CustomerNameProps) => {
   const { t } = useTranslation();
   const { loading, data } = useQuery<CUSTOMER_NAME>(CUSTOMER_NAME_QUERY, {
     variables: {
@@ -25,7 +25,7 @@ const CustomerName = ({ id, customInternalLink }: CustomerNameProps) => {
 
   return (
     <InternalLink
-      to={customInternalLink || `/customers/${id}`}
+      to={linkTo || `/customers/${id}`}
     >{`${data.profile.lastName} ${data.profile.firstName}`}</InternalLink>
   );
 };

--- a/src/features/winterStorageAreaView/UnmarkedWinterStorageLeaseTable.tsx
+++ b/src/features/winterStorageAreaView/UnmarkedWinterStorageLeaseTable.tsx
@@ -3,12 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { Cell } from 'react-table';
 
 import { Lease, UnmarkedWinterStorage } from './types';
-import InternalLink from '../../common/internalLink/InternalLink';
 import Table, { Column, COLUMN_WIDTH } from '../../common/table/Table';
 import Pagination from '../../common/pagination/Pagination';
 import GlobalSearchTableTools from '../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
 import { formatDate } from '../../common/utils/format';
 import CardHeader from '../../common/cardHeader/CardHeader';
+import StatusLabel from '../../common/statusLabel/StatusLabel';
+import CustomerName from '../harborView/customerName/CustomerName';
 
 type ColumnType = Column<Lease>;
 
@@ -25,15 +26,24 @@ const WinterStoragePlaceTable = ({ leases, className }: WinterStorageAreaViewTab
   const columns: ColumnType[] = [
     {
       Cell: ({ cell }: { cell: Cell<Lease> }) => {
-        const lease = cell.row.original;
-        return <InternalLink to={`/unmarked-ws-notices/${lease.applicationId}`}>{cell.value}</InternalLink>;
+        const isBerthActive = cell.row.original.isActive;
+        if (!isBerthActive) return <StatusLabel type="error" label={t('harborView.berthProperties.inactive')} />;
+
+        if (cell.value)
+          return (
+            <CustomerName
+              customInternalLink={`/unmarked-ws-notices/${cell.row.original.applicationId}`}
+              id={cell.value}
+            />
+          );
+
+        return '';
       },
       Header: t('winterStorageAreaView.tableHeaders.customer') as string,
-      accessor: ({ customer }) => {
-        return `${customer.firstName} ${customer.lastName}`;
-      },
+      accessor: ({ customer }) => customer.id,
       id: 'leases',
-      filter: 'text',
+      disableFilters: true,
+      disableSortBy: true,
     },
     {
       Header: t('winterStorageAreaView.tableHeaders.notified') as string,

--- a/src/features/winterStorageAreaView/UnmarkedWinterStorageLeaseTable.tsx
+++ b/src/features/winterStorageAreaView/UnmarkedWinterStorageLeaseTable.tsx
@@ -26,16 +26,11 @@ const WinterStoragePlaceTable = ({ leases, className }: WinterStorageAreaViewTab
   const columns: ColumnType[] = [
     {
       Cell: ({ cell }: { cell: Cell<Lease> }) => {
-        const isBerthActive = cell.row.original.isActive;
-        if (!isBerthActive) return <StatusLabel type="error" label={t('harborView.berthProperties.inactive')} />;
+        const isPlaceActive = cell.row.original.isActive;
+        if (!isPlaceActive) return <StatusLabel type="error" label={t('winterStorageAreaView.place.inactive')} />;
 
         if (cell.value)
-          return (
-            <CustomerName
-              customInternalLink={`/unmarked-ws-notices/${cell.row.original.applicationId}`}
-              id={cell.value}
-            />
-          );
+          return <CustomerName linkTo={`/unmarked-ws-notices/${cell.row.original.applicationId}`} id={cell.value} />;
 
         return '';
       },

--- a/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
+++ b/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
@@ -34,9 +34,8 @@ const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageA
     },
     {
       Cell: ({ cell }: { cell: Cell<WinterStoragePlace> }) => {
-        const isBerthActive = cell.row.original.isActive;
-        if (!isBerthActive)
-          return <StatusLabel type="error" label={t('winterStorageAreaView.berthProperties.inactive')} />;
+        const isPlaceActive = cell.row.original.isActive;
+        if (!isPlaceActive) return <StatusLabel type="error" label={t('winterStorageAreaView.place.inactive')} />;
 
         if (cell.value) return <CustomerName id={cell.value} />;
 

--- a/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
+++ b/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from 'react-i18next';
 import { Cell } from 'react-table';
 
 import { WinterStoragePlace, WinterStorageSection } from './types';
-import InternalLink from '../../common/internalLink/InternalLink';
 import Table, { Column } from '../../common/table/Table';
 import StatusLabel from '../../common/statusLabel/StatusLabel';
 import SelectHeader from '../../common/selectHeader/SelectHeader';
 import Pagination from '../../common/pagination/Pagination';
 import GlobalSearchTableTools from '../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
 import { formatDimension } from '../../common/utils/format';
+import CustomerName from '../harborView/customerName/CustomerName';
 
 type ColumnType = Column<WinterStoragePlace>;
 
@@ -34,24 +34,23 @@ const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageA
     },
     {
       Cell: ({ cell }: { cell: Cell<WinterStoragePlace> }) => {
-        const isPlaceActive = cell.row.original.isActive;
-        if (!isPlaceActive) {
+        const isBerthActive = cell.row.original.isActive;
+        if (!isBerthActive)
           return <StatusLabel type="error" label={t('winterStorageAreaView.berthProperties.inactive')} />;
-        }
-        const activeLease = cell.row.original.leases?.find((lease) => lease.isActive);
-        if (!activeLease) {
-          return cell.value;
-        }
-        return <InternalLink to={`/customers/${activeLease.customer.id}`}>{cell.value}</InternalLink>;
+
+        if (cell.value) return <CustomerName id={cell.value} />;
+
+        return '';
       },
       Header: t('winterStorageAreaView.tableHeaders.customer') || '',
       accessor: ({ leases }) => {
         const activeLease = leases?.find((lease) => lease.isActive);
         if (!activeLease) return '';
-        return `${activeLease.customer.firstName} ${activeLease.customer.lastName}`;
+        return activeLease.customer.id;
       },
       id: 'leases',
-      filter: 'text',
+      disableFilters: true,
+      disableSortBy: true,
     },
     {
       Header: t('winterStorageAreaView.tableHeaders.length') || '',

--- a/src/features/winterStorageAreaView/__fixtures__/mockData.ts
+++ b/src/features/winterStorageAreaView/__fixtures__/mockData.ts
@@ -45,14 +45,12 @@ export const mockData: INDIVIDUAL_WINTER_STORAGE_AREA = {
                                 endDate: '2021-06-10',
                                 status: LeaseStatus.DRAFTED,
                                 isActive: false,
+                                customer: {
+                                  __typename: 'ProfileNode',
+                                  id: 'UHJvZmlsZU5vZGU6NWNjYzgyNDUtNmRiOS00YTRiLWI5NTEtNWYxNDQ5YTY5NzY2',
+                                },
                                 application: {
                                   createdAt: '2020-07-17T10:52:57.079036+00:00',
-                                  customer: {
-                                    id: 'UHJvZmlsZU5vZGU6NWNjYzgyNDUtNmRiOS00YTRiLWI5NTEtNWYxNDQ5YTY5NzY2',
-                                    firstName: 'Heikki',
-                                    lastName: 'Kinnunen',
-                                    __typename: 'ProfileNode',
-                                  },
                                   id: 'foo',
                                   __typename: 'WinterStorageApplicationNode',
                                 },
@@ -83,6 +81,10 @@ export const mockData: INDIVIDUAL_WINTER_STORAGE_AREA = {
                                 endDate: '2021-06-10',
                                 status: LeaseStatus.DRAFTED,
                                 isActive: false,
+                                customer: {
+                                  __typename: 'ProfileNode',
+                                  id: '0a43fd1d-420b-448c-be1a-7268d845c4dc',
+                                },
                                 application: null,
                                 __typename: 'WinterStorageLeaseNode',
                               },

--- a/src/features/winterStorageAreaView/__generated__/INDIVIDUAL_WINTER_STORAGE_AREA.ts
+++ b/src/features/winterStorageAreaView/__generated__/INDIVIDUAL_WINTER_STORAGE_AREA.ts
@@ -9,18 +9,15 @@ import { LeaseStatus } from "./../../../@types/__generated__/globalTypes";
 // GraphQL query operation: INDIVIDUAL_WINTER_STORAGE_AREA
 // ====================================================
 
-export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_application_customer {
+export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_customer {
   __typename: "ProfileNode";
   id: string;
-  firstName: string;
-  lastName: string;
 }
 
 export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_application {
   __typename: "WinterStorageApplicationNode";
   id: string;
   createdAt: any;
-  customer: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_application_customer | null;
 }
 
 export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node {
@@ -30,6 +27,7 @@ export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sec
   endDate: any;
   status: LeaseStatus;
   isActive: boolean;
+  customer: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_customer;
   application: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges_node_application | null;
 }
 
@@ -43,18 +41,15 @@ export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sec
   edges: (INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases_edges | null)[];
 }
 
-export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_application_customer {
+export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_customer {
   __typename: "ProfileNode";
   id: string;
-  firstName: string;
-  lastName: string;
 }
 
 export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_application {
   __typename: "WinterStorageApplicationNode";
   id: string;
   createdAt: any;
-  customer: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_application_customer | null;
 }
 
 export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node {
@@ -64,6 +59,7 @@ export interface INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sec
   endDate: any;
   status: LeaseStatus;
   isActive: boolean;
+  customer: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_customer;
   application: INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases_edges_node_application | null;
 }
 

--- a/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
+++ b/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
@@ -546,34 +546,9 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 class="headerCell"
                 colspan="1"
                 role="columnheader"
-                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
-                title="Toggle SortBy"
+                style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
               >
                 Asiakas
-                <div
-                  class="sortArrowWrapper"
-                >
-                  <svg
-                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_m__3edUY icon_hds-icon--size-m__1mcHv sortArrow sortArrowDown"
-                    role="img"
-                    viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <g
-                      fill="none"
-                      fill-rule="evenodd"
-                    >
-                      <rect
-                        height="24"
-                        width="24"
-                      />
-                      <polygon
-                        fill="currentColor"
-                        points="10 5.5 11.5 7 7.5 11 20 11 20 13 7.5 13 11.5 17 10 18.5 3.5 12"
-                      />
-                    </g>
-                  </svg>
-                </div>
               </div>
               <div
                 class="headerCell"

--- a/src/features/winterStorageAreaView/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/winterStorageAreaView/__tests__/__snapshots__/utils.test.ts.snap
@@ -11,9 +11,7 @@ Array [
         "applicationDate": "2020-07-17T10:52:57.079036+00:00",
         "applicationId": "foo",
         "customer": Object {
-          "firstName": "Heikki",
           "id": "UHJvZmlsZU5vZGU6NWNjYzgyNDUtNmRiOS00YTRiLWI5NTEtNWYxNDQ5YTY5NzY2",
-          "lastName": "Kinnunen",
         },
         "endDate": "2021-06-10",
         "id": "V2ludGVyU3RvcmFnZUxlYXNlTm9kZTo3ZTU0NjdmMy1jZGJhLTQzMmEtODdiZi05ODBiZTI1ZGFjNzg=",
@@ -30,7 +28,20 @@ Array [
     "id": "V2ludGVyU3RvcmFnZVBsYWNlTm9kZTo3OTkzYzAxOC0zMTMwLTRjNTItYjA3Ni1mMGZlN2Q5YjRmYTE=",
     "identifier": "-",
     "isActive": true,
-    "leases": Array [],
+    "leases": Array [
+      Object {
+        "applicationDate": undefined,
+        "applicationId": "",
+        "customer": Object {
+          "id": "0a43fd1d-420b-448c-be1a-7268d845c4dc",
+        },
+        "endDate": "2021-06-10",
+        "id": "V2ludGVyU3RvcmFnZUxlYXNlTm9kZTpjOWNjODAyNi1hZTkzLTRjMTUtYmJiNy1kM2Q1ZjE4ZjViYjA=",
+        "isActive": false,
+        "startDate": "2020-09-15",
+        "status": "DRAFTED",
+      },
+    ],
     "length": 5,
     "number": 2,
     "width": 3,

--- a/src/features/winterStorageAreaView/queries.ts
+++ b/src/features/winterStorageAreaView/queries.ts
@@ -30,14 +30,12 @@ export const INDIVIDUAL_WINTER_STORAGE_AREA_QUERY = gql`
                       endDate
                       status
                       isActive
+                      customer {
+                        id
+                      }
                       application {
                         id
                         createdAt
-                        customer {
-                          id
-                          firstName
-                          lastName
-                        }
                       }
                     }
                   }
@@ -58,14 +56,12 @@ export const INDIVIDUAL_WINTER_STORAGE_AREA_QUERY = gql`
                             endDate
                             status
                             isActive
+                            customer {
+                              id
+                            }
                             application {
                               id
                               createdAt
-                              customer {
-                                id
-                                firstName
-                                lastName
-                              }
                             }
                           }
                         }

--- a/src/features/winterStorageAreaView/types.ts
+++ b/src/features/winterStorageAreaView/types.ts
@@ -18,8 +18,6 @@ export type Lease = {
   id: string;
   customer: {
     id: string;
-    firstName: string;
-    lastName: string;
   };
   status: string;
   startDate: string;

--- a/src/features/winterStorageAreaView/utils.ts
+++ b/src/features/winterStorageAreaView/utils.ts
@@ -3,7 +3,7 @@ import {
   INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections as SECTIONS,
   INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node as SECTION,
   INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties as SECTION_PROPERTIES,
-  INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_leases as LEASES,
+  INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node_leases as LEASES,
   // eslint-disable-next-line max-len
   INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges as WINTER_STORAGE_PLACES,
   INDIVIDUAL_WINTER_STORAGE_AREA_winterStorageArea_properties_sections_edges_node_properties_places_edges_node as PLACE,
@@ -73,22 +73,18 @@ export const getIndividualWinterStorageArea = (
 
 const getLeases = (leases: LEASES): Lease[] => {
   return leases?.edges.reduce<Lease[]>((acc, leaseEdge) => {
-    if (!leaseEdge?.node?.application?.customer) {
-      return acc;
-    }
+    if (!leaseEdge?.node) return acc;
     const { id, status, startDate, endDate, isActive } = leaseEdge.node;
     return [
       ...acc,
       {
         id,
         customer: {
-          id: leaseEdge.node.application.customer.id,
-          firstName: leaseEdge.node.application.customer.firstName,
-          lastName: leaseEdge.node.application.customer.lastName,
+          id: leaseEdge.node.customer.id,
         },
         status,
-        applicationId: leaseEdge.node.application.id,
-        applicationDate: leaseEdge.node.application.createdAt,
+        applicationId: leaseEdge.node.application?.id ?? '',
+        applicationDate: leaseEdge.node.application?.createdAt,
         startDate,
         endDate,
         isActive,

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -828,6 +828,9 @@
       "length": "Pituus",
       "width": "Leveys",
       "notified": "Ilmoitettu"
+    },
+    "place": {
+      "inactive": "Ei käytössä"
     }
   },
   "actionHistoryCard": {


### PR DESCRIPTION
## Description :sparkles:
- Change the query to retrieve customer info from the lease rather than the application
- Let `CustomerInfo` component handles fetching customer's name

## Issues :bug:

### Closes :no_good_woman:
[VEN-1334](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1334): Imported winter storage leases not shown in the winter storage area

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️
- Updated related tests

### Manual testing :construction_worker_man:
- Go to the [page](https://venepaikka-admin.test.kuva.hel.ninja/winter-storage-areas/V2ludGVyU3RvcmFnZUFyZWFOb2RlOjlkNTc3Yzk5LTYzZjMtNDIzNC04MTM4LWY3MGE0Zjg2ODRmMg==) mentioned in the ticket 
- The place number `1` should show the leaseholder name
- Customers' names on both Marked & Unmarked Winter Storage Areas are now fetched separately, therefore you'll notice a loading indicator in the corresponding table cells first

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/117991999-3ea54300-b347-11eb-8834-737b12428e2c.png)

## Additional notes :spiral_notepad:
