### PR TITLE
VEN-983 Search by sticker number and season

### DIFF
--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -31,6 +31,7 @@ export enum SearchBy {
   EMAIL = 'email',
   ADDRESS = 'address',
   STICKER_NUMBER = 'stickerNumber',
+  STICKER_NUMBER_SEASON = 'stickerNumberSeason',
   BOAT_REGISTRATION_NUMBER = 'boatRegistrationNumber',
   INVOICING_TYPE = 'invoicingType',
 }
@@ -85,6 +86,18 @@ const transformSearchBy = (searchBy: SearchBy, value: string): SearchByTransform
   if (searchBy === SearchBy.INVOICING_TYPE) {
     return {
       invoicingTypes: [value],
+    };
+  }
+  if (searchBy === SearchBy.STICKER_NUMBER_SEASON) {
+    if (value.indexOf(' ') === -1) {
+      return {
+        stickerNumber: value,
+      };
+    }
+    const [stickerNumber, season] = value.split(' ');
+    return {
+      stickerNumber,
+      stickerSeason: season,
     };
   }
   return {
@@ -213,13 +226,22 @@ const CustomerListContainer = () => {
           handleCustomersExport,
           isExporting,
           searchByOptions: [
-            { value: SearchBy.NAME, label: t('common.name') },
+            {
+              value: SearchBy.NAME,
+              label: t('common.name'),
+              placeholder: `${t('common.lastName')} ${t('common.firstName')}`,
+            },
             { value: SearchBy.FIRST_NAME, label: t('common.firstName') },
             { value: SearchBy.LAST_NAME, label: t('common.lastName') },
             { value: SearchBy.ORGANIZATION_NAME, label: t('common.customerGroups.COMPANY') },
             { value: SearchBy.EMAIL, label: t('common.email') },
             { value: SearchBy.ADDRESS, label: t('common.address') },
             { value: SearchBy.STICKER_NUMBER, label: t('common.terminology.stickerNumber') },
+            {
+              value: SearchBy.STICKER_NUMBER_SEASON,
+              label: t('forms.customer.stickerNumberAndSeason'),
+              placeholder: t('forms.customer.stickerNumberAndSeasonPlaceholder'),
+            },
             { value: SearchBy.BOAT_REGISTRATION_NUMBER, label: t('common.terminology.registrationNumber') },
             {
               value: SearchBy.INVOICING_TYPE,

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -121,7 +121,15 @@ const CustomerListContainer = () => {
 
   const [displayNotification, setDisplayNotification] = useState(false);
 
-  const [debouncedSearchVal] = useDebounce(searchVal, 500, {
+  const debounceWait = [
+    SearchBy.STICKER_NUMBER,
+    SearchBy.STICKER_NUMBER_SEASON,
+    SearchBy.BOAT_REGISTRATION_NUMBER,
+  ].includes(searchBy)
+    ? 1200
+    : 500;
+
+  const [debouncedSearchVal] = useDebounce(searchVal, debounceWait, {
     equalityFn: (prev, next) => prev === next,
     leading: true,
   });

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -121,13 +121,15 @@ const CustomerListContainer = () => {
 
   const [displayNotification, setDisplayNotification] = useState(false);
 
+  const debounceSlowProfileQueryDelay = 1200;
+  const debounceDefaultDelay = 500;
   const debounceWait = [
     SearchBy.STICKER_NUMBER,
     SearchBy.STICKER_NUMBER_SEASON,
     SearchBy.BOAT_REGISTRATION_NUMBER,
   ].includes(searchBy)
-    ? 1200
-    : 500;
+    ? debounceSlowProfileQueryDelay
+    : debounceDefaultDelay;
 
   const [debouncedSearchVal] = useDebounce(searchVal, debounceWait, {
     equalityFn: (prev, next) => prev === next,

--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -89,7 +89,7 @@ const transformSearchBy = (searchBy: SearchBy, value: string): SearchByTransform
     };
   }
   if (searchBy === SearchBy.STICKER_NUMBER_SEASON) {
-    if (value.indexOf(' ') === -1) {
+    if (!value.includes(' ')) {
       return {
         stickerNumber: value,
       };

--- a/src/features/customerList/__generated__/CUSTOMERS.ts
+++ b/src/features/customerList/__generated__/CUSTOMERS.ts
@@ -181,6 +181,7 @@ export interface CUSTOMERSVariables {
   email?: string | null;
   address?: string | null;
   stickerNumber?: string | null;
+  stickerSeason?: string | null;
   boatRegistrationNumber?: string | null;
   orderBy?: string | null;
   customerGroups?: (CustomerGroup | null)[] | null;

--- a/src/features/customerList/queries.ts
+++ b/src/features/customerList/queries.ts
@@ -93,6 +93,7 @@ export const CUSTOMERS_QUERY = gql`
     $email: String
     $address: String
     $stickerNumber: String
+    $stickerSeason: String
     $boatRegistrationNumber: String
     $orderBy: String
     $customerGroups: [CustomerGroup]
@@ -118,6 +119,7 @@ export const CUSTOMERS_QUERY = gql`
       email: $email
       address: $address
       stickerNumber: $stickerNumber
+      stickerSeason: $stickerSeason
       boatRegistrationNumber: $boatRegistrationNumber
       sortBy: $orderBy
       customerGroups: $customerGroups

--- a/src/features/customerList/tableTools/CustomerListTableTools.tsx
+++ b/src/features/customerList/tableTools/CustomerListTableTools.tsx
@@ -20,7 +20,12 @@ export interface CustomerListTableToolsProps<T> {
   className?: string;
   searchVal: string | undefined;
   searchBy: T;
-  searchByOptions: Array<{ value: T; label: string; options?: CustomerListTableToolsSearchByOptionOption[] }>;
+  searchByOptions: Array<{
+    value: T;
+    label: string;
+    options?: CustomerListTableToolsSearchByOptionOption[];
+    placeholder?: string;
+  }>;
   selectedCustomerIds: string[];
   isExporting: boolean;
   handleCustomersExport: () => Promise<void>;
@@ -102,7 +107,7 @@ const CustomerListTableTools = <T extends string>({
               className={styles.searchInput}
               id="searchSimilarCustomers"
               value={searchVal}
-              placeholder={searchBy === 'name' ? `${t('common.lastName')} ${t('common.firstName')}` : undefined}
+              placeholder={selectedSearchByOption?.placeholder}
               onChange={(e) => setSearchVal((e.target as HTMLInputElement).value)}
             />
           )}

--- a/src/features/customerList/tableTools/customerListTableTools.module.scss
+++ b/src/features/customerList/tableTools/customerListTableTools.module.scss
@@ -41,6 +41,5 @@
   input {
     background-color: $white;
   }
-  width: 25%;
   min-width: units(12);
 }

--- a/src/features/customerList/useCustomersQuery.ts
+++ b/src/features/customerList/useCustomersQuery.ts
@@ -46,6 +46,7 @@ type Config = Omit<CustomerListTableFilters, 'dateInterval'> & {
   email?: string;
   address?: string;
   stickerNumber?: string;
+  stickerSeason?: string;
   boatRegistrationNumber?: string;
   invoicingTypes?: InvoicingType[];
 };

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -320,7 +320,9 @@
       "phone": "Puhelinnumero",
       "email": "Sähköpostiosoite",
       "comment": "Huomiot",
-      "selectInvoicingTypePaperInvoice": "Laskutus paperisena"
+      "selectInvoicingTypePaperInvoice": "Laskutus paperisena",
+      "stickerNumberAndSeason": "Tarra ja kausi",
+      "stickerNumberAndSeasonPlaceholder": "Numero vuosi/vuosi"
     },
     "additionalServices": {
       "title": "Lisäpalvelu",

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -322,7 +322,7 @@
       "comment": "Huomiot",
       "selectInvoicingTypePaperInvoice": "Laskutus paperisena",
       "stickerNumberAndSeason": "Tarra ja kausi",
-      "stickerNumberAndSeasonPlaceholder": "Numero vuosi/vuosi"
+      "stickerNumberAndSeasonPlaceholder": "Nro alkuvuosi/loppuvuosi"
     },
     "additionalServices": {
       "title": "Lisäpalvelu",


### PR DESCRIPTION
## Description :sparkles:
This allows filtering searches by both sticker number and season combination. Backend with `stickerSeason` needs to be deployed first since this relies on the new filter.

Since queries to berthProfile are slow, triggering queries from input box too fast seems to cause errors from the backend (the responses will come eventually, but users see error notifications), there's slower debounce rate on input for queries to `berthProfile`. Users will see that UI is loading from the first key press so users won't notice the difference (since the query is slow anyway...).

Also, we need to discuss if the separate stickernumber -only filter is needed, for now the task was to keep both.

## Issues :bug:

### Closes :no_good_woman:
VEN-983
### Related :handshake:
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1538

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
![Screenshot 2022-12-02 at 9 55 30](https://user-images.githubusercontent.com/53874567/205243666-acf56f85-4a78-49b9-987a-a0c71d644c27.png)


## Additional notes :spiral_notepad:
