### PR TITLE
Fix customer xlsx export 

### DIFF
--- a/src/common/utils/useTableExport.ts
+++ b/src/common/utils/useTableExport.ts
@@ -75,8 +75,7 @@ export const fetchExportFile = async ({
       `/${exportType}/${fileType}/`,
       {
         ids,
-        // eslint-disable-next-line @typescript-eslint/camelcase
-        profile_token: getProfileToken(),
+        profileToken: getProfileToken(),
       },
       {
         responseType: 'blob',


### PR DESCRIPTION
API renamed `profile_token` field to `profileToken` to be consistent with the GraphQL side.

Refs VEN-1443