### PR TITLE
Fix broken sort by

### DIFF
--- a/src/common/utils/useBackendSorting.ts
+++ b/src/common/utils/useBackendSorting.ts
@@ -9,7 +9,7 @@ export const useRecoilBackendSorting = <T>(atom: RecoilState<SortingRule<T>[]>, 
   const [sortBy, setSortBy] = useRecoilState<SortingRule<T>[]>(atom);
 
   const handleSortedColsChange = useCallback(
-    () => (sortedColumns: SortingRule<T>[]) => {
+    (sortedColumns: SortingRule<T>[]) => {
       if (!equal(sortBy, sortedColumns)) {
         setSortBy(sortedColumns);
       }


### PR DESCRIPTION
## Description :sparkles:

A previous change accidentally transformed a callback into a "factory" which resulted in the callback not being called.

https://github.com/City-of-Helsinki/berth-reservations-admin/commit/75cd28b745ab6bba69f63c5d66bd440b275d79d4#diff-77f21d0fb28d2e1a5a0460d95151caf6444585f49d6042306ff6edb6d539f323R12
