### PR TITLE
VEN-1543 Clear customer list search field after invoicing type selection

### DIFF
--- a/src/features/customerList/CustomerListContainer.tsx
+++ b/src/features/customerList/CustomerListContainer.tsx
@@ -175,7 +175,16 @@ const CustomerListContainer = () => {
       setSearchBy(SearchBy.NAME);
       setDisplayNotification(true);
     }
-  }, [customerListTableFilters, searchBy, setSearchBy]);
+  }, [customerListTableFilters, prevSearchBy, searchBy, setSearchBy]);
+
+  // Clear the search value if changed from invoicing type, so the
+  // value from the select box doesn't stay in the search field
+  useEffect(() => {
+    if (prevSearchBy === SearchBy.INVOICING_TYPE) {
+      setSearchVal('');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchBy]);
 
   const tableData = getCustomersData(profiles);
 


### PR DESCRIPTION
## Description :sparkles:
Small fix to clear the input field after selecting invoicing type. Currently the selection value is converted to the text in the input field after selecting invoicing type as filter, and then something else - this results to the string, for example, "ONLINE_PAYMENT" staying in the field. This fixes that by clearing the field with useEffect hook if changing from invoicing type.

## Issues :bug:

### Closes :no_good_woman:
ven-1543
### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
