### PR TITLE
VEN-1242 | Change the order of order-status filter options

### DIFF
--- a/src/common/utils/constants.ts
+++ b/src/common/utils/constants.ts
@@ -30,21 +30,10 @@ type OrderStatusType = {
 };
 
 export const ORDER_STATUS: OrderStatusType = {
-  CANCELLED: {
-    label: 'common.orderStatus.cancelled',
-    type: 'error',
-  },
+  // Note: Changing the order affects the status filters
   DRAFTED: {
     label: 'common.orderStatus.drafted',
     type: 'warning',
-  },
-  ERROR: {
-    label: 'common.orderStatus.error',
-    type: 'error',
-  },
-  EXPIRED: {
-    label: 'common.orderStatus.expired',
-    type: 'error',
   },
   OFFERED: {
     label: 'common.orderStatus.offered',
@@ -64,6 +53,18 @@ export const ORDER_STATUS: OrderStatusType = {
   },
   REJECTED: {
     label: 'common.orderStatus.rejected',
+    type: 'error',
+  },
+  EXPIRED: {
+    label: 'common.orderStatus.expired',
+    type: 'error',
+  },
+  CANCELLED: {
+    label: 'common.orderStatus.cancelled',
+    type: 'error',
+  },
+  ERROR: {
+    label: 'common.orderStatus.error',
     type: 'error',
   },
 };

--- a/src/features/customerView/invoiceModal/InvoiceModal.tsx
+++ b/src/features/customerView/invoiceModal/InvoiceModal.tsx
@@ -152,6 +152,7 @@ const InvoiceModal = ({ invoice, toggleModal, actions, selectedAction, ...modalP
 
           <Section>
             <LabelValuePair
+              className={styles.bolded}
               label={t('common.total').toUpperCase()}
               value={formatPrice(invoice.totalPrice, i18n.language)}
               align="right"

--- a/src/features/customerView/invoiceModal/InvoiceModal.tsx
+++ b/src/features/customerView/invoiceModal/InvoiceModal.tsx
@@ -152,7 +152,7 @@ const InvoiceModal = ({ invoice, toggleModal, actions, selectedAction, ...modalP
 
           <Section>
             <LabelValuePair
-              className={styles.bolded}
+              className={styles.bold}
               label={t('common.total').toUpperCase()}
               value={formatPrice(invoice.totalPrice, i18n.language)}
               align="right"

--- a/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
+++ b/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`InvoiceModal renders correctly 1`] = `
         class="body"
       >
         <div
-          class="labelValuePair bolded"
+          class="labelValuePair bold"
         >
           <span
             class="label standard"

--- a/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
+++ b/src/features/customerView/invoiceModal/__tests__/__snapshots__/InvoiceModal.test.tsx.snap
@@ -273,7 +273,7 @@ exports[`InvoiceModal renders correctly 1`] = `
         class="body"
       >
         <div
-          class="labelValuePair"
+          class="labelValuePair bolded"
         >
           <span
             class="label standard"

--- a/src/features/customerView/invoiceModal/invoiceModal.module.scss
+++ b/src/features/customerView/invoiceModal/invoiceModal.module.scss
@@ -31,7 +31,7 @@
     left: 0;
   }
 
-  .bolded {
+  .bold {
     font-weight: bold;
   }
 }

--- a/src/features/customerView/invoiceModal/invoiceModal.module.scss
+++ b/src/features/customerView/invoiceModal/invoiceModal.module.scss
@@ -30,4 +30,8 @@
     top: 0;
     left: 0;
   }
+
+  .bolded {
+    font-weight: bold;
+  }
 }


### PR DESCRIPTION
## Description :sparkles:
- Change the order of order-status filter options
- Make the text of the total amount bold in the order details modal

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
- On the single customer, the filter dropdown above the invoices table now follows a logical order
- Clicking on one of the invoices, the total amount text is bolded

## Screenshots :camera_flash:
![image](https://user-images.githubusercontent.com/23040926/118634024-c45b3f80-b7da-11eb-9375-36b1b98f35e2.png)
![image](https://user-images.githubusercontent.com/23040926/118634064-cd4c1100-b7da-11eb-9f60-d5feccab4982.png)

## Additional notes :spiral_notepad:
