### PR TITLE
VEN-1431 | Fix pagination in customer list page

### DIFF
--- a/src/common/utils/usePagination.ts
+++ b/src/common/utils/usePagination.ts
@@ -18,9 +18,13 @@ export const usePagination = (pageSize = PAGE_SIZE) => {
     (pageIndex: number) => {
       const newPageNumber = pageIndex + 1;
       const currentPageNumber = getCurrentPageParam(history);
+      const search = history.location.search;
 
       if (currentPageNumber !== newPageNumber) {
-        history.push({ search: `?page=${newPageNumber}` });
+        const params = new URLSearchParams(search);
+
+        params.set('page', newPageNumber?.toString());
+        history.push({ search: `?${params}` });
       }
     },
     [history]

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -5,6 +5,7 @@ import { useDebounce } from 'use-debounce';
 import { atom, selector, useRecoilState, useRecoilValue } from 'recoil';
 import { SortingRule } from 'react-table';
 import format from 'date-fns/format';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import { ALL_CUSTOMERS_QUERY, CUSTOMERS_QUERY } from './queries';
 import { getCustomersData } from './utils';
@@ -64,6 +65,8 @@ const orderBySelector = selector<string | undefined>({
 });
 
 const CustomerListContainer = () => {
+  usePersistedSearch();
+
   const { t } = useTranslation();
 
   const [customerListTableFilters] = useListTableFilters();
@@ -167,5 +170,27 @@ const CustomerListContainer = () => {
     />
   );
 };
+
+const PERSISTED_SEARCH_SESSION_STORAGE_KEY = 'berth-reservations-admin/persistedCustomerListContainer';
+
+function usePersistedSearch() {
+  const { search, pathname } = useLocation();
+  const history = useHistory();
+
+  useEffect(() => {
+    // Whenever search changes, persist it for the duration of the session
+    sessionStorage.setItem(PERSISTED_SEARCH_SESSION_STORAGE_KEY, search);
+  }, [search]);
+
+  useEffect(() => {
+    const persistedSearch = sessionStorage.getItem(PERSISTED_SEARCH_SESSION_STORAGE_KEY);
+
+    // If search is empty and we have a persisted search, apply the persisted
+    // search
+    if (!search && persistedSearch) {
+      history.replace(`${pathname}${persistedSearch}`);
+    }
+  }, [history, pathname, search]);
+}
 
 export default CustomerListContainer;

--- a/src/features/customerList/customerListTableFilters/CustomerListTableFilters.tsx
+++ b/src/features/customerList/customerListTableFilters/CustomerListTableFilters.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { IconAngleDown } from 'hds-react';
 import { useTranslation } from 'react-i18next';
-import { useHistory, useLocation } from 'react-router-dom';
 
 import useListTableFilters from './useListTableFilters';
 import CustomerListTableFiltersFormContainer from './CustomerListTableFiltersFormContainer';
@@ -15,7 +14,6 @@ enum Content {
 }
 
 const CustomerListTableFilters = () => {
-  usePersistedSearch();
   const { t } = useTranslation();
   const [areFiltersExpanded, setFiltersExpanded] = React.useState<boolean>(false);
   const [listTableFilters] = useListTableFilters();
@@ -53,27 +51,6 @@ function getVariant(areFiltersExpanded: boolean, someFilterIsActive: boolean) {
   }
 
   return Content.EMPTY;
-}
-
-const PERSISTED_SEARCH_SESSION_STORAGE_KEY = 'berth-reservations-admin/persistedCustomerListTableFilters';
-
-function usePersistedSearch() {
-  const { search, pathname } = useLocation();
-  const history = useHistory();
-  const persistedSearch = sessionStorage.getItem(PERSISTED_SEARCH_SESSION_STORAGE_KEY);
-
-  useEffect(() => {
-    // Whenever search changes, persist it for the duration of the session
-    sessionStorage.setItem(PERSISTED_SEARCH_SESSION_STORAGE_KEY, search);
-  }, [search]);
-
-  useEffect(() => {
-    // If search is empty and we have a persisted search, apply the persisted
-    // search
-    if (!search && persistedSearch) {
-      history.replace(`${pathname}${persistedSearch}`);
-    }
-  }, [history, pathname, persistedSearch, search]);
 }
 
 export default CustomerListTableFilters;

--- a/src/features/customerList/customerListTableFilters/CustomerListTableFiltersForm.tsx
+++ b/src/features/customerList/customerListTableFilters/CustomerListTableFiltersForm.tsx
@@ -8,10 +8,10 @@ import {
 } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
+import { CustomerGroup, LeaseStatus } from '../../../@types/__generated__/globalTypes';
 import Button from '../../../common/button/Button';
 import { Option, ControlledFilters } from './CustomerListTableFiltersFormContainer';
 import styles from './customerListTableFilters.module.scss';
-import { CustomerGroup, LeaseStatus } from '../../../@types/__generated__/globalTypes';
 
 type Section = {
   berthSection: boolean;


### PR DESCRIPTION
## Description :sparkles:

Fixes issues with pagination:

* Changing page reset filters
* Removing all filters doesn't clear persisted filters from session storage

Queries on customers page can be forced through by typing for instance `lind` in the surname filter box.