### PR TITLE
Fix the Apollo issue of the create berth switch offer

### DIFF
--- a/src/features/applicationView/__fixtures__/mockData.ts
+++ b/src/features/applicationView/__fixtures__/mockData.ts
@@ -44,6 +44,7 @@ export const mockCustomer: CUSTOMER = {
 
 export const mockBerthSwitch: BERTH_SWITCH = {
   __typename: 'BerthSwitchType',
+  id: 'MOCK-BERTH_SWITCH',
   berth: {
     __typename: 'BerthNode',
     id: 'MOCK-BERTH',

--- a/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
+++ b/src/features/applicationView/__generated__/INDIVIDUAL_APPLICATION.ts
@@ -91,6 +91,7 @@ export interface INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_reason {
 
 export interface INDIVIDUAL_APPLICATION_berthApplication_berthSwitch {
   __typename: "BerthSwitchType";
+  id: string;
   berth: INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_berth;
   reason: INDIVIDUAL_APPLICATION_berthApplication_berthSwitch_reason | null;
 }

--- a/src/features/applicationView/queries.ts
+++ b/src/features/applicationView/queries.ts
@@ -48,6 +48,7 @@ export const INDIVIDUAL_APPLICATION_QUERY = gql`
         language
       }
       berthSwitch {
+        id
         berth {
           id
           number


### PR DESCRIPTION
VEN-1454. Apollo threw an error when the 2nd level node of individual application query did not contain an id. An cache issue which is described here: https://www.apollographql.com/docs/react/caching/cache-configuration/#default-identifiers