### PR TITLE
VEN-1530 wrong name in berth view

### DIFF
--- a/src/features/berthDetails/BerthDetails.tsx
+++ b/src/features/berthDetails/BerthDetails.tsx
@@ -8,6 +8,7 @@ import Section from '../../common/section/Section';
 import { formatDate } from '../../common/utils/format';
 import styles from './berthDetails.module.scss';
 import MaintenanceServicesPlaceholder from '../../common/maintenancePlaceholders/MaintenanceServicesPlaceholder';
+import { LeaseStatus } from '../../@types/__generated__/globalTypes';
 
 export interface Lease {
   customer: {
@@ -17,7 +18,7 @@ export interface Lease {
   };
   startDate: string;
   endDate: string;
-  status: string;
+  status: LeaseStatus;
   isActive: boolean;
 }
 
@@ -31,7 +32,7 @@ const BerthDetails = ({ leases, comment, onEdit }: BerthDetailsProps) => {
   const { t, i18n } = useTranslation();
 
   const expiredLeasesElements = leases
-    .filter((lease) => !lease.isActive)
+    .filter((lease) => !lease.isActive && lease.status === LeaseStatus.PAID)
     .map(({ startDate, endDate, customer }, i) => {
       return (
         <div key={i}>

--- a/src/features/harborView/HarborViewTable.tsx
+++ b/src/features/harborView/HarborViewTable.tsx
@@ -52,7 +52,10 @@ const HarborViewTable = ({
       Cell: ({ cell }: { cell: Cell<Berth> }) => {
         const isBerthActive = cell.row.original.isActive;
         if (!isBerthActive) return <StatusLabel type="error" label={t('harborView.berthProperties.inactive')} />;
-        if (cell.value) return <CustomerName disabled={!cell.value.isActiveLease} id={cell.value.customerId} />;
+        if (cell.value)
+          return (
+            <CustomerName disabled={!cell.value.isActiveLease} id={cell.value.customerId} displayPlaceholder={false} />
+          );
         return '';
       },
       Header: t('harborView.tableHeaders.customer') || '',

--- a/src/features/harborView/customerName/CustomerName.tsx
+++ b/src/features/harborView/customerName/CustomerName.tsx
@@ -12,9 +12,10 @@ export interface CustomerNameProps {
   id: string;
   linkTo?: string;
   disabled?: boolean;
+  displayPlaceholder?: boolean;
 }
 
-const CustomerName = ({ id, linkTo, disabled }: CustomerNameProps) => {
+const CustomerName = ({ id, linkTo, disabled, displayPlaceholder }: CustomerNameProps) => {
   const { t } = useTranslation();
   const { loading, data } = useQuery<CUSTOMER_NAME>(CUSTOMER_NAME_QUERY, {
     skip: !id,
@@ -23,6 +24,9 @@ const CustomerName = ({ id, linkTo, disabled }: CustomerNameProps) => {
     },
   });
 
+  if (!displayPlaceholder && !data) {
+    return null;
+  }
   if (loading) return <LoadingCell />;
   if (disabled && data?.profile)
     return <Text color="secondary">{`${data.profile.lastName} ${data.profile.firstName}`}</Text>;


### PR DESCRIPTION
## Description :sparkles:
There was some confusion as to how the previous lease names appear on the harbours list, since the list shows currently 1) all leases, regardless if they were active or not 2) previous season as last year. This means the (gray) names might not be from last summer, but actually last year, and they might have not been activated at all in the first place.

This fixes that by only displaying leases that have `status==PAID`. Also there was a request to not show anything if there were no customers, so now `CustomerName` displays empty string in place of "Nimi Puuttuu".

Note! This requires the backend update to be deployed (https://helsinkisolutionoffice.atlassian.net/browse/VEN-1541), since the season is resolved on the backend. Will work without as well, but the previousLease is not resolved as described here.

## Issues :bug:

### Closes :no_good_woman:
VEN-1530
### Related :handshake:
https://helsinkisolutionoffice.atlassian.net/browse/VEN-1541

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
