### PR TITLE
Add a show inactive berths filter to the harbor view

### DIFF
--- a/src/features/harborView/HarborView.tsx
+++ b/src/features/harborView/HarborView.tsx
@@ -19,6 +19,8 @@ export type HarborViewProps = {
   setCreatingPier: (creatingPier: boolean) => void;
   setEditingHarbor: (editingHarbor: boolean) => void;
   setPierToEdit: (pierToEdit: string | null) => void;
+  setFilterByActiveBerths: (filterByActiveBerths: boolean | null) => void;
+  filterByActiveBerths: boolean | null;
 };
 
 const HarborView = ({
@@ -30,6 +32,8 @@ const HarborView = ({
   setCreatingPier,
   setEditingHarbor,
   setPierToEdit,
+  setFilterByActiveBerths,
+  filterByActiveBerths,
 }: HarborViewProps) => {
   const { t } = useTranslation();
 
@@ -71,6 +75,8 @@ const HarborView = ({
         onAddBerth={() => setCreatingBerth(true)}
         onEditBerth={(berth) => setBerthToEdit(berth.id)}
         onEditPier={(pier) => setPierToEdit(pier.id)}
+        setFilterByActiveBerths={setFilterByActiveBerths}
+        filterByActiveBerths={filterByActiveBerths}
       />
     </PageContent>
   );

--- a/src/features/harborView/HarborViewContainer.tsx
+++ b/src/features/harborView/HarborViewContainer.tsx
@@ -23,10 +23,12 @@ const HarborViewContainer = () => {
   const [creatingBerth, setCreatingBerth] = useState<boolean>(false);
   const [pierToEdit, setPierToEdit] = useState<string | null>(null);
   const [creatingPier, setCreatingPier] = useState<boolean>(false);
+  const [filterByActiveBerths, setFilterByActiveBerths] = useState<boolean | null>(true);
   const { id: harborId } = useParams<{ id: string }>();
   const { loading, data } = useQuery<INDIVIDUAL_HARBOR, INDIVIDUAL_HARBOR_VARS>(INDIVIDUAL_HARBOR_QUERY, {
     variables: {
       harborId,
+      isBerthActive: filterByActiveBerths,
     },
   });
 
@@ -48,6 +50,8 @@ const HarborViewContainer = () => {
         setCreatingPier={setCreatingPier}
         setEditingHarbor={setEditingHarbor}
         setPierToEdit={setPierToEdit}
+        setFilterByActiveBerths={setFilterByActiveBerths}
+        filterByActiveBerths={filterByActiveBerths}
       />
 
       {berthToEdit && (

--- a/src/features/harborView/HarborViewTable.tsx
+++ b/src/features/harborView/HarborViewTable.tsx
@@ -11,17 +11,29 @@ import StatusLabel from '../../common/statusLabel/StatusLabel';
 import { formatDimension } from '../../common/utils/format';
 import Pagination from '../../common/pagination/Pagination';
 import CustomerName from './customerName/CustomerName';
+import HarborViewTableFilters from './harborViewTableFilters/HarborViewTableFilters';
 
 interface Props {
   berths: Berth[];
   piers: Pier[];
+  filterByActiveBerths: boolean | null;
   onAddBerth(): void;
   onAddPier(): void;
   onEditBerth(berth: Berth): void;
   onEditPier(pier: Pier): void;
+  setFilterByActiveBerths(isActive: boolean | null): void;
 }
 
-const HarborViewTable = ({ berths, piers, onAddBerth, onAddPier, onEditBerth, onEditPier }: Props) => {
+const HarborViewTable = ({
+  berths,
+  piers,
+  onAddBerth,
+  onAddPier,
+  onEditBerth,
+  onEditPier,
+  setFilterByActiveBerths,
+  filterByActiveBerths,
+}: Props) => {
   const { t, i18n } = useTranslation();
   const [tablePageIndex, setTablePageIndex] = useState(0);
 
@@ -81,6 +93,16 @@ const HarborViewTable = ({ berths, piers, onAddBerth, onAddPier, onEditBerth, on
     },
   ];
 
+  const renderTableFilters = React.useMemo(
+    () => () => (
+      <HarborViewTableFilters
+        setFilterByActiveBerths={setFilterByActiveBerths}
+        filterByActiveBerths={filterByActiveBerths}
+      />
+    ),
+    [setFilterByActiveBerths, filterByActiveBerths]
+  );
+
   return (
     <Table
       data={berths}
@@ -96,6 +118,7 @@ const HarborViewTable = ({ berths, piers, onAddBerth, onAddPier, onEditBerth, on
         />
       )}
       styleMainHeader={false}
+      renderTableFilters={renderTableFilters}
       renderMainHeader={(props) => {
         const piersFilters = props.state.filters.filter((filter) => filter.id === 'identifier');
         const selectedPier = piers.find(({ identifier }) => piersFilters.find(({ value }) => value === identifier));

--- a/src/features/harborView/__generated__/INDIVIDUAL_HARBOR.ts
+++ b/src/features/harborView/__generated__/INDIVIDUAL_HARBOR.ts
@@ -145,4 +145,5 @@ export interface INDIVIDUAL_HARBOR {
 
 export interface INDIVIDUAL_HARBORVariables {
   harborId: string;
+  isBerthActive?: boolean | null;
 }

--- a/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
+++ b/src/features/harborView/__tests__/__snapshots__/HarborView.test.tsx.snap
@@ -522,6 +522,96 @@ exports[`HarborView renders normally 1`] = `
             </div>
           </div>
           <div
+            class="header tableFilterHeader"
+          >
+            <div
+              class="tableFilters"
+            >
+              <div
+                class="titleRow"
+              >
+                <button
+                  class="expandButton"
+                >
+                  Rajaa 
+                  <svg
+                    aria-hidden="true"
+                    class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik"
+                    role="img"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <g
+                      fill="none"
+                      fill-rule="evenodd"
+                    >
+                      <path
+                        d="M0 0h24v24H0z"
+                      />
+                      <path
+                        d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
+                        fill="currentColor"
+                      />
+                    </g>
+                  </svg>
+                </button>
+              </div>
+              <form
+                class="form"
+              >
+                <div
+                  class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+                >
+                  <input
+                    checked=""
+                    class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+                    id="showInactiveBerths"
+                    name="showInactiveBerths"
+                    type="checkbox"
+                    value="true"
+                  />
+                  <label
+                    class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+                    for="showInactiveBerths"
+                  >
+                    Näytä myös käytöstä poistetut venepaikat
+                  </label>
+                </div>
+                <div
+                  class="actionRow"
+                >
+                  <div
+                    class="controlsContainer"
+                  />
+                  <div
+                    class="buttonContainer"
+                  >
+                    <button
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0"
+                      type="button"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Tyhjennä valinnat
+                      </span>
+                    </button>
+                    <button
+                      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0"
+                      type="submit"
+                    >
+                      <span
+                        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+                      >
+                        Käytä
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          </div>
+          <div
             class="header"
             role="row"
             style="display:flex;flex:1 0 auto;min-width:150px"

--- a/src/features/harborView/harborViewTableFilters/HarborViewTableFilters.tsx
+++ b/src/features/harborView/harborViewTableFilters/HarborViewTableFilters.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { IconAngleDown } from 'hds-react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './harborViewTableFilters.module.scss';
+import HarborViewTableFiltersForm from './HarborViewTableFiltersForm';
+import { HarborViewTableFiltersType } from './types';
+
+interface Props {
+  filterByActiveBerths: boolean | null;
+  setFilterByActiveBerths(isActive: boolean | null): void;
+}
+
+const controlledFiltersEmptyValues: HarborViewTableFiltersType = {};
+
+const createInitialState = ({ ...delegated }: HarborViewTableFiltersType): HarborViewTableFiltersType => {
+  return {
+    ...controlledFiltersEmptyValues,
+    ...delegated,
+  };
+};
+
+const HarborViewTableFilters = ({ filterByActiveBerths, setFilterByActiveBerths }: Props) => {
+  const { t } = useTranslation();
+  const [filters, setFilters] = React.useState(() => createInitialState({ showInactiveBerths: !filterByActiveBerths }));
+  const [areFiltersExpanded, setFiltersExpanded] = React.useState(!filterByActiveBerths);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const nextValue = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    setFilters((prev) => ({
+      ...prev,
+      [e.target.name]: nextValue,
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    // When the inactive berths are wanted to be shown,
+    // the active berths filter should not be used.
+    // The default is that only the active berths are shown,
+    // so the show inactive berth cehckbo should be unchecked.
+    setFilterByActiveBerths(filters.showInactiveBerths === true ? null : true);
+  };
+
+  const handleReset = () => {
+    setFilters(controlledFiltersEmptyValues);
+  };
+
+  return (
+    <div className={styles.tableFilters}>
+      <div className={styles.titleRow}>
+        <button
+          className={styles.expandButton}
+          onClick={() => {
+            setFiltersExpanded((prev) => !prev);
+          }}
+        >
+          {t('harborView.message.filter')} <IconAngleDown aria-hidden="true" />
+        </button>
+      </div>
+      {areFiltersExpanded && (
+        <HarborViewTableFiltersForm
+          filters={filters}
+          onFieldChange={handleChange}
+          onSubmit={handleSubmit}
+          onResetAll={handleReset}
+        />
+      )}
+    </div>
+  );
+};
+
+export default HarborViewTableFilters;

--- a/src/features/harborView/harborViewTableFilters/HarborViewTableFiltersForm.tsx
+++ b/src/features/harborView/harborViewTableFilters/HarborViewTableFiltersForm.tsx
@@ -1,0 +1,46 @@
+import { Button, Checkbox } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { HarborViewTableFiltersType } from './types';
+import styles from './harborViewTableFilters.module.scss';
+
+interface Props {
+  filters: HarborViewTableFiltersType;
+  onFieldChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSubmit(e: React.FormEvent<HTMLFormElement>): void;
+  onResetAll(): void;
+}
+
+const HarborViewTableFiltersForm = ({ filters, onFieldChange, onSubmit, onResetAll }: Props) => {
+  const { t } = useTranslation();
+
+  return (
+    <form className={styles.form} onSubmit={onSubmit}>
+      <Checkbox
+        id="showInactiveBerths"
+        name="showInactiveBerths"
+        label={t('harborView.filters.showInactiveBerths')}
+        checked={filters.showInactiveBerths === true}
+        value={filters.showInactiveBerths?.toString()}
+        onChange={(e) => {
+          const event = { ...e };
+          onFieldChange(event);
+        }}
+      />
+      <div className={styles.actionRow}>
+        <div className={styles.controlsContainer} />
+        <div className={styles.buttonContainer}>
+          <Button theme="coat" variant="secondary" onClick={onResetAll}>
+            {t('customerList.message.resetFilters')}
+          </Button>
+          <Button theme="coat" type="submit">
+            {t('customerList.message.useFilters')}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default HarborViewTableFiltersForm;

--- a/src/features/harborView/harborViewTableFilters/harborViewTableFilters.module.scss
+++ b/src/features/harborView/harborViewTableFilters/harborViewTableFilters.module.scss
@@ -1,0 +1,55 @@
+@import 'colours';
+@import 'spacings';
+@import 'z-index';
+
+.titleRow {
+  width: 100%;
+  padding: units(1);
+
+  display: flex;
+  justify-content: flex-end;
+
+  background-color: $blue;
+}
+
+.expandButton {
+  display: flex;
+  align-items: center;
+
+  color: $white;
+  font-weight: 400;
+  text-transform: uppercase;
+
+  & > svg {
+    margin-left: units(0.5);
+  }
+}
+
+.tableFilters {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.form {
+  padding: units(2) 0;
+
+  .actionRow {
+    grid-column: 1 / -1;
+
+    margin-top: units(1);
+
+    display: flex;
+    justify-content: space-between;
+
+    .controlsContainer,
+    .buttonContainer {
+      display: flex;
+      align-items: center;
+
+      & > *:not(:last-child) {
+        margin-right: units(1);
+      }
+    }
+  }
+}

--- a/src/features/harborView/harborViewTableFilters/types.ts
+++ b/src/features/harborView/harborViewTableFilters/types.ts
@@ -1,0 +1,3 @@
+export type HarborViewTableFiltersType = {
+  showInactiveBerths?: boolean;
+};

--- a/src/features/harborView/queries.ts
+++ b/src/features/harborView/queries.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const INDIVIDUAL_HARBOR_QUERY = gql`
-  query INDIVIDUAL_HARBOR($harborId: ID!) {
+  query INDIVIDUAL_HARBOR($harborId: ID!, $isBerthActive: Boolean) {
     harbor(id: $harborId) {
       id
       properties {
@@ -36,7 +36,7 @@ export const INDIVIDUAL_HARBOR_QUERY = gql`
         }
       }
     }
-    berths(harbor: $harborId) {
+    berths(harbor: $harborId, isActive: $isBerthActive) {
       count
       edges {
         node {

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -421,6 +421,12 @@
     "tableTools": {
       "addPier": "Lisää laituri",
       "addBerth": "Lisää venepaikka"
+    },
+    "message": {
+      "filter": "Rajaa"
+    },
+    "filters": {
+      "showInactiveBerths": "Näytä myös käytöstä poistetut venepaikat"
     }
   },
   "applicationList": {


### PR DESCRIPTION
VEN-1482 VEN-1488. 

NOTE: This pull request first needs changes from the Berth Reservations API: https://github.com/City-of-Helsinki/berth-reservations/pull/668

Can be tested with `Merihaan venesatama (Hakaniemenranta 30)` or some else which have inactive berths.

1 page of active berths:

![image](https://user-images.githubusercontent.com/389204/164685769-9b703bc8-8ea6-4587-91d1-f2231fd81ad8.png)

5 pages of all berths (inactive included):

![image](https://user-images.githubusercontent.com/389204/164685897-8e176aba-c232-4e3d-be7d-6a5ae8eb892d.png)

![image](https://user-images.githubusercontent.com/389204/164685975-0acec701-b815-4ffc-a7b9-bf61714cbfda.png)
