### PR TITLE
VEN-1340: CRUD Sections/Places

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -92,7 +92,6 @@ export enum EmailType {
 }
 
 export enum InvoicingType {
-  DIGITAL_INVOICE = "DIGITAL_INVOICE",
   ONLINE_PAYMENT = "ONLINE_PAYMENT",
   PAPER_INVOICE = "PAPER_INVOICE",
 }
@@ -295,9 +294,9 @@ export interface CreateBerthMutationInput {
   comment?: string | null;
   isAccessible?: boolean | null;
   isInvoiceable?: boolean | null;
-  width: number;
-  length: number;
-  depth?: number | null;
+  width: any;
+  length: any;
+  depth?: any | null;
   mooringType: BerthMooringType;
   clientMutationId?: string | null;
 }
@@ -383,9 +382,32 @@ export interface CreateWinterStorageLeaseMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface CreateWinterStoragePlaceMutationInput {
+  isActive?: boolean | null;
+  number: string;
+  winterStorageSectionId: string;
+  comment?: string | null;
+  width: any;
+  length?: any | null;
+  clientMutationId?: string | null;
+}
+
 export interface CreateWinterStorageProductMutationInput {
   priceValue: any;
   winterStorageAreaId?: string | null;
+  clientMutationId?: string | null;
+}
+
+export interface CreateWinterStorageSectionMutationInput {
+  identifier?: string | null;
+  location?: any | null;
+  electricity?: boolean | null;
+  water?: boolean | null;
+  gate?: boolean | null;
+  areaId: string;
+  summerStorageForDockingEquipment?: boolean | null;
+  summerStorageForTrailers?: boolean | null;
+  summerStorageForBoats?: boolean | null;
   clientMutationId?: string | null;
 }
 
@@ -435,6 +457,16 @@ export interface DeleteWinterStorageApplicationMutationInput {
 }
 
 export interface DeleteWinterStorageLeaseMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
+export interface DeleteWinterStoragePlaceMutationInput {
+  id: string;
+  clientMutationId?: string | null;
+}
+
+export interface DeleteWinterStorageSectionMutationInput {
   id: string;
   clientMutationId?: string | null;
 }
@@ -594,9 +626,9 @@ export interface UpdateBerthMutationInput {
   comment?: string | null;
   isAccessible?: boolean | null;
   isInvoiceable?: boolean | null;
-  width?: number | null;
-  length?: number | null;
-  depth?: number | null;
+  width?: any | null;
+  length?: any | null;
+  depth?: any | null;
   mooringType?: BerthMooringType | null;
   id: string;
   clientMutationId?: string | null;
@@ -787,10 +819,35 @@ export interface UpdateWinterStorageAreaMutationInput {
   clientMutationId?: string | null;
 }
 
+export interface UpdateWinterStoragePlaceMutationInput {
+  isActive?: boolean | null;
+  number?: string | null;
+  winterStorageSectionId?: string | null;
+  comment?: string | null;
+  width?: any | null;
+  length?: any | null;
+  id: string;
+  clientMutationId?: string | null;
+}
+
 export interface UpdateWinterStorageProductMutationInput {
   id: string;
   priceValue?: any | null;
   winterStorageAreaId?: string | null;
+  clientMutationId?: string | null;
+}
+
+export interface UpdateWinterStorageSectionMutationInput {
+  identifier?: string | null;
+  location?: any | null;
+  electricity?: boolean | null;
+  water?: boolean | null;
+  gate?: boolean | null;
+  areaId?: string | null;
+  summerStorageForDockingEquipment?: boolean | null;
+  summerStorageForTrailers?: boolean | null;
+  summerStorageForBoats?: boolean | null;
+  id: string;
   clientMutationId?: string | null;
 }
 

--- a/src/features/applicationView/__fixtures__/mockData.ts
+++ b/src/features/applicationView/__fixtures__/mockData.ts
@@ -26,7 +26,7 @@ export const mockCustomer: CUSTOMER = {
   comment: 'Comment',
   firstName: 'Testi',
   id: 'MOCK-CUSTOMER',
-  invoicingType: InvoicingType.DIGITAL_INVOICE,
+  invoicingType: InvoicingType.ONLINE_PAYMENT,
   language: Language.FINNISH,
   lastName: 'Testinen',
   organization: null,

--- a/src/features/harborView/HarborViewContainer.tsx
+++ b/src/features/harborView/HarborViewContainer.tsx
@@ -23,7 +23,6 @@ const HarborViewContainer = () => {
   const [creatingBerth, setCreatingBerth] = useState<boolean>(false);
   const [pierToEdit, setPierToEdit] = useState<string | null>(null);
   const [creatingPier, setCreatingPier] = useState<boolean>(false);
-
   const { id: harborId } = useParams<{ id: string }>();
   const { loading, data } = useQuery<INDIVIDUAL_HARBOR, INDIVIDUAL_HARBOR_VARS>(INDIVIDUAL_HARBOR_QUERY, {
     variables: {

--- a/src/features/harborView/forms/berthForm/__tests__/__snapshots__/BerthEditForm.test.tsx.snap
+++ b/src/features/harborView/forms/berthForm/__tests__/__snapshots__/BerthEditForm.test.tsx.snap
@@ -182,7 +182,7 @@ exports[`features/harborView/BerthEditForm renders content after loading 1`] = `
           class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
           id="depth"
           type="text"
-          value="1"
+          value="2"
         />
       </div>
     </div>

--- a/src/features/unmarkedWsNoticeView/__fixtures__/mockData.ts
+++ b/src/features/unmarkedWsNoticeView/__fixtures__/mockData.ts
@@ -127,7 +127,7 @@ export const mockCustomer: CUSTOMER = {
   customerGroup: CustomerGroup.PRIVATE,
   firstName: 'Hessu',
   id: '1',
-  invoicingType: InvoicingType.DIGITAL_INVOICE,
+  invoicingType: InvoicingType.ONLINE_PAYMENT,
   language: Language.FINNISH,
   lastName: 'Hopo',
   organization: null,

--- a/src/features/winterStorageAreaView/WinterStorageAreaView.tsx
+++ b/src/features/winterStorageAreaView/WinterStorageAreaView.tsx
@@ -16,6 +16,10 @@ interface WinterStorageAreaViewPageProps {
   markedWinterStorage?: MarkedWinterStorage;
   unmarkedWinterStorage?: UnmarkedWinterStorage;
   setEditingWinterStorageArea: (editingWinterStorageArea: boolean) => void;
+  setSectionToEdit: (sectionToEdit: string | null) => void;
+  setCreatingSection: (creatingSection: boolean) => void;
+  setCreatingPlace: (creatingPlace: boolean) => void;
+  setPlaceToEdit: (placeToEdit: string | null) => void;
 }
 
 const WinterStorageAreaView = ({
@@ -23,6 +27,10 @@ const WinterStorageAreaView = ({
   markedWinterStorage,
   unmarkedWinterStorage,
   setEditingWinterStorageArea,
+  setCreatingSection,
+  setSectionToEdit,
+  setCreatingPlace,
+  setPlaceToEdit,
 }: WinterStorageAreaViewPageProps) => {
   const { t } = useTranslation();
 
@@ -37,7 +45,16 @@ const WinterStorageAreaView = ({
         />
         <ContactInformationCard />
         <ActionHistoryCard />
-        {markedWinterStorage && <WinterStoragePlaceTable {...markedWinterStorage} className={styles.fullWidth} />}
+        {markedWinterStorage && (
+          <WinterStoragePlaceTable
+            {...markedWinterStorage}
+            className={styles.fullWidth}
+            onAddSection={() => setCreatingSection(true)}
+            onAddPlace={() => setCreatingPlace(true)}
+            onEditSection={(section) => setSectionToEdit(section.id)}
+            onEditPlace={(place) => setPlaceToEdit(place.id)}
+          />
+        )}
         {unmarkedWinterStorage && (
           <UnmarkedWinterStorageLeaseTable {...unmarkedWinterStorage} className={styles.fullWidth} />
         )}

--- a/src/features/winterStorageAreaView/WinterStorageAreaViewContainer.tsx
+++ b/src/features/winterStorageAreaView/WinterStorageAreaViewContainer.tsx
@@ -9,11 +9,19 @@ import WinterStorageAreaView from './WinterStorageAreaView';
 import { INDIVIDUAL_WINTER_STORAGE_AREA_QUERY } from './queries';
 import Modal from '../../common/modal/Modal';
 import WinterStorageAreaEditForm from './forms/WinterStorageAreaEditForm';
+import SectionCreateForm from './forms/sectionForm/SectionCreateForm';
+import SectionEditForm from './forms/sectionForm/SectionEditForm';
+import PlaceEditForm from './forms/placeForm/PlaceEditForm';
+import PlaceCreateForm from './forms/placeForm/PlaceCreateForm';
 
 const WinterStorageAreaViewContainer = () => {
   const { id } = useParams<{ id: string }>();
 
   const [editingWinterStorageArea, setEditingWinterStorageArea] = useState<boolean>(false);
+  const [sectionToEdit, setSectionToEdit] = useState<string | null>(null);
+  const [creatingSection, setCreatingSection] = useState<boolean>(false);
+  const [placeToEdit, setPlaceToEdit] = useState<string | null>(null);
+  const [creatingPlace, setCreatingPlace] = useState<boolean>(false);
 
   const { loading, data } = useQuery<INDIVIDUAL_WINTER_STORAGE_AREA>(INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, {
     variables: { id },
@@ -32,6 +40,10 @@ const WinterStorageAreaViewContainer = () => {
         markedWinterStorage={markedWinterStorage}
         unmarkedWinterStorage={unmarkedWinterStorage}
         setEditingWinterStorageArea={setEditingWinterStorageArea}
+        setSectionToEdit={setSectionToEdit}
+        setCreatingSection={setCreatingSection}
+        setPlaceToEdit={setPlaceToEdit}
+        setCreatingPlace={setCreatingPlace}
       />
       <Modal isOpen={editingWinterStorageArea} toggleModal={() => setEditingWinterStorageArea(false)}>
         <WinterStorageAreaEditForm
@@ -39,6 +51,45 @@ const WinterStorageAreaViewContainer = () => {
           onCancel={() => setEditingWinterStorageArea(false)}
           onSubmit={() => setEditingWinterStorageArea(false)}
           refetchQueries={[{ query: INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, variables: { id } }]}
+        />
+      </Modal>
+      <Modal isOpen={creatingSection} toggleModal={() => setCreatingSection(false)}>
+        <SectionCreateForm
+          winterStorageAreaId={id}
+          onCancel={() => setCreatingSection(false)}
+          onSubmit={() => setCreatingSection(false)}
+          refetchQueries={[{ query: INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, variables: { id } }]}
+        />
+      </Modal>
+      {sectionToEdit && (
+        <Modal isOpen toggleModal={() => setSectionToEdit(null)}>
+          <SectionEditForm
+            winterStorageSectionId={sectionToEdit}
+            onCancel={() => setSectionToEdit(null)}
+            onDelete={() => setSectionToEdit(null)}
+            onSubmit={() => setSectionToEdit(null)}
+            refetchQueries={[{ query: INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, variables: { id } }]}
+          />
+        </Modal>
+      )}
+      {placeToEdit && (
+        <Modal isOpen toggleModal={() => setPlaceToEdit(null)}>
+          <PlaceEditForm
+            placeId={placeToEdit}
+            onCancel={() => setPlaceToEdit(null)}
+            onDelete={() => setPlaceToEdit(null)}
+            onSubmit={() => setPlaceToEdit(null)}
+            refetchQueries={[{ query: INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, variables: { id } }]}
+            sectionOptions={markedWinterStorage?.sections || []}
+          />
+        </Modal>
+      )}
+      <Modal isOpen={creatingPlace} toggleModal={() => setCreatingPlace(false)}>
+        <PlaceCreateForm
+          onCancel={() => setCreatingPlace(false)}
+          onSubmit={() => setCreatingPlace(false)}
+          refetchQueries={[{ query: INDIVIDUAL_WINTER_STORAGE_AREA_QUERY, variables: { id } }]}
+          sectionOptions={markedWinterStorage?.sections || []}
         />
       </Modal>
     </>

--- a/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
+++ b/src/features/winterStorageAreaView/WinterStoragePlaceTable.tsx
@@ -7,10 +7,10 @@ import Table, { Column } from '../../common/table/Table';
 import StatusLabel from '../../common/statusLabel/StatusLabel';
 import SelectHeader from '../../common/selectHeader/SelectHeader';
 import Pagination from '../../common/pagination/Pagination';
-import GlobalSearchTableTools from '../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
 import { formatDimension } from '../../common/utils/format';
 import CustomerName from '../harborView/customerName/CustomerName';
 import WinterStoragePlaceDetailsContainer from '../winterStoragePlaceDetails/WinterStoragePlaceDetailsContainer';
+import WinterStoragePlaceTableTools from './winterStoragePlaceTableTools/WinterStoragePlaceTableTools';
 
 type ColumnType = Column<WinterStoragePlace>;
 
@@ -18,9 +18,21 @@ interface WinterStorageAreaViewTableProps {
   places: WinterStoragePlace[];
   sections: WinterStorageSection[];
   className?: string;
+  onAddSection(): void;
+  onAddPlace(): void;
+  onEditSection(section: WinterStorageSection): void;
+  onEditPlace(place: WinterStoragePlace): void;
 }
 
-const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageAreaViewTableProps) => {
+const WinterStoragePlaceTable = ({
+  places,
+  sections,
+  className,
+  onAddSection,
+  onAddPlace,
+  onEditSection,
+  onEditPlace,
+}: WinterStorageAreaViewTableProps) => {
   const { t, i18n } = useTranslation();
   const columns: ColumnType[] = [
     {
@@ -72,7 +84,14 @@ const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageA
       data={places}
       columns={columns}
       canSelectRows
-      renderTableToolsTop={(_, setters) => <GlobalSearchTableTools handleGlobalFilter={setters.setGlobalFilter} />}
+      renderTableToolsTop={(_, setters) => (
+        <WinterStoragePlaceTableTools
+          onAddSection={onAddSection}
+          onAddPlace={onAddPlace}
+          handleGlobalFilter={setters.setGlobalFilter}
+          canAddPlace={sections.length > 0}
+        />
+      )}
       renderMainHeader={(props) => {
         const sectionFilters = props.state.filters.filter((filter) => filter.id === 'identifier');
         const selectedSection = sections.find(({ identifier }) =>
@@ -80,7 +99,6 @@ const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageA
         );
 
         if (sectionFilters.length && selectedSection === undefined) props.setFilter('identifier', undefined);
-
         return (
           <SelectHeader
             title={t('winterStorageAreaView.markedPlaces').toUpperCase()}
@@ -91,11 +109,14 @@ const WinterStoragePlaceTable = ({ places, sections, className }: WinterStorageA
             formatter={(section) => `${t('winterStorageAreaView.tableHeaders.identifier')} ${section.identifier}`}
             equals={(a, b) => a.identifier === b.identifier}
             onSelect={(section) => props.setFilter('identifier', section?.identifier)}
+            onEdit={onEditSection}
           />
         );
       }}
       styleMainHeader={false}
-      renderSubComponent={(row) => <WinterStoragePlaceDetailsContainer id={row.original.id} />}
+      renderSubComponent={(row) => (
+        <WinterStoragePlaceDetailsContainer id={row.original.id} onEdit={() => onEditPlace(row.original)} />
+      )}
       renderPaginator={({ pageIndex, pageCount, goToPage }) => (
         <Pagination
           pageIndex={pageIndex}

--- a/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
+++ b/src/features/winterStorageAreaView/__tests__/__snapshots__/WinterStorageAreaViewContainer.test.tsx.snap
@@ -392,21 +392,49 @@ exports[`WinterStorageAreaViewContainer renders correctly 1`] = `
       class="fullWidth"
     >
       <div
-        class="globalSearchTableTools"
+        class="container"
       >
         <div
-          class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq filterField"
+          class="buttons"
+        >
+          <button
+            class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0 button"
+            type="button"
+          >
+            <span
+              class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+            >
+              Lisää osasto
+            </span>
+          </button>
+          <button
+            class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0 button"
+            type="button"
+          >
+            <span
+              class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+            >
+              Lisää paikka
+            </span>
+          </button>
+        </div>
+        <div
+          class="globalSearchTableTools"
         >
           <div
-            class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq filterField"
           >
-            <input
-              class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-              id="textSearchGlobalFilter"
-              placeholder="Haku"
-              type="text"
-              value=""
-            />
+            <div
+              class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+            >
+              <input
+                class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+                id="textSearchGlobalFilter"
+                placeholder="Haku"
+                type="text"
+                value=""
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceCreateForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceCreateForm.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useMutation } from '@apollo/react-hooks';
+import { useTranslation } from 'react-i18next';
+
+import { CREATE_PLACE, CREATE_PLACEVariables as CREATE_PLACE_VARS } from './__generated__/CREATE_PLACE';
+import { CREATE_PLACE_MUTATION } from './mutations';
+import { Place, FormProps } from '../types';
+import PlaceForm from './PlaceForm';
+import { WinterStorageSection } from '../../types';
+import { CreateWinterStoragePlaceMutationInput } from '../../../../@types/__generated__/globalTypes';
+
+interface PlaceCreateFormProps extends Omit<FormProps<Place>, 'initialValues' | 'onDelete'> {
+  sectionOptions: WinterStorageSection[];
+}
+
+const PlaceCreateForm = ({ onCancel, onSubmit, refetchQueries, sectionOptions }: PlaceCreateFormProps) => {
+  const [createWinterStoragePlace, { loading: isSubmitting }] = useMutation<CREATE_PLACE, CREATE_PLACE_VARS>(
+    CREATE_PLACE_MUTATION,
+    {
+      refetchQueries: refetchQueries ?? [],
+    }
+  );
+  const { t } = useTranslation();
+
+  return (
+    <PlaceForm
+      onCancel={onCancel}
+      onSubmitText={t('forms.common.create')}
+      onSubmit={(values) => {
+        const { winterStorageSectionId, number, width, length, isActive } = values;
+        createWinterStoragePlace({
+          variables: {
+            input: {
+              winterStorageSectionId,
+              number,
+              width,
+              length,
+              isActive,
+            } as CreateWinterStoragePlaceMutationInput,
+          },
+        }).then(() => onSubmit?.(values));
+      }}
+      isSubmitting={isSubmitting}
+      sectionOptions={sectionOptions}
+    />
+  );
+};
+
+export default PlaceCreateForm;

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { useMutation, useQuery } from '@apollo/react-hooks';
+import { useTranslation } from 'react-i18next';
+
+import { INDIVIDUAL_PLACE_QUERY } from './queries';
+import LoadingSpinner from '../../../../common/spinner/LoadingSpinner';
+import { INDIVIDUAL_PLACE } from './__generated__/INDIVIDUAL_PLACE';
+import { UPDATE_PLACE, UPDATE_PLACEVariables as UPDATE_PLACE_VARS } from './__generated__/UPDATE_PLACE';
+import { DELETE_PLACE_MUTATION, UPDATE_PLACE_MUTATION } from './mutations';
+import { Place, FormProps } from '../types';
+import { DELETE_PLACE, DELETE_PLACEVariables as DELETE_PLACE_VARS } from './__generated__/DELETE_PLACE';
+import PlaceForm from './PlaceForm';
+import { WinterStorageSection } from '../../types';
+import { getWinterStoragePlace } from '../utils/utils';
+
+interface PlaceEditFormProps extends Omit<FormProps<Place>, 'initialValues' | 'onCreate'> {
+  placeId: string;
+  sectionOptions: WinterStorageSection[];
+}
+
+const PlaceEditForm = ({
+  placeId,
+  onCancel,
+  onSubmit,
+  onDelete,
+  refetchQueries,
+  sectionOptions,
+}: PlaceEditFormProps) => {
+  const { loading, error, data } = useQuery<INDIVIDUAL_PLACE>(INDIVIDUAL_PLACE_QUERY, {
+    variables: { id: placeId },
+    fetchPolicy: 'no-cache',
+  });
+
+  const [updateWinterStoragePlace, { loading: isSubmitting }] = useMutation<UPDATE_PLACE, UPDATE_PLACE_VARS>(
+    UPDATE_PLACE_MUTATION,
+    {
+      refetchQueries: [...(refetchQueries ?? []), { query: INDIVIDUAL_PLACE_QUERY, variables: { id: placeId } }],
+    }
+  );
+
+  const [deleteWinterStoragePlace] = useMutation<DELETE_PLACE, DELETE_PLACE_VARS>(DELETE_PLACE_MUTATION, {
+    refetchQueries: refetchQueries ?? [],
+  });
+
+  const { t } = useTranslation();
+
+  if (loading) return <LoadingSpinner />;
+  if (error) return <div>{t('forms.common.error')}</div>;
+
+  const initialValues = getWinterStoragePlace(data);
+
+  return (
+    <PlaceForm
+      initialValues={initialValues}
+      isEditing={true}
+      onCancel={onCancel}
+      onDelete={(values) =>
+        deleteWinterStoragePlace({ variables: { input: { id: placeId } } }).then(() => onDelete?.(values))
+      }
+      onSubmitText={t('forms.common.update')}
+      onSubmit={(values) => {
+        const { width, length } = values;
+        updateWinterStoragePlace({
+          variables: {
+            input: {
+              id: placeId,
+              width,
+              length,
+            },
+          },
+        }).then(() => onSubmit?.(values));
+      }}
+      isSubmitting={isSubmitting}
+      sectionOptions={sectionOptions}
+    />
+  );
+};
+
+export default PlaceEditForm;

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
@@ -6,63 +6,57 @@ import { TFunction } from 'i18next';
 import { TextInput } from 'hds-react';
 import { ObjectSchema } from 'yup';
 
-import { Berth, FormProps } from '../types';
-import { BerthMooringType } from '../../../../@types/__generated__/globalTypes';
+import { Place, FormProps } from '../types';
 import Grid from '../../../../common/grid/Grid';
 import Select from '../../../../common/select/Select';
-import styles from './berthForm.module.scss';
-import { Pier } from '../../types';
+import styles from './placeForm.module.scss';
+import { WinterStorageSection } from '../../types';
 import FormHeader from '../../../../common/formHeader/FormHeader';
 import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
 import { isNumber, isPositive, replaceCommaWithDot, replaceDotWithComma } from '../../../../common/utils/forms';
 import Checkbox from '../../../../common/checkbox/Checkbox';
 import Button from '../../../../common/button/Button';
 
-interface BerthFormProps extends FormProps<Berth> {
+interface PlaceFormProps extends FormProps<Place> {
   isEditing?: boolean;
   onSubmitText?: string;
-  pierOptions: Pier[];
+  sectionOptions: WinterStorageSection[];
 }
 
-interface BerthFormValues extends Omit<Berth, 'width' | 'length' | 'depth'> {
+interface PlaceFormValues extends Omit<Place, 'width' | 'length'> {
   width?: string;
   length?: string;
-  depth?: string;
 }
 
-const getBerthValidationSchema = (t: TFunction, pierOptions: Pier[]): ObjectSchema => {
+const getPlaceValidationSchema = (t: TFunction, sectionOptions: WinterStorageSection[]): ObjectSchema => {
   return Yup.object().shape({
-    pierId: Yup.string()
-      .oneOf(pierOptions.map((pier) => pier.id))
+    winterStorageSectionId: Yup.string()
+      .oneOf(sectionOptions.map((section) => section.id))
       .required(t('forms.common.errors.required')),
-    number: Yup.string().required(t('forms.common.errors.required')),
-    width: Yup.string()
-      .test('isNumber', t('forms.common.errors.numberType'), (val) => isNumber(val))
-      .test('isPositive', t('forms.common.errors.positive'), (val) => isPositive(val))
-      .required(t('forms.common.errors.required')),
-    length: Yup.string()
-      .test('isNumber', t('forms.common.errors.numberType'), (val) => isNumber(val))
-      .test('isPositive', t('forms.common.errors.positive'), (val) => isPositive(val))
-      .required(t('forms.common.errors.required')),
-    depth: Yup.string()
+    number: Yup.string()
+      .required(t('forms.common.errors.required'))
       .test('isNumber', t('forms.common.errors.numberType'), (val) => isNumber(val))
       .test('isPositive', t('forms.common.errors.positive'), (val) => isPositive(val)),
-    mooringType: Yup.string().oneOf(Object.keys(BerthMooringType)).required(t('forms.common.errors.required')),
+    width: Yup.string()
+      .test('isNumber', t('forms.common.errors.numberType'), (val) => isNumber(val))
+      .test('isPositive', t('forms.common.errors.positive'), (val) => isPositive(val)),
+    length: Yup.string()
+      .test('isNumber', t('forms.common.errors.numberType'), (val) => isNumber(val))
+      .test('isPositive', t('forms.common.errors.positive'), (val) => isPositive(val)),
   });
 };
 
-const transformValues = (values: BerthFormValues): Berth => {
-  const { number, width, length, depth } = values;
+const transformValues = (values: PlaceFormValues): Place => {
+  const { winterStorageSectionId, number, width, length } = values;
   return {
-    ...values,
     number: number,
     width: width ? parseFloat(replaceCommaWithDot(width)) : undefined,
     length: length ? parseFloat(replaceCommaWithDot(length)) : undefined,
-    depth: depth ? parseFloat(replaceCommaWithDot(depth)) : undefined,
+    winterStorageSectionId: winterStorageSectionId,
   };
 };
 
-const BerthForm = ({
+const PlaceForm = ({
   isEditing = false,
   initialValues,
   isSubmitting,
@@ -70,23 +64,20 @@ const BerthForm = ({
   onCancel,
   onDelete,
   onSubmitText,
-  pierOptions,
-}: BerthFormProps) => {
+  sectionOptions,
+}: PlaceFormProps) => {
   const { t } = useTranslation();
-  const validationSchema = getBerthValidationSchema(t, pierOptions);
+  const validationSchema = getPlaceValidationSchema(t, sectionOptions);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
-  const initial: BerthFormValues = initialValues
+  const initial: PlaceFormValues = initialValues
     ? {
         ...initialValues,
         width: initialValues.width ? replaceDotWithComma(String(initialValues.width)) : '',
         length: initialValues.length ? replaceDotWithComma(String(initialValues.length)) : '',
-        depth: initialValues.depth ? replaceDotWithComma(String(initialValues.depth)) : '',
       }
     : {
-        pierId: pierOptions[0].id,
-        mooringType: BerthMooringType.DINGHY_PLACE,
-        comment: '',
+        winterStorageSectionId: sectionOptions[0].id,
         isActive: true,
       };
 
@@ -101,23 +92,23 @@ const BerthForm = ({
       {({ values, errors, handleChange, handleSubmit }) => (
         <form onSubmit={handleSubmit} className={styles.form}>
           <FormHeader
-            title={t('forms.berth.title')}
+            title={t('forms.winterStoragePlace.title')}
             isSubmitting={isSubmitting}
             onDelete={onDelete ? () => setIsDeleteModalOpen(true) : undefined}
-            onDeleteText={t('forms.berth.delete')}
+            onDeleteText={t('forms.winterStoragePlace.delete')}
           />
           <Grid colsCount={3} className={styles.grid}>
             <Select
-              id="pierId"
-              value={values.pierId}
-              options={pierOptions.map((pier) => {
+              id="winterStorageSectionId"
+              value={values.winterStorageSectionId}
+              options={sectionOptions.map((section) => {
                 return {
-                  label: pier.identifier,
-                  value: pier.id,
+                  label: section.identifier,
+                  value: section.id,
                 };
               })}
               onChange={handleChange}
-              label={t('forms.berth.pier')}
+              label={t('forms.winterStoragePlace.section')}
               required
               disabled={isEditing}
             />
@@ -125,7 +116,7 @@ const BerthForm = ({
               id="number"
               value={values.number ? String(values.number) : ''}
               onChange={handleChange}
-              label={t('forms.berth.number')}
+              label={t('forms.winterStoragePlace.number')}
               invalid={!!errors.number}
               helperText={errors.number}
               disabled={isEditing}
@@ -135,7 +126,7 @@ const BerthForm = ({
               id="width"
               value={values.width ? String(values.width) : ''}
               onChange={handleChange}
-              label={t('forms.berth.width')}
+              label={t('forms.winterStoragePlace.width')}
               invalid={!!errors.width}
               helperText={errors.width}
             />
@@ -143,37 +134,18 @@ const BerthForm = ({
               id="length"
               value={values.length ? String(values.length) : ''}
               onChange={handleChange}
-              label={t('forms.berth.length')}
+              label={t('forms.winterStoragePlace.length')}
               invalid={!!errors.length}
               helperText={errors.length}
             />
-            <TextInput
-              id="depth"
-              onChange={handleChange}
-              value={values.depth ? String(values.number) : ''}
-              label={t('forms.berth.depth')}
-              invalid={!!errors.depth}
-              helperText={errors.depth}
-            />
           </Grid>
-
           <hr />
-
-          <Select
-            id="mooringType"
-            value={values.mooringType}
-            label={t('forms.berth.mooringType')}
-            options={Object.keys(BerthMooringType).map((mooringType) => {
-              return {
-                label: t([`common.mooringTypes.${mooringType}`, mooringType]),
-                value: mooringType,
-              };
-            })}
+          <Checkbox
+            id="isActive"
             onChange={handleChange}
-            required
+            checked={values.isActive}
+            label={t('forms.winterStoragePlace.isActive')}
           />
-          <TextInput id="comment" onChange={handleChange} value={values.comment} label={t('forms.berth.comment')} />
-          <Checkbox id="isActive" onChange={handleChange} checked={values.isActive} label={t('forms.berth.isActive')} />
           <div className={styles.formActionButtons}>
             <Button variant="secondary" disabled={isSubmitting} color={'supplementary'} onClick={onCancel}>
               {t('forms.common.cancel')}
@@ -185,14 +157,14 @@ const BerthForm = ({
 
           <ConfirmationModal
             isOpen={isDeleteModalOpen}
-            title={t('forms.berth.title')}
-            infoText={t('forms.berth.deleteConfirmation.infoText', {
-              pier: values.pier,
-              berthNumber: values.number,
+            title={t('forms.winterStoragePlace.title')}
+            infoText={t('forms.winterStoragePlace.deleteConfirmation.infoText', {
+              section: values.winterStorageSection,
+              placeNumber: values.number,
             })}
             onCancelText={t('forms.common.cancel')}
-            onConfirmText={t('forms.berth.delete')}
-            warningText={t('forms.berth.deleteConfirmation.warningText')}
+            onConfirmText={t('forms.winterStoragePlace.delete')}
+            warningText={t('forms.winterStoragePlace.deleteConfirmation.warningText')}
             onCancel={() => setIsDeleteModalOpen(false)}
             onConfirm={() => onDelete?.(transformValues(values))}
             className={styles.confirmationModal}
@@ -203,4 +175,4 @@ const BerthForm = ({
   );
 };
 
-export default BerthForm;
+export default PlaceForm;

--- a/src/features/winterStorageAreaView/forms/placeForm/__generated__/CREATE_PLACE.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/__generated__/CREATE_PLACE.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateWinterStoragePlaceMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: CREATE_PLACE
+// ====================================================
+
+export interface CREATE_PLACE_createWinterStoragePlace {
+  __typename: "CreateWinterStoragePlaceMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface CREATE_PLACE {
+  createWinterStoragePlace: CREATE_PLACE_createWinterStoragePlace | null;
+}
+
+export interface CREATE_PLACEVariables {
+  input: CreateWinterStoragePlaceMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/placeForm/__generated__/DELETE_PLACE.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/__generated__/DELETE_PLACE.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { DeleteWinterStoragePlaceMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: DELETE_PLACE
+// ====================================================
+
+export interface DELETE_PLACE_deleteWinterStoragePlace {
+  __typename: "DeleteWinterStoragePlaceMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface DELETE_PLACE {
+  deleteWinterStoragePlace: DELETE_PLACE_deleteWinterStoragePlace | null;
+}
+
+export interface DELETE_PLACEVariables {
+  input: DeleteWinterStoragePlaceMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/placeForm/__generated__/INDIVIDUAL_PLACE.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/__generated__/INDIVIDUAL_PLACE.ts
@@ -1,0 +1,37 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: INDIVIDUAL_PLACE
+// ====================================================
+
+export interface INDIVIDUAL_PLACE_winterStoragePlace_winterStorageSection_properties {
+  __typename: "WinterStorageSectionProperties";
+  identifier: string;
+}
+
+export interface INDIVIDUAL_PLACE_winterStoragePlace_winterStorageSection {
+  __typename: "WinterStorageSectionNode";
+  id: string;
+  properties: INDIVIDUAL_PLACE_winterStoragePlace_winterStorageSection_properties | null;
+}
+
+export interface INDIVIDUAL_PLACE_winterStoragePlace {
+  __typename: "WinterStoragePlaceNode";
+  id: string;
+  number: number;
+  isActive: boolean;
+  winterStorageSection: INDIVIDUAL_PLACE_winterStoragePlace_winterStorageSection;
+  width: number;
+  length: number;
+}
+
+export interface INDIVIDUAL_PLACE {
+  winterStoragePlace: INDIVIDUAL_PLACE_winterStoragePlace | null;
+}
+
+export interface INDIVIDUAL_PLACEVariables {
+  id: string;
+}

--- a/src/features/winterStorageAreaView/forms/placeForm/__generated__/UPDATE_PLACE.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/__generated__/UPDATE_PLACE.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateWinterStoragePlaceMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UPDATE_PLACE
+// ====================================================
+
+export interface UPDATE_PLACE_updateWinterStoragePlace {
+  __typename: "UpdateWinterStoragePlaceMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface UPDATE_PLACE {
+  updateWinterStoragePlace: UPDATE_PLACE_updateWinterStoragePlace | null;
+}
+
+export interface UPDATE_PLACEVariables {
+  input: UpdateWinterStoragePlaceMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceEditForm.test.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceEditForm.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+import { MockedProvider } from '@apollo/react-testing';
+import waitForExpect from 'wait-for-expect';
+import { act } from 'react-dom/test-utils';
+
+import PlaceEditForm from '../PlaceEditForm';
+import { INDIVIDUAL_PLACE_QUERY } from '../queries';
+import { UPDATE_PLACE_MUTATION } from '../mutations';
+import LoadingSpinner from '../../../../../common/spinner/LoadingSpinner';
+import { WinterStorageSection } from '../../../types';
+
+const sectionOptions: WinterStorageSection[] = [
+  {
+    id: 'a',
+    identifier: 'A',
+  },
+];
+const queryMock = {
+  request: { query: INDIVIDUAL_PLACE_QUERY, variables: { id: 'a' } },
+  result: {
+    data: {
+      winterStoragePlace: {
+        __typename: 'WinterStoragePlaceNode',
+        id: 'MOCK-PLACE',
+        number: '2',
+        isActive: true,
+        winterStorageSection: {
+          __typename: 'WinterStorageSectionNode',
+          id: sectionOptions[0].id,
+          properties: {
+            __typename: 'WinterStorageSectionProperties',
+            identifier: sectionOptions[0].identifier,
+          },
+        },
+        width: 2.25,
+        length: 5,
+      },
+    },
+  },
+};
+
+describe('features/winterStorageAreaView/PlaceEditForm', () => {
+  const waitForContent = async (wrapper: ReactWrapper) => {
+    await act(async () => {
+      await waitForExpect(() => {
+        wrapper.update();
+        expect(wrapper.contains(<LoadingSpinner />)).toBeFalsy();
+      });
+    });
+  };
+
+  it('initially renders loading spinner', () => {
+    const wrapper = mount(
+      <MockedProvider mocks={[queryMock]}>
+        <PlaceEditForm placeId="a" sectionOptions={sectionOptions} />
+      </MockedProvider>
+    );
+    expect(wrapper.contains(<LoadingSpinner />)).toBeTruthy();
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('renders content after loading', async () => {
+    const wrapper = mount(
+      <MockedProvider mocks={[queryMock]}>
+        <PlaceEditForm placeId="a" sectionOptions={sectionOptions} />
+      </MockedProvider>
+    );
+    await waitForContent(wrapper);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+
+  it('calls update mutation on save', async () => {
+    let updateMockCalled = false;
+    const onUpdateMock = jest.fn();
+    const updateMock = {
+      request: {
+        query: UPDATE_PLACE_MUTATION,
+        variables: {
+          input: {
+            id: 'a',
+            width: 2.25,
+            length: 5,
+          },
+        },
+      },
+      result: () => {
+        updateMockCalled = true;
+        return {
+          data: { updateWinterStoragePlace: { clientMutationId: '-', __typename: 'ID' } },
+        };
+      },
+    };
+    const wrapper = mount(
+      // We need queryMock twice here, because MockedProvider requires an
+      // instance for each query made and the original query is refetched after updates.
+      <MockedProvider mocks={[queryMock, queryMock, updateMock]}>
+        <PlaceEditForm placeId="a" onSubmit={onUpdateMock} sectionOptions={sectionOptions} />
+      </MockedProvider>
+    );
+    await waitForContent(wrapper);
+    await act(async () => {
+      wrapper.find('form').simulate('submit');
+      await waitForExpect(() => {
+        wrapper.update();
+        expect(onUpdateMock).toBeCalledTimes(1);
+        expect(updateMockCalled).toBe(true);
+      });
+    });
+  });
+});

--- a/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceForm.test.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceForm.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import PlaceForm from '../PlaceForm';
+import { WinterStorageSection } from '../../../types';
+
+const sectionOptions = [{ id: 'a', identifier: 'A' }] as WinterStorageSection[];
+const validValues = {
+  numer: 0,
+  isActive: true,
+  width: 3,
+  length: 3,
+  winterStorageSection: sectionOptions[0].identifier,
+  winterStorageSectionId: sectionOptions[0].id,
+};
+
+describe('features/winterStorageAreaView/PlaceForm', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(<PlaceForm initialValues={validValues} sectionOptions={sectionOptions} />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/src/features/winterStorageAreaView/forms/placeForm/__tests__/__snapshots__/PlaceEditForm.test.tsx.snap
+++ b/src/features/winterStorageAreaView/forms/placeForm/__tests__/__snapshots__/PlaceEditForm.test.tsx.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/harborView/BerthForm renders correctly 1`] = `
+exports[`features/winterStorageAreaView/PlaceEditForm initially renders loading spinner 1`] = `
+<div
+  class="spinnerWrapper"
+>
+  <div
+    class="LoadingSpinner-module_loadingSpinner__2xHT_"
+  >
+    <div />
+    <div />
+    <div />
+  </div>
+</div>
+`;
+
+exports[`features/winterStorageAreaView/PlaceEditForm renders content after loading 1`] = `
 <form
   class="form"
 >
@@ -10,21 +24,30 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
     <h4
       class="text brand h4"
     >
-      Venepaikka
+      Paikka
     </h4>
+    <button
+      type="button"
+    >
+      <span
+        class="text critical span"
+      >
+        Poista talvisäilytypaikka
+      </span>
+    </button>
   </div>
   <div
     class="grid cols3 grid"
   >
     <div
-      class="Select-module_root__Ka5uO"
+      class="Select-module_root__Ka5uO Select-module_disabled__3MKDP"
     >
       <label
         class="FieldLabel-module_label__1zrXK "
-        for="pierId-toggle-button"
-        id="pierId-label"
+        for="winterStorageSectionId-toggle-button"
+        id="winterStorageSectionId-label"
       >
-        Laituri
+        Osasto
         <span
           class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
         >
@@ -37,10 +60,11 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
         <button
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="pierId-label pierId-toggle-button"
-          aria-owns="pierId-menu"
+          aria-labelledby="winterStorageSectionId-label winterStorageSectionId-toggle-button"
+          aria-owns="winterStorageSectionId-menu"
           class="Select-module_button__1aIsm"
-          id="pierId-toggle-button"
+          disabled=""
+          id="winterStorageSectionId-toggle-button"
           type="button"
         >
           <span
@@ -70,10 +94,10 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
           </svg>
         </button>
         <ul
-          aria-labelledby="pierId-label"
+          aria-labelledby="winterStorageSectionId-label"
           aria-required="true"
           class="Select-module_menu__1H2aU"
-          id="pierId-menu"
+          id="winterStorageSectionId-menu"
           role="listbox"
           style="max-height: 260px;"
           tabindex="-1"
@@ -87,16 +111,17 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
         class="FieldLabel-module_label__1zrXK "
         for="number"
       >
-        Paikka
+        Numero
       </label>
       <div
         class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
       >
         <input
           class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+          disabled=""
           id="number"
           type="text"
-          value=""
+          value="2"
         />
       </div>
     </div>
@@ -117,7 +142,7 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
           class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
           id="width"
           type="text"
-          value="3"
+          value="2,25"
         />
       </div>
     </div>
@@ -137,116 +162,12 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
           class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
           id="length"
           type="text"
-          value="3"
-        />
-      </div>
-    </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="depth"
-      >
-        Syvyys (m)
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="depth"
-          type="text"
-          value="undefined"
+          value="5"
         />
       </div>
     </div>
   </div>
   <hr />
-  <div
-    class="Select-module_root__Ka5uO"
-  >
-    <label
-      class="FieldLabel-module_label__1zrXK "
-      for="mooringType-toggle-button"
-      id="mooringType-label"
-    >
-      Kiinnitystapa
-      <span
-        class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-      >
-         *
-      </span>
-    </label>
-    <div
-      class="Select-module_wrapper__1WQXs"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="mooringType-label mooringType-toggle-button"
-        aria-owns="mooringType-menu"
-        class="Select-module_button__1aIsm"
-        id="mooringType-toggle-button"
-        type="button"
-      >
-        <span
-          class="Select-module_buttonLabel__1fqu5"
-        >
-          Jollapaikka
-        </span>
-        <svg
-          aria-hidden="true"
-          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fill-rule="evenodd"
-          >
-            <path
-              d="M0 0h24v24H0z"
-            />
-            <path
-              d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </button>
-      <ul
-        aria-labelledby="mooringType-label"
-        aria-required="true"
-        class="Select-module_menu__1H2aU Select-module_overflow__EZdsW"
-        id="mooringType-menu"
-        role="listbox"
-        style="max-height: 260px;"
-        tabindex="-1"
-      />
-    </div>
-  </div>
-  <div
-    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-  >
-    <label
-      class="FieldLabel-module_label__1zrXK "
-      for="comment"
-    >
-      Huomiot
-    </label>
-    <div
-      class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-    >
-      <input
-        class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-        id="comment"
-        type="text"
-        value=""
-      />
-    </div>
-  </div>
   <div
     class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
   >
@@ -284,7 +205,9 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
     >
       <span
         class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
-      />
+      >
+        Tallenna
+      </span>
     </button>
   </div>
 </form>

--- a/src/features/winterStorageAreaView/forms/placeForm/__tests__/__snapshots__/PlaceForm.test.tsx.snap
+++ b/src/features/winterStorageAreaView/forms/placeForm/__tests__/__snapshots__/PlaceForm.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`features/harborView/BerthForm renders correctly 1`] = `
+exports[`features/winterStorageAreaView/PlaceForm renders correctly 1`] = `
 <form
   class="form"
 >
@@ -10,7 +10,7 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
     <h4
       class="text brand h4"
     >
-      Venepaikka
+      Paikka
     </h4>
   </div>
   <div
@@ -21,10 +21,10 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
     >
       <label
         class="FieldLabel-module_label__1zrXK "
-        for="pierId-toggle-button"
-        id="pierId-label"
+        for="winterStorageSectionId-toggle-button"
+        id="winterStorageSectionId-label"
       >
-        Laituri
+        Osasto
         <span
           class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
         >
@@ -37,10 +37,10 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
         <button
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="pierId-label pierId-toggle-button"
-          aria-owns="pierId-menu"
+          aria-labelledby="winterStorageSectionId-label winterStorageSectionId-toggle-button"
+          aria-owns="winterStorageSectionId-menu"
           class="Select-module_button__1aIsm"
-          id="pierId-toggle-button"
+          id="winterStorageSectionId-toggle-button"
           type="button"
         >
           <span
@@ -70,10 +70,10 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
           </svg>
         </button>
         <ul
-          aria-labelledby="pierId-label"
+          aria-labelledby="winterStorageSectionId-label"
           aria-required="true"
           class="Select-module_menu__1H2aU"
-          id="pierId-menu"
+          id="winterStorageSectionId-menu"
           role="listbox"
           style="max-height: 260px;"
           tabindex="-1"
@@ -87,7 +87,7 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
         class="FieldLabel-module_label__1zrXK "
         for="number"
       >
-        Paikka
+        Numero
       </label>
       <div
         class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
@@ -141,112 +141,8 @@ exports[`features/harborView/BerthForm renders correctly 1`] = `
         />
       </div>
     </div>
-    <div
-      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-    >
-      <label
-        class="FieldLabel-module_label__1zrXK "
-        for="depth"
-      >
-        Syvyys (m)
-      </label>
-      <div
-        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-      >
-        <input
-          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-          id="depth"
-          type="text"
-          value="undefined"
-        />
-      </div>
-    </div>
   </div>
   <hr />
-  <div
-    class="Select-module_root__Ka5uO"
-  >
-    <label
-      class="FieldLabel-module_label__1zrXK "
-      for="mooringType-toggle-button"
-      id="mooringType-label"
-    >
-      Kiinnitystapa
-      <span
-        class="RequiredIndicator-module_indicator__Pt7GX text-input_hds-text-input__required__2K-Bs"
-      >
-         *
-      </span>
-    </label>
-    <div
-      class="Select-module_wrapper__1WQXs"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-labelledby="mooringType-label mooringType-toggle-button"
-        aria-owns="mooringType-menu"
-        class="Select-module_button__1aIsm"
-        id="mooringType-toggle-button"
-        type="button"
-      >
-        <span
-          class="Select-module_buttonLabel__1fqu5"
-        >
-          Jollapaikka
-        </span>
-        <svg
-          aria-hidden="true"
-          class="Icon-module_icon__1Jtzj icon_hds-icon__1YqNC Icon-module_s__2WGWe icon_hds-icon--size-s__2Lkik Select-module_angleIcon__2-9AD"
-          role="img"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <g
-            fill="none"
-            fill-rule="evenodd"
-          >
-            <path
-              d="M0 0h24v24H0z"
-            />
-            <path
-              d="M12 13.5l5-5 1.5 1.5-6.5 6.5L5.5 10 7 8.5z"
-              fill="currentColor"
-            />
-          </g>
-        </svg>
-      </button>
-      <ul
-        aria-labelledby="mooringType-label"
-        aria-required="true"
-        class="Select-module_menu__1H2aU Select-module_overflow__EZdsW"
-        id="mooringType-menu"
-        role="listbox"
-        style="max-height: 260px;"
-        tabindex="-1"
-      />
-    </div>
-  </div>
-  <div
-    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
-  >
-    <label
-      class="FieldLabel-module_label__1zrXK "
-      for="comment"
-    >
-      Huomiot
-    </label>
-    <div
-      class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
-    >
-      <input
-        class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
-        id="comment"
-        type="text"
-        value=""
-      />
-    </div>
-  </div>
   <div
     class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
   >

--- a/src/features/winterStorageAreaView/forms/placeForm/mutations.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/mutations.ts
@@ -1,0 +1,25 @@
+import gql from 'graphql-tag';
+
+export const UPDATE_PLACE_MUTATION = gql`
+  mutation UPDATE_PLACE($input: UpdateWinterStoragePlaceMutationInput!) {
+    updateWinterStoragePlace(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const DELETE_PLACE_MUTATION = gql`
+  mutation DELETE_PLACE($input: DeleteWinterStoragePlaceMutationInput!) {
+    deleteWinterStoragePlace(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const CREATE_PLACE_MUTATION = gql`
+  mutation CREATE_PLACE($input: CreateWinterStoragePlaceMutationInput!) {
+    createWinterStoragePlace(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/features/winterStorageAreaView/forms/placeForm/placeForm.module.scss
+++ b/src/features/winterStorageAreaView/forms/placeForm/placeForm.module.scss
@@ -1,0 +1,1 @@
+@import 'form';

--- a/src/features/winterStorageAreaView/forms/placeForm/queries.ts
+++ b/src/features/winterStorageAreaView/forms/placeForm/queries.ts
@@ -1,0 +1,19 @@
+import gql from 'graphql-tag';
+
+export const INDIVIDUAL_PLACE_QUERY = gql`
+  query INDIVIDUAL_PLACE($id: ID!) {
+    winterStoragePlace(id: $id) {
+      id
+      number
+      isActive
+      winterStorageSection {
+        id
+        properties {
+          identifier
+        }
+      }
+      width
+      length
+    }
+  }
+`;

--- a/src/features/winterStorageAreaView/forms/sectionForm/SectionCreateForm.tsx
+++ b/src/features/winterStorageAreaView/forms/sectionForm/SectionCreateForm.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMutation } from '@apollo/react-hooks';
+
+import { FormProps, Section } from '../types';
+import SectionForm from './SectionForm';
+import { CREATE_SECTION_MUTATION } from './mutations';
+import { CREATE_SECTION, CREATE_SECTIONVariables as CREATE_SECTION_VARS } from './__generated__/CREATE_SECTION';
+
+interface Props extends Omit<FormProps<Section>, 'initialValues' | 'isSubmitting' | 'onDelete'> {
+  winterStorageAreaId: string;
+}
+
+const SectionCreateForm = ({ winterStorageAreaId, onCancel, onSubmit, refetchQueries }: Props) => {
+  const [createSection, { loading: isSubmitting, error: createError }] = useMutation<
+    CREATE_SECTION,
+    CREATE_SECTION_VARS
+  >(CREATE_SECTION_MUTATION, {
+    refetchQueries: refetchQueries ?? [],
+  });
+  const { t } = useTranslation();
+
+  if (createError) return <div>{t('forms.common.error')}</div>;
+
+  return (
+    <SectionForm
+      onSubmitText={t('forms.common.create')}
+      onCancel={onCancel}
+      onSubmit={(values: Section) =>
+        createSection({ variables: { input: { ...values, areaId: winterStorageAreaId } } }).then(() =>
+          onSubmit?.(values)
+        )
+      }
+      isSubmitting={isSubmitting}
+    />
+  );
+};
+
+export default SectionCreateForm;

--- a/src/features/winterStorageAreaView/forms/sectionForm/SectionEditForm.tsx
+++ b/src/features/winterStorageAreaView/forms/sectionForm/SectionEditForm.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMutation, useQuery } from '@apollo/react-hooks';
+
+import { FormProps, Section } from '../types';
+import SectionForm from './SectionForm';
+import { DELETE_SECTION_MUTATION, UPDATE_SECTION_MUTATION } from './mutations';
+import { UPDATE_SECTION, UPDATE_SECTIONVariables as UPDATE_SECTION_VARS } from './__generated__/UPDATE_SECTION';
+import { SECTION_QUERY } from './queries';
+import LoadingSpinner from '../../../../common/spinner/LoadingSpinner';
+import { getSection } from './utils/utils';
+import { SECTION } from './__generated__/SECTION';
+import { DELETE_SECTION, DELETE_SECTIONVariables as DELETE_SECTION_VARS } from './__generated__/DELETE_SECTION';
+
+interface Props extends Omit<FormProps<Section>, 'initialValues' | 'isSubmitting'> {
+  winterStorageSectionId: string;
+}
+
+const SectionEditForm = ({ winterStorageSectionId, onCancel, onSubmit, onDelete, refetchQueries }: Props) => {
+  const { loading, error, data } = useQuery<SECTION>(SECTION_QUERY, {
+    variables: { id: winterStorageSectionId },
+  });
+  const [updateSection, { loading: isSubmitting, error: updateError }] = useMutation<
+    UPDATE_SECTION,
+    UPDATE_SECTION_VARS
+  >(UPDATE_SECTION_MUTATION, {
+    refetchQueries: [...(refetchQueries ?? []), { query: SECTION_QUERY, variables: { id: winterStorageSectionId } }],
+  });
+  const [deleteSection, { error: deleteError }] = useMutation<DELETE_SECTION, DELETE_SECTION_VARS>(
+    DELETE_SECTION_MUTATION,
+    {
+      refetchQueries: refetchQueries ?? [],
+    }
+  );
+  const { t } = useTranslation();
+
+  if (loading) return <LoadingSpinner />;
+  if (error || updateError || deleteError) return <div>{t('forms.common.error')}</div>;
+
+  const initialValues = getSection(data);
+
+  return (
+    <SectionForm
+      initialValues={initialValues}
+      onSubmitText={t('forms.common.update')}
+      onCancel={onCancel}
+      onSubmit={(values) =>
+        updateSection({
+          variables: { input: { id: winterStorageSectionId, ...values } },
+        }).then(() => onSubmit?.(values))
+      }
+      onDelete={(values) =>
+        deleteSection({ variables: { input: { id: winterStorageSectionId } } }).then(() => onDelete?.(values))
+      }
+      isSubmitting={isSubmitting}
+    />
+  );
+};
+
+export default SectionEditForm;

--- a/src/features/winterStorageAreaView/forms/sectionForm/SectionForm.tsx
+++ b/src/features/winterStorageAreaView/forms/sectionForm/SectionForm.tsx
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import * as Yup from 'yup';
+import { Formik } from 'formik';
+import { TFunction } from 'i18next';
+import { ObjectSchema } from 'yup';
+import { useTranslation } from 'react-i18next';
+import { TextInput } from 'hds-react';
+
+import Text from '../../../../common/text/Text';
+import styles from './sectionForm.module.scss';
+import { FormProps, Section } from '../types';
+import Grid from '../../../../common/grid/Grid';
+import FormHeader from '../../../../common/formHeader/FormHeader';
+import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
+import Checkbox from '../../../../common/checkbox/Checkbox';
+import Button from '../../../../common/button/Button';
+
+interface SectionFormProps extends FormProps<Section> {
+  onSubmitText?: string;
+}
+
+const getSectionValidationSchema = (t: TFunction): ObjectSchema => {
+  return Yup.object().shape({
+    identifier: Yup.string().required(t('forms.common.errors.required')),
+    electricity: Yup.boolean(),
+    water: Yup.boolean(),
+    gate: Yup.boolean(),
+    summerStorageForBoats: Yup.boolean(),
+    summerStorageForDockingEquipment: Yup.boolean(),
+    summerStorageForTrailers: Yup.boolean(),
+  });
+};
+
+const SectionForm = ({ onSubmit, onDelete, onCancel, onSubmitText, isSubmitting, initialValues }: SectionFormProps) => {
+  const { t } = useTranslation();
+  const validationSchema = getSectionValidationSchema(t);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const initial: Section = {
+    identifier: '',
+    electricity: false,
+    gate: false,
+    water: false,
+    summerStorageForBoats: false,
+    summerStorageForDockingEquipment: false,
+    summerStorageForTrailers: false,
+    ...initialValues,
+  };
+
+  return (
+    <Formik
+      initialValues={initial}
+      onSubmit={(values) => onSubmit?.(values)}
+      validateOnBlur={false}
+      validateOnChange={false}
+      validationSchema={validationSchema}
+    >
+      {({ values, errors, handleChange, handleSubmit, setFieldValue }) => (
+        <form onSubmit={handleSubmit} className={styles.form}>
+          <FormHeader
+            title={t('forms.winterStorageSection.title')}
+            isSubmitting={isSubmitting}
+            onDelete={onDelete ? () => setIsDeleteModalOpen(true) : undefined}
+            onDeleteText={t('forms.winterStorageSection.delete')}
+          />
+
+          <TextInput
+            id="identifier"
+            type="text"
+            value={values.identifier}
+            onChange={handleChange}
+            label={t('forms.winterStorageSection.identifier')}
+            invalid={!!errors.identifier}
+            helperText={errors.identifier}
+          />
+
+          <Grid colsCount={2}>
+            <div className={styles.checkboxes}>
+              <Text weight="bold" size="s">
+                {t('forms.winterStorageSection.services')}
+              </Text>
+              {[
+                'gate',
+                'electricity',
+                'water',
+                'summerStorageForBoats',
+                'summerStorageForDockingEquipment',
+                'summerStorageForTrailers',
+              ].map((keyForCheckbox, id) => (
+                <Checkbox
+                  key={id}
+                  id={keyForCheckbox}
+                  onChange={handleChange}
+                  checked={values[keyForCheckbox as keyof Section] as boolean}
+                  label={t(`forms.winterStorageSection.${keyForCheckbox}`)}
+                />
+              ))}
+            </div>
+          </Grid>
+          <div className={styles.formActionButtons}>
+            <Button variant="secondary" disabled={isSubmitting} onClick={onCancel}>
+              {t('forms.common.cancel')}
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {onSubmitText}
+            </Button>
+          </div>
+
+          <ConfirmationModal
+            isOpen={isDeleteModalOpen}
+            title={t('forms.winterStorageSection.title')}
+            infoText={t('forms.winterStorageSection.deleteConfirmation.infoText', {
+              sectionIdentifier: values.identifier,
+            })}
+            onCancelText={t('forms.common.cancel')}
+            onConfirmText={t('forms.winterStorageSection.delete')}
+            warningText={t('forms.winterStorageSection.deleteConfirmation.warningText')}
+            onCancel={() => setIsDeleteModalOpen(false)}
+            onConfirm={() => onDelete?.(values)}
+            className={styles.confirmationModal}
+          />
+        </form>
+      )}
+    </Formik>
+  );
+};
+
+export default SectionForm;

--- a/src/features/winterStorageAreaView/forms/sectionForm/__generated__/CREATE_SECTION.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__generated__/CREATE_SECTION.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CreateWinterStorageSectionMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: CREATE_SECTION
+// ====================================================
+
+export interface CREATE_SECTION_createWinterStorageSection {
+  __typename: "CreateWinterStorageSectionMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface CREATE_SECTION {
+  createWinterStorageSection: CREATE_SECTION_createWinterStorageSection | null;
+}
+
+export interface CREATE_SECTIONVariables {
+  input: CreateWinterStorageSectionMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/sectionForm/__generated__/DELETE_SECTION.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__generated__/DELETE_SECTION.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { DeleteWinterStorageSectionMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: DELETE_SECTION
+// ====================================================
+
+export interface DELETE_SECTION_deleteWinterStorageSection {
+  __typename: "DeleteWinterStorageSectionMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface DELETE_SECTION {
+  deleteWinterStorageSection: DELETE_SECTION_deleteWinterStorageSection | null;
+}
+
+export interface DELETE_SECTIONVariables {
+  input: DeleteWinterStorageSectionMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/sectionForm/__generated__/SECTION.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__generated__/SECTION.ts
@@ -1,0 +1,32 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SECTION
+// ====================================================
+
+export interface SECTION_winterStorageSection_properties {
+  __typename: "WinterStorageSectionProperties";
+  identifier: string;
+  electricity: boolean;
+  gate: boolean;
+  water: boolean;
+  summerStorageForBoats: boolean;
+  summerStorageForDockingEquipment: boolean;
+  summerStorageForTrailers: boolean;
+}
+
+export interface SECTION_winterStorageSection {
+  __typename: "WinterStorageSectionNode";
+  properties: SECTION_winterStorageSection_properties | null;
+}
+
+export interface SECTION {
+  winterStorageSection: SECTION_winterStorageSection | null;
+}
+
+export interface SECTIONVariables {
+  id: string;
+}

--- a/src/features/winterStorageAreaView/forms/sectionForm/__generated__/UPDATE_SECTION.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__generated__/UPDATE_SECTION.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { UpdateWinterStorageSectionMutationInput } from "./../../../../../@types/__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UPDATE_SECTION
+// ====================================================
+
+export interface UPDATE_SECTION_updateWinterStorageSection {
+  __typename: "UpdateWinterStorageSectionMutationPayload";
+  clientMutationId: string | null;
+}
+
+export interface UPDATE_SECTION {
+  updateWinterStorageSection: UPDATE_SECTION_updateWinterStorageSection | null;
+}
+
+export interface UPDATE_SECTIONVariables {
+  input: UpdateWinterStorageSectionMutationInput;
+}

--- a/src/features/winterStorageAreaView/forms/sectionForm/__tests__/SectionForm.test.tsx
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__tests__/SectionForm.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SectionForm from '../SectionForm';
+
+describe('features/winterStorageAreaView/SectionForm', () => {
+  it('renders correctly', () => {
+    const wrapper = mount(<SectionForm initialValues={{}} onSubmitText="Luo" />);
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/src/features/winterStorageAreaView/forms/sectionForm/__tests__/__snapshots__/SectionForm.test.tsx.snap
+++ b/src/features/winterStorageAreaView/forms/sectionForm/__tests__/__snapshots__/SectionForm.test.tsx.snap
@@ -1,0 +1,170 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`features/winterStorageAreaView/SectionForm renders correctly 1`] = `
+<form
+  class="form"
+>
+  <div
+    class="heading"
+  >
+    <h4
+      class="text brand h4"
+    >
+      Osasto
+    </h4>
+  </div>
+  <div
+    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq"
+  >
+    <label
+      class="FieldLabel-module_label__1zrXK "
+      for="identifier"
+    >
+      Osasto
+    </label>
+    <div
+      class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+    >
+      <input
+        class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+        id="identifier"
+        type="text"
+        value=""
+      />
+    </div>
+  </div>
+  <div
+    class="grid cols2"
+  >
+    <div
+      class="checkboxes"
+    >
+      <span
+        class="text standard span s bold"
+      >
+        Palvelut
+      </span>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="gate"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="gate"
+        >
+          Portti
+        </label>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="electricity"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="electricity"
+        >
+          Sähkö
+        </label>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="water"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="water"
+        >
+          Vesi
+        </label>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="summerStorageForBoats"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="summerStorageForBoats"
+        >
+          Veneiden kesäsäilytys
+        </label>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="summerStorageForDockingEquipment"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="summerStorageForDockingEquipment"
+        >
+          Telakointi­tarvikkeiden kesäsäilytys
+        </label>
+      </div>
+      <div
+        class="Checkbox-module_checkbox__3L0GR checkbox_hds-checkbox__9HMCz checkbox"
+      >
+        <input
+          class="Checkbox-module_input__3VZvy checkbox_hds-checkbox__input__1w0pu"
+          id="summerStorageForTrailers"
+          type="checkbox"
+          value=""
+        />
+        <label
+          class="Checkbox-module_label__L5AN1 checkbox_hds-checkbox__label__3HoD3"
+          for="summerStorageForTrailers"
+        >
+          Trailerin kesäsäilytys
+        </label>
+      </div>
+    </div>
+  </div>
+  <div
+    class="formActionButtons"
+  >
+    <button
+      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0"
+      type="button"
+    >
+      <span
+        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      >
+        Peruuta
+      </span>
+    </button>
+    <button
+      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_primary__2LfKB button_hds-button--primary__2NVvO Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0"
+      type="submit"
+    >
+      <span
+        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      >
+        Luo
+      </span>
+    </button>
+  </div>
+</form>
+`;

--- a/src/features/winterStorageAreaView/forms/sectionForm/mutations.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/mutations.ts
@@ -1,0 +1,25 @@
+import gql from 'graphql-tag';
+
+export const CREATE_SECTION_MUTATION = gql`
+  mutation CREATE_SECTION($input: CreateWinterStorageSectionMutationInput!) {
+    createWinterStorageSection(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const UPDATE_SECTION_MUTATION = gql`
+  mutation UPDATE_SECTION($input: UpdateWinterStorageSectionMutationInput!) {
+    updateWinterStorageSection(input: $input) {
+      clientMutationId
+    }
+  }
+`;
+
+export const DELETE_SECTION_MUTATION = gql`
+  mutation DELETE_SECTION($input: DeleteWinterStorageSectionMutationInput!) {
+    deleteWinterStorageSection(input: $input) {
+      clientMutationId
+    }
+  }
+`;

--- a/src/features/winterStorageAreaView/forms/sectionForm/queries.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/queries.ts
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+
+export const SECTION_QUERY = gql`
+  query SECTION($id: ID!) {
+    winterStorageSection(id: $id) {
+      properties {
+        identifier
+        electricity
+        gate
+        water
+        summerStorageForBoats
+        summerStorageForDockingEquipment
+        summerStorageForTrailers
+      }
+    }
+  }
+`;

--- a/src/features/winterStorageAreaView/forms/sectionForm/sectionForm.module.scss
+++ b/src/features/winterStorageAreaView/forms/sectionForm/sectionForm.module.scss
@@ -1,0 +1,8 @@
+@import 'spacings';
+@import 'form';
+
+.checkboxes {
+  > * {
+    margin: units(0.5) 0;
+  }
+}

--- a/src/features/winterStorageAreaView/forms/sectionForm/utils/utils.ts
+++ b/src/features/winterStorageAreaView/forms/sectionForm/utils/utils.ts
@@ -1,0 +1,24 @@
+import { Section } from '../../types';
+import { SECTION } from '../__generated__/SECTION';
+
+export const getSection = (data: SECTION | undefined): Section => {
+  if (!data || !data?.winterStorageSection?.properties) return {};
+  const {
+    electricity,
+    water,
+    gate,
+    identifier,
+    summerStorageForBoats,
+    summerStorageForDockingEquipment,
+    summerStorageForTrailers,
+  } = data.winterStorageSection.properties;
+  return {
+    identifier,
+    electricity,
+    water,
+    gate,
+    summerStorageForBoats,
+    summerStorageForDockingEquipment,
+    summerStorageForTrailers,
+  };
+};

--- a/src/features/winterStorageAreaView/forms/types.ts
+++ b/src/features/winterStorageAreaView/forms/types.ts
@@ -9,6 +9,25 @@ export type WinterStorageAreaForm = {
   zipCode: string;
 };
 
+export type Section = {
+  identifier?: string;
+  electricity?: boolean;
+  gate?: boolean;
+  water?: boolean;
+  summerStorageForBoats?: boolean;
+  summerStorageForDockingEquipment?: boolean;
+  summerStorageForTrailers?: boolean;
+};
+
+export type Place = {
+  number?: string;
+  isActive?: boolean;
+  width?: number;
+  length?: number;
+  winterStorageSection?: string;
+  winterStorageSectionId?: string;
+};
+
 export interface FormProps<T> {
   initialValues?: T;
   // Queries to refetch when mutations are run

--- a/src/features/winterStorageAreaView/forms/utils/utils.ts
+++ b/src/features/winterStorageAreaView/forms/utils/utils.ts
@@ -1,5 +1,6 @@
-import { WinterStorageAreaForm } from '../types';
+import { Place, WinterStorageAreaForm } from '../types';
 import { WINTER_STORAGE_AREA_FORM } from '../__generated__/WINTER_STORAGE_AREA_FORM';
+import { INDIVIDUAL_PLACE } from '../placeForm/__generated__/INDIVIDUAL_PLACE';
 
 export const getWinterStorageAreaForm = (
   winterStorageAreaData: WINTER_STORAGE_AREA_FORM | undefined
@@ -24,6 +25,19 @@ export const getWinterStorageAreaForm = (
     municipality: municipality || '',
     wwwUrl,
     imageFile: imageFile || '',
+  };
+};
+
+export const getWinterStoragePlace = (placeData: INDIVIDUAL_PLACE | undefined): Place | undefined => {
+  if (!placeData || !placeData.winterStoragePlace) return undefined;
+  const { number, isActive, width, length } = placeData.winterStoragePlace;
+  return {
+    number: String(number),
+    isActive,
+    width,
+    length,
+    winterStorageSectionId: placeData.winterStoragePlace.winterStorageSection.id,
+    winterStorageSection: placeData.winterStoragePlace.winterStorageSection.properties?.identifier,
   };
 };
 

--- a/src/features/winterStorageAreaView/types.ts
+++ b/src/features/winterStorageAreaView/types.ts
@@ -40,6 +40,7 @@ export type WinterStoragePlace = {
 };
 
 export type WinterStorageSection = {
+  id: string;
   identifier: string;
 };
 

--- a/src/features/winterStorageAreaView/utils.ts
+++ b/src/features/winterStorageAreaView/utils.ts
@@ -152,7 +152,7 @@ export const getWinterStorageSections = (
     if (unmarked ? !isUnmarkedSection(sectionEdge.node) : isUnmarkedSection(sectionEdge.node)) {
       return acc;
     }
-    return [...acc, { identifier: sectionEdge.node.properties.identifier }];
+    return [...acc, { id: sectionEdge.node.id, identifier: sectionEdge.node.properties.identifier }];
   }, []);
 };
 

--- a/src/features/winterStorageAreaView/winterStoragePlaceTableTools/WinterStoragePlaceTableTools.tsx
+++ b/src/features/winterStorageAreaView/winterStoragePlaceTableTools/WinterStoragePlaceTableTools.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import GlobalSearchTableTools from '../../../common/tableTools/globalSearchTableTools/GlobalSearchTableTools';
+import styles from './winterStoragePlaceTableTools.module.scss';
+import Button from '../../../common/button/Button';
+
+interface Props {
+  canAddPlace: boolean;
+  onAddSection(): void;
+  onAddPlace(): void;
+  handleGlobalFilter(value?: string): void;
+}
+
+const WinterStoragePlaceTableTools = ({ onAddSection, onAddPlace, handleGlobalFilter, canAddPlace }: Props) => {
+  const { t } = useTranslation();
+  return (
+    <div className={styles.container}>
+      <div className={styles.buttons}>
+        <Button onClick={onAddSection} variant="secondary" className={styles.button}>
+          {t('winterStorageAreaView.tableTools.addSection')}
+        </Button>
+        <Button onClick={onAddPlace} variant="secondary" className={styles.button} disabled={!canAddPlace}>
+          {t('winterStorageAreaView.tableTools.addPlace')}
+        </Button>
+      </div>
+      <GlobalSearchTableTools handleGlobalFilter={handleGlobalFilter} />
+    </div>
+  );
+};
+
+export default WinterStoragePlaceTableTools;

--- a/src/features/winterStorageAreaView/winterStoragePlaceTableTools/__tests__/WinterStoragePlaceTableTools.test.tsx
+++ b/src/features/winterStorageAreaView/winterStoragePlaceTableTools/__tests__/WinterStoragePlaceTableTools.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import WinterStoragePlaceTableTools from '../WinterStoragePlaceTableTools';
+
+describe('WinterStorageAreaTableTools', () => {
+  const getWrapper = () =>
+    shallow(
+      <WinterStoragePlaceTableTools
+        onAddSection={jest.fn()}
+        onAddPlace={jest.fn()}
+        handleGlobalFilter={jest.fn()}
+        canAddPlace={true}
+      />
+    );
+
+  it('renders normally', () => {
+    const wrapper = getWrapper();
+
+    expect(wrapper.render()).toMatchSnapshot();
+  });
+});

--- a/src/features/winterStorageAreaView/winterStoragePlaceTableTools/__tests__/__snapshots__/WinterStoragePlaceTableTools.test.tsx.snap
+++ b/src/features/winterStorageAreaView/winterStoragePlaceTableTools/__tests__/__snapshots__/WinterStoragePlaceTableTools.test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WinterStorageAreaTableTools renders normally 1`] = `
+<div
+  class="container"
+>
+  <div
+    class="buttons"
+  >
+    <button
+      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0 button"
+      type="button"
+    >
+      <span
+        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      >
+        Lisää osasto
+      </span>
+    </button>
+    <button
+      class="Button-module_button__1msFE button_hds-button__2A0je Button-module_secondary__1nABp button_hds-button--secondary__1NOWS Button-module_theme-coat__2_3U7 button_hds-button--theme-coat__12cO0 button"
+      type="button"
+    >
+      <span
+        class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
+      >
+        Lisää paikka
+      </span>
+    </button>
+  </div>
+  <div
+    class="globalSearchTableTools"
+  >
+    <div
+      class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq filterField"
+    >
+      <div
+        class="TextInput-module_inputWrapper__3Rvel text-input_hds-text-input__input-wrapper__1OqYG"
+      >
+        <input
+          class="TextInput-module_input__1BlHi text-input_hds-text-input__input__GJm5C"
+          id="textSearchGlobalFilter"
+          placeholder="Haku"
+          type="text"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/features/winterStorageAreaView/winterStoragePlaceTableTools/winterStoragePlaceTableTools.module.scss
+++ b/src/features/winterStorageAreaView/winterStoragePlaceTableTools/winterStoragePlaceTableTools.module.scss
@@ -1,0 +1,11 @@
+@import 'spacings';
+
+.container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.buttons {
+  @include horizontal-margin-between(button, units(1));
+}

--- a/src/features/winterStoragePlaceDetails/WinterStoragePlaceDetails.tsx
+++ b/src/features/winterStoragePlaceDetails/WinterStoragePlaceDetails.tsx
@@ -7,6 +7,7 @@ import InternalLink from '../../common/internalLink/InternalLink';
 import styles from './winterStoragePlaceDetails.module.scss';
 import Grid from '../../common/grid/Grid';
 import Section from '../../common/section/Section';
+import MaintenanceServicesPlaceholder from '../../common/maintenancePlaceholders/MaintenanceServicesPlaceholder';
 
 export interface Lease {
   customer: {
@@ -22,9 +23,10 @@ export interface Lease {
 
 export interface WinterStoragePlaceDetailsProps {
   leases: Lease[];
+  onEdit?(): void;
 }
 
-const WinterStoragePlaceDetails = ({ leases }: WinterStoragePlaceDetailsProps) => {
+const WinterStoragePlaceDetails = ({ leases, onEdit }: WinterStoragePlaceDetailsProps) => {
   const { t, i18n } = useTranslation();
 
   const expiredLeasesElements = leases
@@ -48,6 +50,7 @@ const WinterStoragePlaceDetails = ({ leases }: WinterStoragePlaceDetailsProps) =
         <Section title={t('offer.previousLeases').toUpperCase()}>
           {expiredLeasesElements.length ? expiredLeasesElements : '-'}
         </Section>
+        <MaintenanceServicesPlaceholder onClick={onEdit} buttonText={t('common.edit')} />
       </Grid>
     </div>
   );

--- a/src/features/winterStoragePlaceDetails/WinterStoragePlaceDetailsContainer.tsx
+++ b/src/features/winterStoragePlaceDetails/WinterStoragePlaceDetailsContainer.tsx
@@ -13,9 +13,10 @@ import {
 
 export interface WinterStoragePlaceDetailsContainerProps {
   id: string;
+  onEdit?(): void;
 }
 
-const WinterStoragePlaceDetailsContainer = ({ id }: WinterStoragePlaceDetailsContainerProps) => {
+const WinterStoragePlaceDetailsContainer = ({ id, onEdit }: WinterStoragePlaceDetailsContainerProps) => {
   const { t } = useTranslation();
   const { loading, data } = useQuery<WINTER_STORAGE_PLACE_DETAILS, WINTER_STORAGE_PLACE_DETAILS_VARS>(
     WINTER_STORAGE_PLACE_DETAILS_QUERY,
@@ -31,7 +32,7 @@ const WinterStoragePlaceDetailsContainer = ({ id }: WinterStoragePlaceDetailsCon
 
   const leases = getPlaceLeases(data.winterStoragePlace.leases);
 
-  return <WinterStoragePlaceDetails leases={leases} />;
+  return <WinterStoragePlaceDetails leases={leases} onEdit={onEdit} />;
 };
 
 export default WinterStoragePlaceDetailsContainer;

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -346,6 +346,36 @@
       "municipality": "Postitoimipaikka",
       "wwwUrl": "WWW-osoite",
       "imageFile": "Talvisäilytyspaikan kuva"
+    },
+    "winterStorageSection": {
+      "delete": "Poista osasto",
+      "title": "Osasto",
+      "identifier": "Osasto",
+      "services": "Palvelut",
+      "gate": "Portti",
+      "electricity": "Sähkö",
+      "water": "Vesi",
+      "summerStorageForBoats": "Veneiden kesäsäilytys",
+      "summerStorageForDockingEquipment": "Telakointi\u00ADtarvikkeiden kesäsäilytys",
+      "summerStorageForTrailers": "Trailerin kesäsäilytys",
+      "deleteConfirmation": {
+        "infoText": "Oletko varma että haluat poistaa osaston {{sectionIdentifier}}?",
+        "warningText": "Tämä poistaa koko osaston ja kaikki siinä olevat talvisäilytyspaikat. Tätä toimenpidettä ei voi perua."
+      }
+    },
+    "winterStoragePlace": {
+      "delete": "Poista talvisäilytypaikka",
+      "title": "Paikka",
+      "section": "Osasto",
+      "number": "Numero",
+      "width": "Leveys (m)",
+      "length": "Pituus (m)",
+      "comment": "Huomiot",
+      "isActive": "Paikka on käytössä",
+      "deleteConfirmation": {
+        "infoText": "Oletko varma että haluat poistaa talvisäilytyspaikan {{placeNumber}} osastosta {{section}}?",
+        "warningText": "Tätä toimenpidettä ei voi perua."
+      }
     }
   },
   "harborList": {
@@ -894,6 +924,10 @@
     },
     "place": {
       "inactive": "Ei käytössä"
+    },
+    "tableTools": {
+      "addSection": "Lisää osasto",
+      "addPlace": "Lisää paikka"
     }
   },
   "actionHistoryCard": {


### PR DESCRIPTION
## Description :sparkles:
Adds the create/add/delete functionality to the single winter storage area page:
- for Sections
- for Places

Fixes the bug with Berth create/edit form when adding the numeric values (there was error about controlled/uncontrolled component when typing the value)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
Edit WS area:
<img width="1516" alt="image" src="https://user-images.githubusercontent.com/16116141/166213208-5785ed8d-523e-4c63-aa33-9a9d777911ab.png">
Add place and section buttons:
<img width="493" alt="image" src="https://user-images.githubusercontent.com/16116141/166213280-50e17ca9-fcc2-49ee-9709-8df85e65eb50.png">
Add section form:
<img width="709" alt="image" src="https://user-images.githubusercontent.com/16116141/166213323-a3217704-ce11-4d59-ba1b-6f04b8503643.png">
Add place form:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/16116141/166213421-f4bdb174-85f6-4835-88cb-ce70de898682.png">
Edit section link:
<img width="675" alt="image" src="https://user-images.githubusercontent.com/16116141/166213597-8d997222-65a7-40a7-bc35-808f8fe79129.png">
Edit place link:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/16116141/166213527-c1636a3a-3054-4bfa-ae1f-7bc42ae12adf.png">




## Additional notes :spiral_notepad:
