### PR TITLE
Disable the BerthOfferTable choose -button when there is a pending offer

### DIFF
--- a/src/features/berthOffer/__fixtures__/mockData.ts
+++ b/src/features/berthOffer/__fixtures__/mockData.ts
@@ -90,6 +90,7 @@ export const berthOfferQueryData: BERTH_OFFER = {
                             },
                           ],
                         },
+                        pendingSwitchOffer: null,
                         length: 10,
                         mooringType: BerthMooringType.DINGHY_PLACE,
                         number: '1',

--- a/src/features/berthOffer/__generated__/BERTH_OFFER.ts
+++ b/src/features/berthOffer/__generated__/BERTH_OFFER.ts
@@ -66,6 +66,16 @@ export interface BERTH_OFFER_harbor_properties_piers_edges_node_properties_berth
   edges: (BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges | null)[];
 }
 
+export interface BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer {
+  __typename: "ProfileNode";
+  id: string;
+}
+
+export interface BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer {
+  __typename: "BerthSwitchOfferNode";
+  customer: BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer;
+}
+
 export interface BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
   comment: string;
@@ -74,6 +84,7 @@ export interface BERTH_OFFER_harbor_properties_piers_edges_node_properties_berth
   isAccessible: boolean | null;
   isActive: boolean;
   leases: BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_leases | null;
+  pendingSwitchOffer: BERTH_OFFER_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer | null;
   length: number;
   mooringType: BerthMooringType;
   number: string;

--- a/src/features/berthOffer/__generated__/BERTH_OFFER_WITHOUT_APPLICATION_HARBOR.ts
+++ b/src/features/berthOffer/__generated__/BERTH_OFFER_WITHOUT_APPLICATION_HARBOR.ts
@@ -33,6 +33,16 @@ export interface BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_
   edges: (BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases_edges | null)[];
 }
 
+export interface BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer {
+  __typename: "ProfileNode";
+  id: string;
+}
+
+export interface BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer {
+  __typename: "BerthSwitchOfferNode";
+  customer: BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer;
+}
+
 export interface BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
   comment: string;
@@ -41,6 +51,7 @@ export interface BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_
   isAccessible: boolean | null;
   isActive: boolean;
   leases: BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_leases | null;
+  pendingSwitchOffer: BERTH_OFFER_WITHOUT_APPLICATION_HARBOR_harbor_properties_piers_edges_node_properties_berths_edges_node_pendingSwitchOffer | null;
   length: number;
   mooringType: BerthMooringType;
   number: string;

--- a/src/features/berthOffer/__generated__/BerthOfferPiers.ts
+++ b/src/features/berthOffer/__generated__/BerthOfferPiers.ts
@@ -33,6 +33,16 @@ export interface BerthOfferPiers_edges_node_properties_berths_edges_node_leases 
   edges: (BerthOfferPiers_edges_node_properties_berths_edges_node_leases_edges | null)[];
 }
 
+export interface BerthOfferPiers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer {
+  __typename: "ProfileNode";
+  id: string;
+}
+
+export interface BerthOfferPiers_edges_node_properties_berths_edges_node_pendingSwitchOffer {
+  __typename: "BerthSwitchOfferNode";
+  customer: BerthOfferPiers_edges_node_properties_berths_edges_node_pendingSwitchOffer_customer;
+}
+
 export interface BerthOfferPiers_edges_node_properties_berths_edges_node {
   __typename: "BerthNode";
   comment: string;
@@ -41,6 +51,7 @@ export interface BerthOfferPiers_edges_node_properties_berths_edges_node {
   isAccessible: boolean | null;
   isActive: boolean;
   leases: BerthOfferPiers_edges_node_properties_berths_edges_node_leases | null;
+  pendingSwitchOffer: BerthOfferPiers_edges_node_properties_berths_edges_node_pendingSwitchOffer | null;
   length: number;
   mooringType: BerthMooringType;
   number: string;

--- a/src/features/berthOffer/__tests__/__snapshots__/utils.test.ts.snap
+++ b/src/features/berthOffer/__tests__/__snapshots__/utils.test.ts.snap
@@ -56,6 +56,7 @@ Array [
     ],
     "length": 10,
     "mooringType": "DINGHY_PLACE",
+    "pendingSwitchOffer": null,
     "pier": "pier",
     "properties": Object {
       "electricity": true,

--- a/src/features/berthOffer/components/BerthOfferTable.tsx
+++ b/src/features/berthOffer/components/BerthOfferTable.tsx
@@ -56,7 +56,7 @@ const BerthOfferTable = ({
 
             return setIsBerthChosen(row.original);
           }, [row])}
-          disabled={!row.original.isActive || isSubmitting}
+          disabled={!row.original.isActive || !!row.original.pendingSwitchOffer || isSubmitting}
         >
           {t('common.select')}
         </Button>

--- a/src/features/berthOffer/fragments.ts
+++ b/src/features/berthOffer/fragments.ts
@@ -50,6 +50,11 @@ export const BERTH_OFFER_PIERS_FRAGMENT = gql`
                     }
                   }
                 }
+                pendingSwitchOffer {
+                  customer {
+                    id
+                  }
+                }
                 length
                 mooringType
                 number

--- a/src/features/berthOffer/types.ts
+++ b/src/features/berthOffer/types.ts
@@ -16,6 +16,12 @@ export type Lease = {
   isActive: boolean;
 };
 
+export type PendingSwitchOffer = {
+  customer: {
+    id: string;
+  };
+};
+
 export type BerthData = {
   berth: string | number;
   berthId: string;
@@ -26,6 +32,7 @@ export type BerthData = {
   id: string;
   isActive: boolean;
   leases: Lease[];
+  pendingSwitchOffer: PendingSwitchOffer | null;
   length: number | null;
   mooringType: string;
   pier: string;

--- a/src/features/berthOffer/utils.ts
+++ b/src/features/berthOffer/utils.ts
@@ -59,6 +59,7 @@ export const getBerthData = (data: HarborData | null | undefined): BerthData[] =
             isAccessible: berth.node.isAccessible,
           },
           width: berth.node.width,
+          pendingSwitchOffer: berth.node.pendingSwitchOffer,
         },
       ];
     }, []);


### PR DESCRIPTION
VEN-1505 VEN-1483.

NOTE: This PR is left as draft because the PO mentioned that this might not be even needed. However, the Jira ticket screenshots and the code suggests that this could be needed. The logic is so complicated overall, that it's a bit hard to say. :)  This PR is supposed to full fill the #483.

The button should be disabled when the berth is not active or there is a pending switch offer.

![image](https://user-images.githubusercontent.com/389204/166654213-937452de-3085-469f-93cd-ddaed6978177.png)
