### PR TITLE
Add sectionIdentifier and placeNumber to address on winterstorage card

### DIFF
--- a/src/features/customerView/leasesCard/WinterStorageLeasesCard.tsx
+++ b/src/features/customerView/leasesCard/WinterStorageLeasesCard.tsx
@@ -22,7 +22,7 @@ const WinterStorageLeasesCard = ({ customerName, cancelLease, leases, createLeas
   const { t } = useTranslation();
   const mapLeaseDetails = (lease: WinterStorageLease): Lease => {
     return {
-      address: lease.winterStorageArea?.name || '',
+      address: [lease.winterStorageArea?.name || '', lease.sectionIdentifier, lease.placeNum].join(' '),
       endDate: lease.endDate,
       id: lease.id,
       link: lease?.winterStorageArea?.id ? `/winter-storage-areas/${lease?.winterStorageArea?.id}` : undefined,


### PR DESCRIPTION
## Description :sparkles:
Section and place were missing from the Winterstorage card on customer profile, this will add them there.
## Issues :bug:

### Closes :no_good_woman:
ven-1528
### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
![Screenshot 2022-11-11 at 15 02 09](https://user-images.githubusercontent.com/53874567/201346265-97fc6c35-9fa8-4377-abb3-c4a270547f01.png)

## Additional notes :spiral_notepad:
