### PR TITLE
VEN-957, VEN-1498 | Fix customer linking in application view

### DIFF
--- a/src/features/applicationView/ApplicationViewContainer.tsx
+++ b/src/features/applicationView/ApplicationViewContainer.tsx
@@ -95,7 +95,7 @@ const ApplicationViewContainer = () => {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
     }).catch(() => {});
   };
-  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id } } });
+  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id, customerId: null } } });
   const handleDeleteLease = (id: string) =>
     deleteDraftedApplication({
       variables: {

--- a/src/features/applicationView/ApplicationViewContainer.tsx
+++ b/src/features/applicationView/ApplicationViewContainer.tsx
@@ -43,7 +43,6 @@ const ApplicationViewContainer = () => {
       variables: {
         id,
       },
-      fetchPolicy: 'no-cache',
     }
   );
   const refetchQuery = {

--- a/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeViewContainer.tsx
+++ b/src/features/unmarkedWsNoticeView/UnmarkedWsNoticeViewContainer.tsx
@@ -116,7 +116,7 @@ const UnmarkedWsNoticeViewContainer = () => {
         input: { id, customerId },
       },
     });
-  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id } } });
+  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id, customerId: null } } });
   const handleCreateLease = () => {
     const options = {
       variables: {

--- a/src/features/winterStorageApplicationView/WinterStorageApplicationViewContainer.tsx
+++ b/src/features/winterStorageApplicationView/WinterStorageApplicationViewContainer.tsx
@@ -98,7 +98,7 @@ const WinterStorageApplicationViewContainer = () => {
       },
     });
   };
-  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id } } });
+  const handleUnlinkCustomer = () => linkCustomer({ variables: { input: { id, customerId: null } } });
 
   if (loading) return <LoadingSpinner />;
   if (!data?.winterStorageApplication)


### PR DESCRIPTION
## Description :sparkles:

Fixes two issues with customer linking in application view.

**Fix application refresh after customer linking**  

After linking a customer, the data in the view wasn't automatically updated.

The data was supposed to be updated with `refetchQueries`. However, because one refetched query had `no-cache` fetch policy, the refetch failed. A new query was never sent to the server.

The `no-cache` policy was added in conjunction with the export functionality. I wasn't able to determine the intention behind setting the policy to `no-cache` so I tested the export functionality with fetch policy set as `no-cache`. I couldn't spot any issues. But I am bit hesitant because I would have liked to get a hunch about the reasoning behind the fetch policy.

**Fix customer unlinking**  

While debugging for the root cause, I noticed that customer unlinking did not work. I fixed unlinking so that the fix for customer linking was easier to test. I talked with the PO about the issue with unlinking and we decided to include that fix as well.

## Issues :bug:

### Closes :no_good_woman:

https://helsinkisolutionoffice.atlassian.net/browse/VEN-957
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1498
