### PR TITLE
Enable more caching

### DIFF
--- a/src/app/apolloClient.ts
+++ b/src/app/apolloClient.ts
@@ -106,10 +106,10 @@ const apolloClient = new ApolloClient({
   link: ApolloLink.from([authLink, errorLink, uploadLink]),
   defaultOptions: {
     watchQuery: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-and-network',
     },
     query: {
-      fetchPolicy: 'network-only',
+      fetchPolicy: 'cache-first',
     },
   },
   cache,

--- a/src/features/customerList/useCustomersQuery.ts
+++ b/src/features/customerList/useCustomersQuery.ts
@@ -87,7 +87,7 @@ export default function useCustomersQuery({
 
   const profilesQuery = useQuery<PROFILE_CUSTOMERS, PROFILE_CUSTOMERS_VARS>(PROFILE_CUSTOMERS_QUERY, {
     variables: sharedFilters,
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'cache-and-network',
     skip: activeQuery !== Query.PROFILE,
   });
 
@@ -99,7 +99,7 @@ export default function useCustomersQuery({
       harborIds,
       apiToken,
     },
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'cache-and-network',
     skip: activeQuery !== Query.BERTH_PROFILE,
   });
 
@@ -111,7 +111,7 @@ export default function useCustomersQuery({
       customerGroups: [CustomerGroup.COMPANY],
       apiToken,
     },
-    fetchPolicy: 'no-cache',
+    fetchPolicy: 'cache-and-network',
     skip: activeQuery !== Query.ORGANIZATION,
   });
 


### PR DESCRIPTION
Since there are still some issues with customer list queries, enable caching on apollo client to speed up the UI. This won't fix the underlying issue that the combined queries from our backend and Helsinki profile are just slow, but at least it will make the UI feel faster and for repeated queries, there's less waiting.

## Description :sparkles:

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
