### PR TITLE
VEN-1577 | fix(docker): use Amazon ECR as source, remove helsinkitest, fix packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,61 +1,69 @@
 # ===============================================
-FROM helsinkitest/node:14-slim as appbase
+FROM public.ecr.aws/docker/library/node:14-slim AS appbase
 # ===============================================
+USER root
+WORKDIR /app
+
 # Offical image has npm log verbosity as info. More info - https://github.com/nodejs/docker-node#verbosity
-ENV NPM_CONFIG_LOGLEVEL warn
+ENV NPM_CONFIG_LOGLEVEL=warn
 
 # set our node environment, either development or production
 # defaults to production, compose overrides this to development on build and run
 ARG NODE_ENV=production
-ENV NODE_ENV $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
 
 # Global npm deps in a non-root user directory
 ENV NPM_CONFIG_PREFIX=/app/.npm-global
 ENV PATH=$PATH:/app/.npm-global/bin
 
 # Yarn
-ENV YARN_VERSION 1.19.1
+ENV YARN_VERSION=1.19.1
 RUN yarn policies set-version $YARN_VERSION
 
-# Use non-root user
-USER appuser
+# Make sure appuser group and user exist
+COPY ./setup_user.sh /setup_user.sh
+RUN chmod a+x /setup_user.sh && /bin/sh -c /setup_user.sh && rm -f /setup_user.sh
 
 # Copy package.json and package-lock.json/yarn.lock files
 COPY package*.json *yarn* ./
 
 # Install npm dependencies
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH=/app/node_modules/.bin:$PATH
 
-USER root
-RUN apt-install.sh build-essential
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends build-essential
 
 # Install the actual app dependencies
-USER appuser
 RUN yarn install && yarn cache clean --force
 
-USER root
-RUN apt-cleanup.sh build-essential
+RUN apt-get remove -y build-essential \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/cache/apt/archives
 
 # =============================
-FROM appbase as development
+FROM appbase AS development
 # =============================
 
 # Set NODE_ENV to development in the development container
 ARG NODE_ENV=development
-ENV NODE_ENV $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
 
 # copy in our source code last, as it changes the most
 COPY --chown=appuser:appuser . .
+
+USER appuser
 
 # Bake package.json start command into the image
 CMD ["react-scripts", "start"]
 
 # ===================================
-FROM appbase as staticbuilder
+FROM appbase AS staticbuilder
 # ===================================
 
 ARG REACT_APP_ENV=development
-ENV REACT_APP_ENV $REACT_APP_ENV
+ENV REACT_APP_ENV=$REACT_APP_ENV
 
 ARG REACT_APP_API_URL
 ARG REACT_APP_BERTH_API_URL
@@ -79,7 +87,7 @@ COPY .prod/tsconfig.json ./
 RUN yarn build
 
 # =============================
-FROM nginx:1.17 as production
+FROM public.ecr.aws/nginx/nginx:1.18 AS production
 # =============================
 
 # Nginx runs with user "nginx" by default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   app:
     container_name: berth-reservation-admin
@@ -10,3 +9,6 @@ services:
       - /app/node_modules
     ports:
       - 3000:3000
+    # So that the development container doesn't exit after "docker compose up":
+    tty: true
+    stdin_open: true

--- a/package.json
+++ b/package.json
@@ -2,9 +2,21 @@
   "name": "berth-reservations-admin",
   "version": "2.4.0",
   "private": true,
+  "//": [
+    "graphql:",
+    "Package graphql is resolved to 15.9.0 in order to fix types generating ",
+    "using 'yarn types:generate'. Without this resolution, there are ",
+    "multiple versions of graphql installed and types generating fails."
+  ],
+  "resolutions": {
+    "graphql": "15.9.0"
+  },
   "dependencies": {
     "@apollo/react-hooks": "^3.1.5",
+    "@apollo/react-testing": "^3.1.4",
     "@sentry/browser": "^5.7.1",
+    "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^13.5.0",
     "@types/apollo-upload-client": "^8.1.3",
     "@types/classnames": "^2.2.9",
     "@types/enzyme": "^3.10.3",
@@ -32,6 +44,7 @@
     "fast-deep-equal": "^3.1.3",
     "focus-visible": "^5.1.0",
     "formik": "^2.1.4",
+    "graphql": "^15.9.0",
     "graphql-tag": "^2.10.3",
     "hds-react": "^1.10.0",
     "i18next": "^17.0.18",
@@ -83,12 +96,9 @@
     ]
   },
   "devDependencies": {
-    "@apollo/react-testing": "^3.1.4",
     "@testing-library/jest-dom": "^5.16.2",
-    "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^3.2.1",
     "@testing-library/testcafe": "^4.3.1",
-    "@testing-library/user-event": "^13.5.0",
     "apollo": "2.34.0",
     "babel-loader": "^8.0.6",
     "codecov": "^3.7.1",

--- a/setup_user.sh
+++ b/setup_user.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+existing_group=$(getent group 1000 | cut -d: -f1)
+if [[ -z "${existing_group}" ]]; then
+    # Create appuser group
+   groupadd --gid 1000 appuser
+elif [[ "${existing_group}" != "appuser" ]]; then
+   # Change group name to appuser
+   groupmod -n appuser "${existing_group}"
+fi
+
+
+existing_user=$(id -nu 1000 2>/dev/null)
+if [[ -z "${existing_user}" ]]; then
+    # Add an application user
+    useradd --uid 1000 --gid appuser --create-home --shell /bin/bash appuser
+else
+    # Change user name to appuser
+    usermod -l appuser "${existing_user}"
+
+    # Add user to appuser group
+    gpasswd -a appuser appuser
+fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -8558,17 +8558,10 @@ graphql-tag@^2.10.1, graphql-tag@^2.10.3:
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
   integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
 
-"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0":
-  version "15.8.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
-  integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
-
-graphql@^14.5.3:
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.6.0.tgz#57822297111e874ea12f5cd4419616930cd83e49"
-  integrity sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==
-  dependencies:
-    iterall "^1.2.2"
+"graphql@14.0.2 - 14.2.0 || ^14.3.1 || ^15.0.0", graphql@15.9.0, graphql@^14.5.3, graphql@^15.9.0:
+  version "15.9.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.9.0.tgz#4e8ca830cfd30b03d44d3edd9cac2b0690304b53"
+  integrity sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -10022,11 +10015,6 @@ istanbul-reports@^2.2.6:
   integrity sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==
   dependencies:
     html-escaper "^2.0.0"
-
-iterall@^1.2.2:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
-  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jake@^10.8.5:
   version "10.8.7"


### PR DESCRIPTION
## Description :sparkles:

### fix(docker): use Amazon ECR as source, remove helsinkitest, fix packages

Removing graphql dependency in 25b40bf6d421cb76bd2e9a690d7fc37ba91a2907
broke building the Dockerfile. Add back the graphql dependency and
resolve graphql packages to use 15.9.0 in order not to get multiple
installed versions of graphql, which would result in
"yarn types:generate" failing.

Tried resolving graphql to 14.7.0 but that still broke the
"yarn types:generate".

Move the following from devDependencies to dependencies so
"docker compose up --build" and opening the http://localhost:3000/
works:
 - @apollo/react-testing
 - @testing-library/react
 - @testing-library/user-event

Set `tty` and `stdin_open` to `true` in docker-compose.yml in order to
make the "docker compose up --build" not exit right after running
"react-scripts start".

Remove deprecated version number from docker-compose.yml.

refs VEN-1577

## Issues :bug:

[VEN-1577](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1577)

### Closes :no_good_woman:

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1577]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ