### PR TITLE
Refactor how headers are handle in Table component

### DIFF
--- a/src/common/table/Table.tsx
+++ b/src/common/table/Table.tsx
@@ -112,6 +112,7 @@ const Table = <D extends { id: string }>({
   manualSortBy,
 }: TableProps<D>) => {
   const { t } = useTranslation();
+  let tableState: TableInstance<D>;
 
   const selectorCol: Column<D> = React.useMemo(
     () => ({
@@ -204,7 +205,20 @@ const Table = <D extends { id: string }>({
     skipPageResetRef.current = false;
   });
 
-  const tableState = useTable(
+  const {
+    headerGroups,
+    state,
+    page,
+    rows,
+    pageCount,
+    gotoPage,
+    getTableProps,
+    getTableBodyProps,
+    prepareRow,
+    setGlobalFilter,
+    setFilter,
+    dispatch,
+  } = (tableState = useTable(
     {
       columns: tableColumns,
       data: dataState,
@@ -226,21 +240,7 @@ const Table = <D extends { id: string }>({
     useExpanded,
     usePagination,
     useRowSelect
-  );
-  const {
-    headerGroups,
-    state,
-    page,
-    rows,
-    pageCount,
-    gotoPage,
-    getTableProps,
-    getTableBodyProps,
-    prepareRow,
-    setGlobalFilter,
-    setFilter,
-    dispatch,
-  } = tableState;
+  ));
 
   const resetSelectedRows = useCallback(() => {
     dispatch({ type: actions.resetSelectedRows });

--- a/src/common/table/table.module.scss
+++ b/src/common/table/table.module.scss
@@ -68,11 +68,7 @@ $transition-duration: 300ms;
     text-transform: uppercase;
     margin: 0;
     padding: 0;
-
-    & .tableCell {
-      margin: 0;
-      padding: units(1);
-    }
+    padding: units(1);
   }
 
   .tableFilterHeader {

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationList.test.tsx.snap
@@ -167,36 +167,27 @@ exports[`ApplicationList renders normally with all props 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 1125px;"
           >
-            <div
-              class="headerCell"
-              colspan="9"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 1125 0 auto; min-width: 1125px; width: 1125px;"
+            <button
+              class="filterBtn"
             >
-              <button
-                class="filterBtn"
-              >
-                Kaikki
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Vaihtohakemukset
-              </button>
-              <button
-                class="filterBtn active"
-              >
-                 Uudet hakemukset
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Hakukoodi
-              </button>
-            </div>
+              Kaikki
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Vaihtohakemukset
+            </button>
+            <button
+              class="filterBtn active"
+            >
+               Uudet hakemukset
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Hakukoodi
+            </button>
           </div>
           <div
             class="header"
@@ -947,36 +938,27 @@ exports[`ApplicationList renders normally with minimum props 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 1125px;"
           >
-            <div
-              class="headerCell"
-              colspan="9"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 1125 0 auto; min-width: 1125px; width: 1125px;"
+            <button
+              class="filterBtn"
             >
-              <button
-                class="filterBtn"
-              >
-                Kaikki
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Vaihtohakemukset
-              </button>
-              <button
-                class="filterBtn active"
-              >
-                 Uudet hakemukset
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Hakukoodi
-              </button>
-            </div>
+              Kaikki
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Vaihtohakemukset
+            </button>
+            <button
+              class="filterBtn active"
+            >
+               Uudet hakemukset
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Hakukoodi
+            </button>
           </div>
           <div
             class="header"

--- a/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
+++ b/src/features/applicationList/__tests__/__snapshots__/ApplicationListContainer.test.tsx.snap
@@ -167,36 +167,27 @@ exports[`ApplicationListContainer renders normally 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 1125px;"
           >
-            <div
-              class="headerCell"
-              colspan="9"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 1125 0 auto; min-width: 1125px; width: 1125px;"
+            <button
+              class="filterBtn active"
             >
-              <button
-                class="filterBtn active"
-              >
-                Kaikki
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Vaihtohakemukset
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Uudet hakemukset
-              </button>
-              <button
-                class="filterBtn"
-              >
-                 Hakukoodi
-              </button>
-            </div>
+              Kaikki
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Vaihtohakemukset
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Uudet hakemukset
+            </button>
+            <button
+              class="filterBtn"
+            >
+               Hakukoodi
+            </button>
           </div>
           <div
             class="header"

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -139,6 +139,7 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColsChang
             />
           );
         }}
+        renderMainHeader={() => t('customerList.tableHeaders.mainHeader')}
         renderTableToolsTop={({ selectedRowIds }, { resetSelectedRows }) => (
           <CustomerListTableTools
             {...tableTools}

--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -139,7 +139,6 @@ const CustomerList = ({ loading, data, pagination, tableTools, onSortedColsChang
             />
           );
         }}
-        renderMainHeader={() => t('customerList.tableHeaders.mainHeader')}
         renderTableToolsTop={({ selectedRowIds }, { resetSelectedRows }) => (
           <CustomerListTableTools
             {...tableTools}

--- a/src/features/customerView/__tests__/__snapshots__/CustomerView.test.tsx.snap
+++ b/src/features/customerView/__tests__/__snapshots__/CustomerView.test.tsx.snap
@@ -421,17 +421,8 @@ exports[`CustomerView renders normally 1`] = `
             >
               <div
                 class="header mainHeader"
-                role="row"
-                style="display: flex; flex: 1 0 auto; min-width: 900px;"
               >
-                <div
-                  class="headerCell"
-                  colspan="8"
-                  role="columnheader"
-                  style="box-sizing: border-box; flex: 900 0 auto; min-width: 900px; width: 900px;"
-                >
-                  Laskut
-                </div>
+                Laskut
               </div>
               <div
                 class="header"

--- a/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
+++ b/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
@@ -478,54 +478,45 @@ exports[`HarborView renders normally 1`] = `
           class="stickyHeaders"
         >
           <div
-            class="header mainHeaderReset"
-            role="row"
-            style="display:flex;flex:1 0 auto;min-width:150px"
+            class="header mainHeader"
           >
             <div
-              class=""
-              colspan="9"
-              role="columnheader"
-              style="box-sizing:border-box;flex:1200 0 auto;min-width:150px;width:1200px"
+              class="container"
             >
               <div
-                class="container"
+                class="selectContainer"
               >
-                <div
-                  class="selectContainer"
-                >
-                  <div>
-                    <button
-                      class="button buttonSelected"
-                    >
-                      Kaikki
-                    </button>
-                    <button
-                      class="button"
-                    >
-                      Laituri 10
-                    </button>
-                    <button
-                      class="button"
-                    >
-                      Laituri 11 a
-                    </button>
-                    <button
-                      class="button"
-                    >
-                      Laituri 11 b
-                    </button>
-                    <button
-                      class="button"
-                    >
-                      Laituri 19 a
-                    </button>
-                    <button
-                      class="button"
-                    >
-                      Laituri 19 b
-                    </button>
-                  </div>
+                <div>
+                  <button
+                    class="button buttonSelected"
+                  >
+                    Kaikki
+                  </button>
+                  <button
+                    class="button"
+                  >
+                    Laituri 10
+                  </button>
+                  <button
+                    class="button"
+                  >
+                    Laituri 11 a
+                  </button>
+                  <button
+                    class="button"
+                  >
+                    Laituri 11 b
+                  </button>
+                  <button
+                    class="button"
+                  >
+                    Laituri 19 a
+                  </button>
+                  <button
+                    class="button"
+                  >
+                    Laituri 19 b
+                  </button>
                 </div>
               </div>
             </div>
@@ -536,7 +527,7 @@ exports[`HarborView renders normally 1`] = `
             style="display:flex;flex:1 0 auto;min-width:150px"
           >
             <div
-              class="headerCell selector"
+              class="selector"
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:75 0 auto;min-width:75px;width:75px"
@@ -558,7 +549,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -591,7 +582,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -624,7 +615,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px"
@@ -632,7 +623,7 @@ exports[`HarborView renders normally 1`] = `
               Asiakas
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -665,7 +656,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -698,7 +689,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -731,7 +722,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell"
+              class=""
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:150 0 auto;min-width:0px;width:150px;cursor:pointer"
@@ -764,7 +755,7 @@ exports[`HarborView renders normally 1`] = `
               </div>
             </div>
             <div
-              class="headerCell expander"
+              class="expander"
               colspan="1"
               role="columnheader"
               style="box-sizing:border-box;flex:75 0 auto;min-width:75px;width:75px"

--- a/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomer.test.tsx.snap
+++ b/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomer.test.tsx.snap
@@ -152,17 +152,8 @@ Array [
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 75px;"
           >
-            <div
-              class="headerCell"
-              colspan="7"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 975 0 auto; min-width: 75px; width: 975px;"
-            >
-              LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
-            </div>
+            LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
           </div>
           <div
             class="header"
@@ -657,17 +648,8 @@ Array [
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 75px;"
           >
-            <div
-              class="headerCell"
-              colspan="7"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 975 0 auto; min-width: 75px; width: 975px;"
-            >
-              LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
-            </div>
+            LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
           </div>
           <div
             class="header"

--- a/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomerContainer.test.tsx.snap
+++ b/src/features/linkApplicationToCustomer/__tests__/__snapshots__/LinkApplicationToCustomerContainer.test.tsx.snap
@@ -157,17 +157,8 @@ Array [
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 75px;"
           >
-            <div
-              class="headerCell"
-              colspan="7"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 975 0 auto; min-width: 75px; width: 975px;"
-            >
-              LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
-            </div>
+            LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
           </div>
           <div
             class="header"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeList.test.tsx.snap
@@ -167,17 +167,8 @@ exports[`UnmarkedWsNoticeList renders normally with data 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 675px;"
           >
-            <div
-              class="headerCell"
-              colspan="6"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 675 0 auto; min-width: 675px; width: 675px;"
-            >
-              Nostojärjestysilmoitukset
-            </div>
+            Nostojärjestysilmoitukset
           </div>
           <div
             class="header"
@@ -1521,17 +1512,8 @@ exports[`UnmarkedWsNoticeList renders normally without data 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 675px;"
           >
-            <div
-              class="headerCell"
-              colspan="6"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 675 0 auto; min-width: 675px; width: 675px;"
-            >
-              Nostojärjestysilmoitukset
-            </div>
+            Nostojärjestysilmoitukset
           </div>
           <div
             class="header"

--- a/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeList/__tests__/__snapshots__/UnmarkedWsNoticeListContainer.test.tsx.snap
@@ -167,17 +167,8 @@ exports[`UnmarkedWsNoticeListContainer renders normally 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 675px;"
           >
-            <div
-              class="headerCell"
-              colspan="6"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 675 0 auto; min-width: 675px; width: 675px;"
-            >
-              Nostojärjestysilmoitukset
-            </div>
+            Nostojärjestysilmoitukset
           </div>
           <div
             class="header"

--- a/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeViewContainer.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeViewContainer.test.tsx.snap
@@ -200,17 +200,8 @@ exports[`UnmarkedWsNoticeViewContainer renders normally 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display: flex; flex: 1 0 auto; min-width: 75px;"
           >
-            <div
-              class="headerCell"
-              colspan="7"
-              role="columnheader"
-              style="box-sizing: border-box; flex: 975 0 auto; min-width: 75px; width: 975px;"
-            >
-              LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
-            </div>
+            LIITÄ HAKEMUS OLEMASSA OLEVAAN ASIAKASPROFIILIIN
           </div>
           <div
             class="header"

--- a/src/features/winterStorageAreaList/__tests__/__snapshots__/WinterStorageAreaList.test.tsx.snap
+++ b/src/features/winterStorageAreaList/__tests__/__snapshots__/WinterStorageAreaList.test.tsx.snap
@@ -41,17 +41,8 @@ exports[`WinterStorageAreaList renders normally 1`] = `
         >
           <div
             class="header mainHeader"
-            role="row"
-            style="display:flex;flex:1 0 auto;min-width:862.5px"
           >
-            <div
-              class="headerCell"
-              colspan="10"
-              role="columnheader"
-              style="box-sizing:border-box;flex:862.5 0 auto;min-width:862.5px;width:862.5px"
-            >
-              Talvisäilytysalueet
-            </div>
+            Talvisäilytysalueet
           </div>
           <div
             class="header"

--- a/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
+++ b/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
@@ -411,39 +411,30 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
             class="stickyHeaders"
           >
             <div
-              class="header mainHeaderReset"
-              role="row"
-              style="display: flex; flex: 1 0 auto; min-width: 150px;"
+              class="header mainHeader"
             >
               <div
-                class=""
-                colspan="7"
-                role="columnheader"
-                style="box-sizing: border-box; flex: 900 0 auto; min-width: 150px; width: 900px;"
+                class="container"
               >
                 <div
-                  class="container"
+                  class="selectContainer"
                 >
-                  <div
-                    class="selectContainer"
-                  >
-                    <div>
-                      <span
-                        class="title"
-                      >
-                        TALVISÄILYTYSPAIKAT
-                      </span>
-                      <button
-                        class="button buttonSelected"
-                      >
-                        Kaikki
-                      </button>
-                      <button
-                        class="button"
-                      >
-                        Osasto -
-                      </button>
-                    </div>
+                  <div>
+                    <span
+                      class="title"
+                    >
+                      TALVISÄILYTYSPAIKAT
+                    </span>
+                    <button
+                      class="button buttonSelected"
+                    >
+                      Kaikki
+                    </button>
+                    <button
+                      class="button"
+                    >
+                      Osasto -
+                    </button>
                   </div>
                 </div>
               </div>
@@ -454,7 +445,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
               style="display: flex; flex: 1 0 auto; min-width: 150px;"
             >
               <div
-                class="headerCell selector"
+                class="selector"
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 75 0 auto; min-width: 75px; width: 75px;"
@@ -477,7 +468,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 </div>
               </div>
               <div
-                class="headerCell"
+                class=""
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
@@ -510,7 +501,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 </div>
               </div>
               <div
-                class="headerCell"
+                class=""
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
@@ -543,7 +534,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 </div>
               </div>
               <div
-                class="headerCell"
+                class=""
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px;"
@@ -551,7 +542,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 Asiakas
               </div>
               <div
-                class="headerCell"
+                class=""
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
@@ -584,7 +575,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 </div>
               </div>
               <div
-                class="headerCell"
+                class=""
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 150 0 auto; min-width: 0px; width: 150px; cursor: pointer;"
@@ -617,7 +608,7 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
                 </div>
               </div>
               <div
-                class="headerCell expander"
+                class="expander"
                 colspan="1"
                 role="columnheader"
                 style="box-sizing: border-box; flex: 75 0 auto; min-width: 75px; width: 75px;"


### PR DESCRIPTION
## Description :sparkles:

It was very hard for me to get clear picture how the headers were handled in the function that returns` tableColumns` (mostly because I haven't used react table that much). I think I found a solution that still works but is much more readable.

In this solution "extra" headers are not part of the columns structure that react table uses but rather manually rendered in the sticky headers div. `tableState` (`TableInstance<D>`) is passed to the `renderMainHeader` render prop as a parameter.

Simplified `tableColumns` calculation:

```
  const tableColumns = React.useMemo(() => {
    return [
      ...(canSelectRows ? [selectorCol] : []),
      ...(canSelectOneRow ? [radioSelectorCol] : []),
      ...columns,
      ...(renderSubComponent ? [expanderCol] : []),
    ];
  }, [canSelectRows, selectorCol, canSelectOneRow, radioSelectorCol, columns, renderSubComponent, expanderCol]);
```

Sticky header section:

```
 <div className={styles.stickyHeaders}>
    {renderMainHeader && (
      <div className={classNames(styles.header, styles.mainHeader)}>{renderMainHeader(tableState)}</div>
    )}
    {renderTableFilters && (
      <div className={classNames(styles.header, styles.tableFilterHeader)}>{renderTableFilters()}</div>
    )}
    {headerGroups.map(renderTableHead)}
</div>
```

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
