### PR TITLE
VEN-1401 | Use Kanslia's test Tunnistamo and HKI Profile

### DIFF
--- a/.env
+++ b/.env
@@ -9,5 +9,5 @@ REACT_APP_TUNNISTAMO_CLIENT_ID=https://api.hel.fi/auth/berths-admin-ui
 REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT=logout
 REACT_APP_TUNNISTAMO_SCOPE_BERTHS=https://api.hel.fi/auth/berths
 REACT_APP_TUNNISTAMO_SCOPE_PROFILE=https://api.hel.fi/auth/helsinkiprofile
-REACT_APP_TUNNISTAMO_URI=https://tunnistamo.test.kuva.hel.ninja
+REACT_APP_TUNNISTAMO_URI=https://tunnistamo.test.hel.ninja
 SASS_PATH=node_modules:src/assets/styles

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -35,7 +35,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_ENV: 'review'
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_BERTH_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/'
-          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.${{ env.BASE_DOMAIN }}/'
+          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.hel.ninja'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_RENEW_ENDPOINT: 'silent_renew'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT: 'logout'

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -36,7 +36,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_ENV: 'staging'
           DOCKER_BUILD_ARG_REACT_APP_API_URL: 'https://venepaikka-federation.test.kuva.hel.ninja/'
           DOCKER_BUILD_ARG_REACT_APP_BERTH_API_URL: 'https://venepaikka-api.test.kuva.hel.ninja/'
-          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.kuva.hel.ninja'
+          DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_URI: 'https://tunnistamo.test.hel.ninja'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_ENDPOINT: 'api-tokens'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_API_TOKEN_RENEW_ENDPOINT: 'silent_renew'
           DOCKER_BUILD_ARG_REACT_APP_TUNNISTAMO_LOGOUT_ENDPOINT: 'logout'

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ yarn
 After cloning this repository, create a new `.env.development.local` file from the provided `.env` file to be able to change environment variables such as `REACT_APP_API_URL`.
 
 ```bash
-cp .env.example .env.development.local
+cp .env .env.development.local
 ```
 
 ## Development environment setup

--- a/src/features/auth/__snapshots__/authService.test.js.snap
+++ b/src/features/auth/__snapshots__/authService.test.js.snap
@@ -4,7 +4,7 @@ exports[`authService fetchApiTokens should call axios.get with the right argumen
 Array [
   "api-tokens/",
   Object {
-    "baseURL": "https://tunnistamo.test.kuva.hel.ninja",
+    "baseURL": "https://tunnistamo.test.hel.ninja",
     "headers": Object {
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",
     },


### PR DESCRIPTION
## Description :sparkles:

Switch the staging and review environments to use Kanslia's test Tunnistamo and HKI Profile to be able to test Suomi.fi strong authentication. Requires the same changes to [the backend](https://github.com/City-of-Helsinki/berth-reservations/pull/618) and to [the federation gateway](https://github.com/City-of-Helsinki/berth-federation-gateway/pull/39).

## Issues :bug:
### Related :handshake:
**[VEN-1401](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1401)** 


## Testing :alembic:

### Manual testing :construction_worker_man:

It is not possible to fully test this before merging, but most parts can be tested locally. 

## Additional notes :spiral_notepad:

Currently it is not possible to get PR environments' authentication to actually work with Kanslia's Tunnistamo, but those envs are not working at the moment anyway, so we switch them to Kanslia's Tunnistamo to prevent confusion in the future.