### PR TITLE
docs: add info how to fix SassError on "yarn start" on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ yarn start
 
 Open [http://localhost:3000](http://localhost:3000) and take a look around.
 
+### Problems starting development environment
+
+#### Windows specific
+
+- `SassError: File to import not found or unreadable`, e.g. `@import 'colours';`
+  - Change all `:` characters to `;` in SASS_PATH, see [sass documentation](https://github.com/sass/sass/blob/embedded-protocol-2.1.0/js-api-doc/legacy/options.d.ts#L32-L35)
+
 ### Testing
 
 To run tests, run:


### PR DESCRIPTION
## Description :sparkles:

### docs: add info how to fix SassError on "yarn start" on Windows

refs VEN-1558 (noticed "yarn start" didn't work on Windows)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1558]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ