### PR TITLE
Ven-1527: Add isActive to winterStorage place update

### DIFF
--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
 import { useMutation, useQuery } from '@apollo/react-hooks';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { INDIVIDUAL_PLACE_QUERY } from './queries';
 import LoadingSpinner from '../../../../common/spinner/LoadingSpinner';
+import { WinterStorageSection } from '../../types';
+import { FormProps, Place } from '../types';
+import { getWinterStoragePlace } from '../utils/utils';
+import { DELETE_PLACE_MUTATION, UPDATE_PLACE_MUTATION } from './mutations';
+import PlaceForm from './PlaceForm';
+import { INDIVIDUAL_PLACE_QUERY } from './queries';
+import { DELETE_PLACE, DELETE_PLACEVariables as DELETE_PLACE_VARS } from './__generated__/DELETE_PLACE';
 import { INDIVIDUAL_PLACE } from './__generated__/INDIVIDUAL_PLACE';
 import { UPDATE_PLACE, UPDATE_PLACEVariables as UPDATE_PLACE_VARS } from './__generated__/UPDATE_PLACE';
-import { DELETE_PLACE_MUTATION, UPDATE_PLACE_MUTATION } from './mutations';
-import { Place, FormProps } from '../types';
-import { DELETE_PLACE, DELETE_PLACEVariables as DELETE_PLACE_VARS } from './__generated__/DELETE_PLACE';
-import PlaceForm from './PlaceForm';
-import { WinterStorageSection } from '../../types';
-import { getWinterStoragePlace } from '../utils/utils';
 
 interface PlaceEditFormProps extends Omit<FormProps<Place>, 'initialValues' | 'onCreate'> {
   placeId: string;
@@ -59,7 +59,7 @@ const PlaceEditForm = ({
       }
       onSubmitText={t('forms.common.update')}
       onSubmit={(values) => {
-        const { width, length, comment } = values;
+        const { width, length, comment, isActive } = values;
         updateWinterStoragePlace({
           variables: {
             input: {
@@ -67,6 +67,7 @@ const PlaceEditForm = ({
               width,
               length,
               comment,
+              isActive,
             },
           },
         }).then(() => onSubmit?.(values));

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceEditForm.tsx
@@ -1,17 +1,17 @@
-import { useMutation, useQuery } from '@apollo/react-hooks';
 import React from 'react';
+import { useMutation, useQuery } from '@apollo/react-hooks';
 import { useTranslation } from 'react-i18next';
 
-import LoadingSpinner from '../../../../common/spinner/LoadingSpinner';
-import { WinterStorageSection } from '../../types';
-import { FormProps, Place } from '../types';
-import { getWinterStoragePlace } from '../utils/utils';
-import { DELETE_PLACE_MUTATION, UPDATE_PLACE_MUTATION } from './mutations';
-import PlaceForm from './PlaceForm';
 import { INDIVIDUAL_PLACE_QUERY } from './queries';
-import { DELETE_PLACE, DELETE_PLACEVariables as DELETE_PLACE_VARS } from './__generated__/DELETE_PLACE';
+import LoadingSpinner from '../../../../common/spinner/LoadingSpinner';
 import { INDIVIDUAL_PLACE } from './__generated__/INDIVIDUAL_PLACE';
 import { UPDATE_PLACE, UPDATE_PLACEVariables as UPDATE_PLACE_VARS } from './__generated__/UPDATE_PLACE';
+import { DELETE_PLACE_MUTATION, UPDATE_PLACE_MUTATION } from './mutations';
+import { Place, FormProps } from '../types';
+import { DELETE_PLACE, DELETE_PLACEVariables as DELETE_PLACE_VARS } from './__generated__/DELETE_PLACE';
+import PlaceForm from './PlaceForm';
+import { WinterStorageSection } from '../../types';
+import { getWinterStoragePlace } from '../utils/utils';
 
 interface PlaceEditFormProps extends Omit<FormProps<Place>, 'initialValues' | 'onCreate'> {
   placeId: string;

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
@@ -1,21 +1,21 @@
-import { Formik } from 'formik';
-import { TextInput } from 'hds-react';
-import { TFunction } from 'i18next';
 import React, { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Formik } from 'formik';
 import * as Yup from 'yup';
+import { useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
+import { TextInput } from 'hds-react';
 import { ObjectSchema } from 'yup';
 
-import Button from '../../../../common/button/Button';
-import Checkbox from '../../../../common/checkbox/Checkbox';
-import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
-import FormHeader from '../../../../common/formHeader/FormHeader';
+import { Place, FormProps } from '../types';
 import Grid from '../../../../common/grid/Grid';
 import Select from '../../../../common/select/Select';
-import { isNumber, isPositive, replaceCommaWithDot, replaceDotWithComma } from '../../../../common/utils/forms';
-import { WinterStorageSection } from '../../types';
-import { FormProps, Place } from '../types';
 import styles from './placeForm.module.scss';
+import { WinterStorageSection } from '../../types';
+import FormHeader from '../../../../common/formHeader/FormHeader';
+import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
+import { isNumber, isPositive, replaceCommaWithDot, replaceDotWithComma } from '../../../../common/utils/forms';
+import Checkbox from '../../../../common/checkbox/Checkbox';
+import Button from '../../../../common/button/Button';
 
 interface PlaceFormProps extends FormProps<Place> {
   isEditing?: boolean;

--- a/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/PlaceForm.tsx
@@ -1,21 +1,21 @@
-import React, { useState } from 'react';
 import { Formik } from 'formik';
-import * as Yup from 'yup';
-import { useTranslation } from 'react-i18next';
-import { TFunction } from 'i18next';
 import { TextInput } from 'hds-react';
+import { TFunction } from 'i18next';
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as Yup from 'yup';
 import { ObjectSchema } from 'yup';
 
-import { Place, FormProps } from '../types';
+import Button from '../../../../common/button/Button';
+import Checkbox from '../../../../common/checkbox/Checkbox';
+import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
+import FormHeader from '../../../../common/formHeader/FormHeader';
 import Grid from '../../../../common/grid/Grid';
 import Select from '../../../../common/select/Select';
-import styles from './placeForm.module.scss';
-import { WinterStorageSection } from '../../types';
-import FormHeader from '../../../../common/formHeader/FormHeader';
-import ConfirmationModal from '../../../../common/confirmationModal/ConfirmationModal';
 import { isNumber, isPositive, replaceCommaWithDot, replaceDotWithComma } from '../../../../common/utils/forms';
-import Checkbox from '../../../../common/checkbox/Checkbox';
-import Button from '../../../../common/button/Button';
+import { WinterStorageSection } from '../../types';
+import { FormProps, Place } from '../types';
+import styles from './placeForm.module.scss';
 
 interface PlaceFormProps extends FormProps<Place> {
   isEditing?: boolean;
@@ -47,13 +47,14 @@ const getPlaceValidationSchema = (t: TFunction, sectionOptions: WinterStorageSec
 };
 
 const transformValues = (values: PlaceFormValues): Place => {
-  const { winterStorageSectionId, number, width, length, comment } = values;
+  const { winterStorageSectionId, number, width, length, comment, isActive } = values;
   return {
     number: number,
     width: width ? parseFloat(replaceCommaWithDot(width)) : undefined,
     length: length ? parseFloat(replaceCommaWithDot(length)) : undefined,
     winterStorageSectionId: winterStorageSectionId,
     comment,
+    isActive,
   };
 };
 

--- a/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceEditForm.test.tsx
+++ b/src/features/winterStorageAreaView/forms/placeForm/__tests__/PlaceEditForm.test.tsx
@@ -81,6 +81,7 @@ describe('features/winterStorageAreaView/PlaceEditForm', () => {
             id: 'a',
             width: 2.25,
             length: 5,
+            isActive: true,
           },
         },
       },


### PR DESCRIPTION
## Description :sparkles:
This fixes the "Place is in use" toggle in winter storage place edit, by including the `isActive` value in the update query.

## Issues :bug:

### Closes :no_good_woman:
Ven-1527
### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:
The highlighted toggle in the screenshot should change and place in the list and if unchecked, customer column in the list will display red "Ei käytössä" box.

## Screenshots :camera_flash:
![Screenshot 2022-11-08 at 16 57 59](https://user-images.githubusercontent.com/53874567/200599538-ab226db0-5a1b-4255-8b81-348fc8ae4ff0.png)

## Additional notes :spiral_notepad:
