### PR TITLE
test: fix formatDate using tests on Windows by using env.TZ as timezone

### DIFF
--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -36,7 +36,14 @@ export const formatDate = (date: string | null, locale: string, withTime = false
     hour: '2-digit',
     minute: '2-digit',
   };
-  const options = withTime ? { ...dateOpts, ...timeOpts } : dateOpts;
+  const optionalTimeZoneOpts = process.env.TZ ? { timeZone: process.env.TZ } : {};
+  const options = withTime
+    ? {
+        ...dateOpts,
+        ...timeOpts,
+        ...optionalTimeZoneOpts,
+      }
+    : dateOpts;
 
   return new Date(date).toLocaleString(locale, options);
 };


### PR DESCRIPTION
## Description :sparkles:

### test: fix formatDate using tests on Windows by using env.TZ as timezone

formatDate:
 - tests using this didn't work on Windows, they returned wrong time
 - fixed on Windows also by using process.env.TZ as the timezone in
   formatDate function if process.env.TZ is set

refs VEN-1558 (trying to get the tests pass locally on Windows)

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1558](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1558]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ