### PR TITLE
VEN-1438, VEN-1439 | Add new dropdown filters

### DIFF
--- a/src/features/customerList/CustomerList.tsx
+++ b/src/features/customerList/CustomerList.tsx
@@ -14,14 +14,8 @@ import { getSelectedRowIds } from '../../common/utils/getSelectedRowIds';
 import PageContent from '../../common/pageContent/PageContent';
 import { getCustomerGroupKey } from '../../common/utils/translations';
 import WrappingTableCell from '../../common/wrappingTableCell/WrappingTableCell';
+import { SearchBy } from './CustomerListContainer';
 import CustomerListTableFilters from './customerListTableFilters/CustomerListTableFilters';
-
-export enum SearchBy {
-  FIRST_NAME = 'firstName',
-  LAST_NAME = 'lastName',
-  EMAIL = 'email',
-  ADDRESS = 'address',
-}
 
 type ColumnType = Column<CustomerData>;
 

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -13,12 +13,20 @@ import CustomerList from './CustomerList';
 import { usePagination } from '../../common/utils/usePagination';
 import { useRecoilBackendSorting } from '../../common/utils/useBackendSorting';
 import { getProfileToken } from '../../common/utils/auth';
-import { SearchBy } from '../applicationView/ApplicationView';
 import { usePrevious } from '../../common/utils/usePrevious';
 import { ApplicationData } from '../applicationList/utils';
 import { orderByToString } from '../../common/utils/recoil';
 import useListTableFilters from './customerListTableFilters/useListTableFilters';
 import { createIntervalWithSilentError, createDate } from './customerListTableFilters/utils';
+
+export enum SearchBy {
+  FIRST_NAME = 'firstName',
+  LAST_NAME = 'lastName',
+  EMAIL = 'email',
+  ADDRESS = 'address',
+  STICKER_NUMBER = 'stickerNumber',
+  BOAT_REGISTRATION_NUMBER = 'boatRegistrationNumber',
+}
 
 const searchByAtom = atom<SearchBy>({
   key: 'CustomerListContainer_searchByAtom',
@@ -127,6 +135,8 @@ const CustomerListContainer = () => {
           { value: SearchBy.LAST_NAME, label: t('common.lastName') },
           { value: SearchBy.EMAIL, label: t('common.email') },
           { value: SearchBy.ADDRESS, label: t('common.address') },
+          { value: SearchBy.STICKER_NUMBER, label: t('common.terminology.stickerNumber') },
+          { value: SearchBy.BOAT_REGISTRATION_NUMBER, label: t('common.terminology.registrationNumber') },
         ],
       }}
     />

--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -180,6 +180,8 @@ export interface CUSTOMERSVariables {
   lastName?: string | null;
   email?: string | null;
   address?: string | null;
+  stickerNumber?: string | null;
+  boatRegistrationNumber?: string | null;
   orderBy?: string | null;
   customerGroups?: (CustomerGroup | null)[] | null;
   boatTypeIds?: (string | null)[] | null;

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -8,6 +8,8 @@ export const CUSTOMERS_QUERY = gql`
     $lastName: String
     $email: String
     $address: String
+    $stickerNumber: String
+    $boatRegistrationNumber: String
     $orderBy: String
     $customerGroups: [CustomerGroup]
     $boatTypeIds: [ID]
@@ -30,6 +32,8 @@ export const CUSTOMERS_QUERY = gql`
       lastName: $lastName
       email: $email
       address: $address
+      stickerNumber: $stickerNumber
+      boatRegistrationNumber: $boatRegistrationNumber
       sortBy: $orderBy
       customerGroups: $customerGroups
       boatTypes: $boatTypeIds

--- a/src/features/customerList/tableTools/__tests__/CustomerListTableTools.test.tsx
+++ b/src/features/customerList/tableTools/__tests__/CustomerListTableTools.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import CustomerListTableTools from '../CustomerListTableTools';
-import { SearchBy } from '../../CustomerList';
+import { SearchBy } from '../../CustomerListContainer';
 
 // CustomerMessageFormContainer is mocked to limit the test scope
 jest.mock('../../../customerMessageForm/CustomerMessageFormContainer', () => {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -146,6 +146,7 @@
       "section": "Osasto",
       "selection": "Valinta",
       "serviceMap": "Palvelukartta",
+      "stickerNumber": "Tarranumero",
       "storageOnIce": "Jäissä säilytys",
       "summerStorageForBoats": "Veneiden kesäsäilytys",
       "summerStorageForDockingEquipment": "Telakointi\u00ADtarvikkeiden kesäsäilytys",


### PR DESCRIPTION
## Description :sparkles:

Adds sticker number and registration number filters into customer list dropdown filters.

## Issues :bug:

[VEN-1438](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1438)
[VEN-1439](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1439)

## Screenshots :camera_flash:

<img width="1680" alt="Screenshot 2022-02-16 at 14 09 34" src="https://user-images.githubusercontent.com/9090689/154261984-e85316ca-45fa-48fc-bfda-2229f3a5b888.png">
