### PR TITLE
Ven-1537 Update customer filter

### DIFF
--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -196,5 +196,5 @@ export interface CUSTOMERSVariables {
   apiToken?: string | null;
   startDate?: any | null;
   endDate?: any | null;
-  invoicingType?: InvoicingType | null;
+  invoicingTypes?: (InvoicingType | null)[] | null;
 }

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -108,7 +108,7 @@ export const CUSTOMERS_QUERY = gql`
     $apiToken: String
     $startDate: Date
     $endDate: Date
-    $invoicingType: InvoicingType
+    $invoicingTypes: [InvoicingType]
   ) {
     berthProfiles(
       first: $first
@@ -133,7 +133,7 @@ export const CUSTOMERS_QUERY = gql`
       apiToken: $apiToken
       leaseStart: $startDate
       leaseEnd: $endDate
-      invoicingTypes: [$invoicingType]
+      invoicingTypes: $invoicingTypes
     ) {
       count
       edges {

--- a/src/features/customerList/useCustomersQuery.ts
+++ b/src/features/customerList/useCustomersQuery.ts
@@ -12,7 +12,6 @@
 import { useQuery } from '@apollo/react-hooks';
 
 import { CustomerGroup, InvoicingType } from '../../@types/__generated__/globalTypes';
-import { limitedCustomerSearchFeatureFlag } from '../../common/utils/featureFlags';
 import {
   CUSTOMERS,
   CUSTOMERSVariables as CUSTOMERS_VARS,
@@ -100,12 +99,7 @@ export default function useCustomersQuery({
       apiToken,
     },
     fetchPolicy: 'no-cache',
-    skip:
-      activeQuery !== Query.BERTH_PROFILE ||
-      // If enabled, stop queries from being fired when a harbor hasn't been
-      // selected. Filtering by harbor limits the result group enough so that
-      // the query does not fail.
-      (limitedCustomerSearchFeatureFlag() ? (harborIds?.length ?? 0) === 0 : false),
+    skip: activeQuery !== Query.BERTH_PROFILE,
   });
 
   const organizationsQuery = useQuery<CUSTOMERS, CUSTOMERS_VARS>(CUSTOMER_GROUPS_QUERY, {

--- a/src/features/customerList/useCustomersQuery.ts
+++ b/src/features/customerList/useCustomersQuery.ts
@@ -48,7 +48,7 @@ type Config = Omit<CustomerListTableFilters, 'dateInterval'> & {
   address?: string;
   stickerNumber?: string;
   boatRegistrationNumber?: string;
-  invoicingType?: InvoicingType;
+  invoicingTypes?: InvoicingType[];
 };
 
 export default function useCustomersQuery({

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -628,8 +628,8 @@
       "deleteButtonAriaLabel": "Poista suodatus",
       "resetAllFiltersAriaLabel": "Poista kaikki suodatukset",
       "loadingOptions": "Etsitään vaihtoehtoja...",
-      "limitedSearchLabel": "Käyttäjähakua on rajoitettu tilapäisesti",
-      "limitedSearchMessage": "Hakujen tekeminen ilman valittua venesatamaa tai -satamia on tilapäisesti estetty. Rajoite pyritään poistamaan. Rajoite on asetettu voimaan palvelun suorituskyvyn takaamiseksi.",
+      "limitedSearchLabel": "Käyttäjähaun rajaus saattaa kestää jonkin aikaa.",
+      "limitedSearchMessage": "Hakujen rajaaminen on mahdollista, mutta hakukriteereistä riippuen haku saattaa kestää muutaman minuutinkin. Nopeutta pyritään parantamaan. Koita erilaisia hakukriteereitä, jos ensimmäinen haku ei tuota tuloksia.",
       "customerGroupOverlapLabel": "Rajaus asiakasryhmällä käytössä",
       "customerGroupOverlapMessage": "Asiakasryhmällä rajaaminen kumoaa haun yrityksen nimellä. Jos haluat etsiä yrityksen nimellä, poista asiakasryhmän rajaus."
     },


### PR DESCRIPTION
## Description :sparkles:
Seems the customer filter doesn't timeout as much as before. Queries are slow, but nevertheless filtering does seem to work without `harbourId` limitation too (in test). So this removes the limitation, but informs users about the slowness of the queries. Whenever the queries start working faster, the notification can be removed (and other related tickets finally resolved).

Also, there was a bug how the `invoicingTypes` was handled on the query, which most of the time resulted on empty results, this also fixes that.

## Issues :bug:

### Closes :no_good_woman:
VEN-1537

### Related :handshake:
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1480
https://helsinkisolutionoffice.atlassian.net/browse/HP-1317
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1481

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
