### PR TITLE
VEN-1169 | Allow customer invoicing type to be controlled and filtered

### DIFF
--- a/src/features/applicationView/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/applicationView/__tests__/__snapshots__/utils.test.ts.snap
@@ -70,7 +70,7 @@ Object {
   "customerGroup": "PRIVATE",
   "customerId": "MOCK-CUSTOMER",
   "firstName": "Testi",
-  "invoicingType": "DIGITAL_INVOICE",
+  "invoicingType": "ONLINE_PAYMENT",
   "language": "FINNISH",
   "lastName": "Testinen",
   "organization": null,

--- a/src/features/applicationView/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/applicationView/__tests__/__snapshots__/utils.test.ts.snap
@@ -70,6 +70,7 @@ Object {
   "customerGroup": "PRIVATE",
   "customerId": "MOCK-CUSTOMER",
   "firstName": "Testi",
+  "invoicingType": "DIGITAL_INVOICE",
   "language": "FINNISH",
   "lastName": "Testinen",
   "organization": null,

--- a/src/features/customerForm/CustomerForm.tsx
+++ b/src/features/customerForm/CustomerForm.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import { Form, Formik } from 'formik';
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
-import { TextArea, TextInput } from 'hds-react';
+import { TextArea, TextInput, Checkbox } from 'hds-react';
 
 import { CustomerFormValues, FormProps } from './types';
-import { CustomerGroup } from '../../@types/__generated__/globalTypes';
+import { CustomerGroup, InvoicingType } from '../../@types/__generated__/globalTypes';
 import Select from '../../common/select/Select';
 import styles from './customerForm.module.scss';
 import Button from '../../common/button/Button';
@@ -72,7 +72,7 @@ const CustomerForm = ({ initialValues, isSubmitting, onSubmit, onCancel }: Custo
         validationSchema={validationSchema}
         validateOnChange={false}
       >
-        {({ errors, handleChange, values, validateForm }) => (
+        {({ errors, handleChange, values, validateForm, setFieldValue }) => (
           <Form className={styles.form}>
             <Select
               id="customerGroup"
@@ -114,6 +114,18 @@ const CustomerForm = ({ initialValues, isSubmitting, onSubmit, onCancel }: Custo
               onChange={handleChange}
               invalid={!!errors.comment}
               helperText={errors.comment}
+            />
+            <Checkbox
+              id="invoicingType"
+              name="invoicingType"
+              label={t('forms.customer.selectInvoicingTypePaperInvoice')}
+              value={InvoicingType.PAPER_INVOICE}
+              onChange={(e) => {
+                const nextFieldValue = e.target.checked ? InvoicingType.PAPER_INVOICE : InvoicingType.ONLINE_PAYMENT;
+
+                setFieldValue(e.target.name, nextFieldValue);
+              }}
+              checked={values.invoicingType === InvoicingType.PAPER_INVOICE}
             />
 
             <div className={styles.formActionButtons}>

--- a/src/features/customerForm/__fixtures__/mockData.ts
+++ b/src/features/customerForm/__fixtures__/mockData.ts
@@ -1,5 +1,5 @@
 import { CUSTOMER_FORM_profile as PROFILE } from '../__generated__/CUSTOMER_FORM';
-import { CustomerGroup, Language } from '../../../@types/__generated__/globalTypes';
+import { CustomerGroup, InvoicingType, Language } from '../../../@types/__generated__/globalTypes';
 import { CustomerFormIdentifiers, CustomerFormValues } from '../types';
 
 export const mockPrivateCustomerProfile: PROFILE = {
@@ -11,6 +11,7 @@ export const mockPrivateCustomerProfile: PROFILE = {
   language: Language.FINNISH,
   lastName: 'Ryti',
   organization: null,
+  invoicingType: InvoicingType.ONLINE_PAYMENT,
   primaryAddress: {
     __typename: 'AddressNode',
     address: 'Mariankatu 2',
@@ -38,6 +39,7 @@ export const mockOrganizationCustomerProfile: PROFILE = {
   id: 'MOCK-PROFILE',
   language: Language.FINNISH,
   lastName: 'Kallio',
+  invoicingType: InvoicingType.ONLINE_PAYMENT,
   organization: {
     __typename: 'OrganizationNode',
     address: 'Mariankatu 2',

--- a/src/features/customerForm/__generated__/CUSTOMER_FORM.ts
+++ b/src/features/customerForm/__generated__/CUSTOMER_FORM.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { CustomerGroup, Language } from "./../../../@types/__generated__/globalTypes";
+import { CustomerGroup, InvoicingType, Language } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: CUSTOMER_FORM
@@ -46,6 +46,7 @@ export interface CUSTOMER_FORM_profile {
   firstName: string;
   lastName: string;
   customerGroup: CustomerGroup | null;
+  invoicingType: InvoicingType | null;
   organization: CUSTOMER_FORM_profile_organization | null;
   primaryAddress: CUSTOMER_FORM_profile_primaryAddress | null;
   primaryEmail: CUSTOMER_FORM_profile_primaryEmail | null;

--- a/src/features/customerForm/__tests__/__snapshots__/CustomerForm.test.tsx.snap
+++ b/src/features/customerForm/__tests__/__snapshots__/CustomerForm.test.tsx.snap
@@ -343,6 +343,23 @@ Array [
       </div>
     </div>
     <div
+      class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+    >
+      <input
+        class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+        id="invoicingType"
+        name="invoicingType"
+        type="checkbox"
+        value="PAPER_INVOICE"
+      />
+      <label
+        class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+        for="invoicingType"
+      >
+        Laskutus paperisena
+      </label>
+    </div>
+    <div
       class="formActionButtons"
     >
       <button
@@ -655,6 +672,23 @@ Array [
           id="comment"
         />
       </div>
+    </div>
+    <div
+      class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+    >
+      <input
+        class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+        id="invoicingType"
+        name="invoicingType"
+        type="checkbox"
+        value="PAPER_INVOICE"
+      />
+      <label
+        class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+        for="invoicingType"
+      >
+        Laskutus paperisena
+      </label>
     </div>
     <div
       class="formActionButtons"

--- a/src/features/customerForm/__tests__/__snapshots__/EditCustomerFormContainer.test.tsx.snap
+++ b/src/features/customerForm/__tests__/__snapshots__/EditCustomerFormContainer.test.tsx.snap
@@ -300,6 +300,23 @@ Array [
       </div>
     </div>
     <div
+      class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz"
+    >
+      <input
+        class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+        id="invoicingType"
+        name="invoicingType"
+        type="checkbox"
+        value="PAPER_INVOICE"
+      />
+      <label
+        class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+        for="invoicingType"
+      >
+        Laskutus paperisena
+      </label>
+    </div>
+    <div
       class="formActionButtons"
     >
       <button

--- a/src/features/customerForm/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/customerForm/__tests__/__snapshots__/utils.test.ts.snap
@@ -37,6 +37,7 @@ Array [
     "comment": "",
     "deleteOrganization": true,
     "id": "MOCK-PROFILE",
+    "invoicingType": undefined,
   },
 ]
 `;
@@ -71,6 +72,7 @@ Array [
   Object {
     "comment": "",
     "id": "MOCK-PROFILE",
+    "invoicingType": undefined,
     "organization": Object {
       "address": "Mariankatu 2",
       "businessId": "1234567-8",
@@ -118,6 +120,7 @@ Array [
   Object {
     "comment": "",
     "id": "MOCK-PROFILE",
+    "invoicingType": undefined,
   },
 ]
 `;
@@ -149,6 +152,7 @@ Array [
   Object {
     "comment": "",
     "id": "MOCK-PROFILE",
+    "invoicingType": undefined,
     "organization": Object {
       "address": "Mariankatu 2",
       "businessId": "1234567-8",
@@ -170,6 +174,7 @@ Object {
   "customerGroup": "PRIVATE",
   "email": "test@example.com",
   "firstName": "Risto Heikki",
+  "invoicingType": "ONLINE_PAYMENT",
   "lastName": "Ryti",
   "organizationName": "",
   "phone": "+358 00 000 0000",
@@ -186,6 +191,7 @@ Object {
   "customerGroup": "PRIVATE",
   "email": "",
   "firstName": "Risto Heikki",
+  "invoicingType": "ONLINE_PAYMENT",
   "lastName": "Ryti",
   "organizationName": "",
   "phone": "",
@@ -202,6 +208,7 @@ Object {
   "customerGroup": "COMPANY",
   "email": "test@example.com",
   "firstName": "Kyösti",
+  "invoicingType": "ONLINE_PAYMENT",
   "lastName": "Kallio",
   "organizationName": "Suomi Oy",
   "phone": "+358 00 000 0000",
@@ -218,6 +225,7 @@ Object {
   "customerGroup": "COMPANY",
   "email": "",
   "firstName": "Kyösti",
+  "invoicingType": "ONLINE_PAYMENT",
   "lastName": "Kallio",
   "organizationName": "Suomi Oy",
   "phone": "",

--- a/src/features/customerForm/queries.ts
+++ b/src/features/customerForm/queries.ts
@@ -8,6 +8,7 @@ export const CUSTOMER_FORM_QUERY = gql`
       firstName
       lastName
       customerGroup
+      invoicingType
       organization {
         id
         address

--- a/src/features/customerForm/types.ts
+++ b/src/features/customerForm/types.ts
@@ -1,6 +1,6 @@
 import { PureQueryOptions } from 'apollo-client';
 
-import { CustomerGroup } from '../../@types/__generated__/globalTypes';
+import { CustomerGroup, InvoicingType } from '../../@types/__generated__/globalTypes';
 
 export interface FormProps<T> {
   initialValues?: T;
@@ -33,4 +33,5 @@ export type CustomerFormValues = {
   businessId: string;
   phone: string;
   postalCode: string;
+  invoicingType?: InvoicingType | null;
 };

--- a/src/features/customerForm/utils.ts
+++ b/src/features/customerForm/utils.ts
@@ -29,6 +29,7 @@ export const getCustomerFormValues = (profile: PROFILE): CustomerFormValues => {
     primaryAddress,
     primaryEmail,
     primaryPhone,
+    invoicingType,
   } = profile;
 
   const common = {
@@ -37,6 +38,7 @@ export const getCustomerFormValues = (profile: PROFILE): CustomerFormValues => {
     firstName,
     lastName,
     phone: primaryPhone?.phone || '',
+    invoicingType,
   };
 
   if (customerGroup === null || customerGroup === CustomerGroup.PRIVATE) {
@@ -266,7 +268,7 @@ export const createUpdateInputs = (
   values: CustomerFormValues,
   identifiers: CustomerFormIdentifiers
 ): [UpdateProfileMutationInput, UpdateBerthServicesProfileMutationInput] => {
-  const { comment, email, firstName, lastName, phone } = values;
+  const { comment, email, firstName, lastName, phone, invoicingType } = values;
   const { id, primaryEmailId, primaryPhoneId } = identifiers;
 
   const emailProperties = createEmailProperties(email, primaryEmailId);
@@ -288,6 +290,7 @@ export const createUpdateInputs = (
     {
       comment,
       id,
+      invoicingType,
       ...organizationProperties,
     },
   ];

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -20,6 +20,7 @@ import useListTableFilters from './customerListTableFilters/useListTableFilters'
 import { ALL_CUSTOMERS, ALL_CUSTOMERSVariables as ALL_CUSTOMERS_VARS } from './__generated__/ALL_CUSTOMERS';
 import useCustomersQuery from './useCustomersQuery';
 import { createIntervalWithSilentError, createDate } from './customerListTableFilters/utils';
+import { InvoicingType } from '../../@types/__generated__/globalTypes';
 
 export enum SearchBy {
   FIRST_NAME = 'firstName',
@@ -28,6 +29,7 @@ export enum SearchBy {
   ADDRESS = 'address',
   STICKER_NUMBER = 'stickerNumber',
   BOAT_REGISTRATION_NUMBER = 'boatRegistrationNumber',
+  INVOICING_TYPE = 'invoicingType',
 }
 
 const searchByAtom = atom<SearchBy>({
@@ -159,6 +161,14 @@ const CustomerListContainer = () => {
           { value: SearchBy.ADDRESS, label: t('common.address') },
           { value: SearchBy.STICKER_NUMBER, label: t('common.terminology.stickerNumber') },
           { value: SearchBy.BOAT_REGISTRATION_NUMBER, label: t('common.terminology.registrationNumber') },
+          {
+            value: SearchBy.INVOICING_TYPE,
+            label: t('common.terminology.invoicingType'),
+            options: [InvoicingType.ONLINE_PAYMENT, InvoicingType.PAPER_INVOICE].map((type) => ({
+              label: t(`common.invoicingTypes.${type}`),
+              value: type,
+            })),
+          },
         ],
       }}
     />

--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -3,7 +3,7 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { CustomerGroup, LeaseStatus, ServiceType, ContactMethod } from "./../../../@types/__generated__/globalTypes";
+import { CustomerGroup, LeaseStatus, InvoicingType, ServiceType, ContactMethod } from "./../../../@types/__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: CUSTOMERS
@@ -196,4 +196,5 @@ export interface CUSTOMERSVariables {
   apiToken?: string | null;
   startDate?: any | null;
   endDate?: any | null;
+  invoicingType?: InvoicingType | null;
 }

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -108,6 +108,7 @@ export const CUSTOMERS_QUERY = gql`
     $apiToken: String
     $startDate: Date
     $endDate: Date
+    $invoicingType: InvoicingType
   ) {
     berthProfiles(
       first: $first
@@ -132,6 +133,7 @@ export const CUSTOMERS_QUERY = gql`
       apiToken: $apiToken
       leaseStart: $startDate
       leaseEnd: $endDate
+      invoicingTypes: [$invoicingType]
     ) {
       count
       edges {

--- a/src/features/customerList/tableTools/CustomerListTableTools.tsx
+++ b/src/features/customerList/tableTools/CustomerListTableTools.tsx
@@ -11,11 +11,16 @@ import Button from '../../../common/button/Button';
 import CustomerMessageFormContainer from '../../customerMessageForm/CustomerMessageFormContainer';
 import AddCustomerFormContainer from '../../customerForm/AddCustomerFormContainer';
 
+type CustomerListTableToolsSearchByOptionOption = {
+  label: string;
+  value: string;
+};
+
 export interface CustomerListTableToolsProps<T> {
   className?: string;
   searchVal: string | undefined;
   searchBy: T;
-  searchByOptions: Array<{ value: T; label: string }>;
+  searchByOptions: Array<{ value: T; label: string; options?: CustomerListTableToolsSearchByOptionOption[] }>;
   selectedCustomerIds: string[];
   isExporting: boolean;
   handleCustomersExport: () => Promise<void>;
@@ -42,6 +47,7 @@ const CustomerListTableTools = <T extends string>({
   const [messageModalOpen, setMessageModalOpen] = useState<boolean>(false);
   const [addCustomerModalOpen, setAddCustomerModalOpen] = useState<boolean>(false);
   const selectedRowsCount = selectedCustomerIds.length;
+  const selectedSearchByOption = searchByOptions.find((option) => option.value === searchBy);
 
   return (
     <>
@@ -66,17 +72,39 @@ const CustomerListTableTools = <T extends string>({
         <div className={styles.tableToolsRight}>
           <Select
             className={styles.select}
-            onChange={(e) => setSearchBy(e.target.value as T)}
+            onChange={(e) => {
+              const nextSearchBy = e.target.value as T;
+              const option = searchByOptions.find((option) => option.value === nextSearchBy);
+              const firstOptionValue = option?.options?.[0]?.value;
+
+              if (firstOptionValue) {
+                // If the next search by options has options, select the value
+                // of the first option by default.
+                setSearchVal(firstOptionValue);
+              }
+
+              setSearchBy(nextSearchBy);
+            }}
             value={searchBy}
             options={searchByOptions}
             required
           />
-          <TextInput
-            className={styles.searchInput}
-            id="searchSimilarCustomers"
-            value={searchVal}
-            onChange={(e) => setSearchVal((e.target as HTMLInputElement).value)}
-          />
+          {selectedSearchByOption?.options ? (
+            <Select
+              className={styles.select}
+              id="searchSimilarCustomers"
+              options={selectedSearchByOption?.options}
+              value={searchVal}
+              onChange={(e) => setSearchVal((e.target as HTMLSelectElement).value)}
+            />
+          ) : (
+            <TextInput
+              className={styles.searchInput}
+              id="searchSimilarCustomers"
+              value={searchVal}
+              onChange={(e) => setSearchVal((e.target as HTMLInputElement).value)}
+            />
+          )}
         </div>
       </div>
 

--- a/src/features/customerList/useCustomersQuery.ts
+++ b/src/features/customerList/useCustomersQuery.ts
@@ -11,6 +11,7 @@
 
 import { useQuery } from '@apollo/react-hooks';
 
+import { InvoicingType } from '../../@types/__generated__/globalTypes';
 import { limitedCustomerSearchFeatureFlag } from '../../common/utils/featureFlags';
 import { CUSTOMERS, CUSTOMERSVariables as CUSTOMERS_VARS } from './__generated__/CUSTOMERS';
 import {
@@ -40,6 +41,7 @@ type Config = Omit<CustomerListTableFilters, 'dateInterval'> & {
   address?: string;
   stickerNumber?: string;
   boatRegistrationNumber?: string;
+  invoicingType?: InvoicingType;
 };
 
 export default function useCustomersQuery({

--- a/src/features/customerView/utils.ts
+++ b/src/features/customerView/utils.ts
@@ -34,6 +34,7 @@ export const getCustomerProfile = (
       language: profile.language,
       customerGroup: profile.customerGroup,
       comment: profile.comment,
+      invoicingType: profile.invoicingType || undefined,
     },
     ...(profile.organization && {
       organization: profile.organization,

--- a/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeView.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeView.test.tsx.snap
@@ -759,6 +759,18 @@ exports[`UnmarkedWsNoticeView renders normally with customer 1`] = `
               Suomi
             </span>
           </div>
+          <div
+            class="labelValuePair"
+          >
+            <span
+              class="label standard"
+            />
+            <span
+              class="value left"
+            >
+              Laskutus sähköisenä
+            </span>
+          </div>
         </section>
       </article>
       <article

--- a/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeView.test.tsx.snap
+++ b/src/features/unmarkedWsNoticeView/__tests__/__snapshots__/UnmarkedWsNoticeView.test.tsx.snap
@@ -768,7 +768,7 @@ exports[`UnmarkedWsNoticeView renders normally with customer 1`] = `
             <span
               class="value left"
             >
-              Laskutus sähköisenä
+              Verkkomaksu
             </span>
           </div>
         </section>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -130,6 +130,7 @@
       "inQueue": "Jonossa",
       "invoice": "Lasku",
       "invoices": "Laskut",
+      "invoicingType": "Laskutustyyppi",
       "length": "Pituus",
       "lighting": "Valaistus",
       "maintenanceDetails": "Huoltotiedot",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -318,7 +318,8 @@
       "city": "Toimipaikka",
       "phone": "Puhelinnumero",
       "email": "Sähköpostiosoite",
-      "comment": "Huomiot"
+      "comment": "Huomiot",
+      "selectInvoicingTypePaperInvoice": "Laskutus paperisena"
     },
     "additionalServices": {
       "title": "Lisäpalvelu",


### PR DESCRIPTION
- Adds invoicing status to customer details customer card
- Allows invoicing type to be changed between PAPER_INVOICE and ONLINE_PAYMENT on customer edit form
- Allows customer profiles to be filtered by invoicingTypes PAPER_INVOICE and ONLINE_PAYMENT

<img width="683" alt="Screenshot 2022-04-27 at 11 59 07" src="https://user-images.githubusercontent.com/9090689/165482697-c086ecb3-cb60-4298-9f0b-073741d44224.png">
<img width="618" alt="Screenshot 2022-04-27 at 15 22 34" src="https://user-images.githubusercontent.com/9090689/165517137-7b3400a7-ff58-423b-8532-8ad1e3700149.png">
<img width="487" alt="Screenshot 2022-04-27 at 15 22 50" src="https://user-images.githubusercontent.com/9090689/165517142-56558d83-9996-473e-b5fc-f6b32b8aed9c.png">

