### PR TITLE
VEN-1575 | feat: add 14% and 25.5% VAT%, fix formatting non-integer percentages

### DIFF
--- a/src/@types/__generated__/globalTypes.ts
+++ b/src/@types/__generated__/globalTypes.ts
@@ -9,7 +9,9 @@
 
 export enum AdditionalProductTaxEnum {
   TAX_10_00 = "TAX_10_00",
+  TAX_14_00 = "TAX_14_00",
   TAX_24_00 = "TAX_24_00",
+  TAX_25_50 = "TAX_25_50",
 }
 
 export enum AdditionalProductType {
@@ -179,6 +181,7 @@ export enum PhoneType {
 
 export enum PlaceProductTaxEnum {
   TAX_24_00 = "TAX_24_00",
+  TAX_25_50 = "TAX_25_50",
 }
 
 export enum PriceTier {

--- a/src/common/utils/__tests__/format.test.ts
+++ b/src/common/utils/__tests__/format.test.ts
@@ -67,6 +67,37 @@ describe('format', () => {
     it('should return the right value', () => {
       expect(formatPercentage(10, 'fi')).toEqual('10 %');
     });
+
+    it.each([
+      // Finnish locale
+      [10, 'fi', '10 %'],
+      [14, 'fi', '14 %'],
+      [24, 'fi', '24 %'],
+      [25.5, 'fi', '25,5 %'],
+      // Swedish locale
+      [10, 'sv', '10 %'],
+      [14, 'sv', '14 %'],
+      [24, 'sv', '24 %'],
+      [25.5, 'sv', '25,5 %'],
+      // English locale
+      [10, 'en', '10%'],
+      [14, 'en', '14%'],
+      [24, 'en', '24%'],
+      [25.5, 'en', '25.5%'],
+    ])('formatPercentage(%s, "%s") == "%s"', (value, locale, expectedResult) => {
+      expect(formatPercentage(value, locale)).toBe(expectedResult);
+    });
+
+    it.each([
+      [25.555, 'fi', '25,56 %'],
+      [25.555, 'sv', '25,56 %'],
+      [25.555, 'en', '25.56%'],
+      [14.333333333, 'fi', '14,33 %'],
+      [16.654321, 'sv', '16,65 %'],
+      [27.499999999999999, 'en', '27.5%'],
+    ])('formatPercentage(%s, "%s") == "%s" with rounding to max. two decimals', (value, locale, expectedResult) => {
+      expect(formatPercentage(value, locale)).toBe(expectedResult);
+    });
   });
 
   describe('formatBytes', () => {

--- a/src/common/utils/__tests__/translations.test.ts
+++ b/src/common/utils/__tests__/translations.test.ts
@@ -20,9 +20,6 @@ import {
   BerthMooringType,
   PriceTier,
 } from '../../../@types/__generated__/globalTypes';
-import { formatPercentage } from '../format';
-
-jest.mock('../format');
 
 describe('translations', () => {
   describe('getMooringTypeTKey', () => {
@@ -106,14 +103,41 @@ describe('translations', () => {
       jest.resetAllMocks();
     });
 
-    test('each provided value of type AdditionalProductTaxEnum should have a corresponding formatted value', () => {
+    test('each provided value of type AdditionalProductTaxEnum should be mapped to a unique different value', () => {
       const taxes = Object.values(AdditionalProductTaxEnum);
 
+      const results: string[] = [];
+
       taxes.forEach((tax) => {
-        getProductTax(tax, 'fi');
+        const result = getProductTax(tax, 'fi');
+        expect(result).not.toBe(tax); // Should change input value
+        expect(typeof result).toBe('string'); // Should be string
+        expect(result).not.toBe(''); // Should be non-empty string
+        results.push(result);
       });
 
-      expect(formatPercentage).toHaveBeenCalledTimes(taxes.length);
+      expect(results.length).toBe(taxes.length); // All input values should be mapped
+      expect(new Set(results).size).toBe(results.length); // All output values should be unique
+    });
+
+    test.each([
+      // Finnish locale
+      [AdditionalProductTaxEnum.TAX_10_00, 'fi', '10 %'],
+      [AdditionalProductTaxEnum.TAX_14_00, 'fi', '14 %'],
+      [AdditionalProductTaxEnum.TAX_24_00, 'fi', '24 %'],
+      [AdditionalProductTaxEnum.TAX_25_50, 'fi', '25,5 %'],
+      // Swedish locale
+      [AdditionalProductTaxEnum.TAX_10_00, 'sv', '10 %'],
+      [AdditionalProductTaxEnum.TAX_14_00, 'sv', '14 %'],
+      [AdditionalProductTaxEnum.TAX_24_00, 'sv', '24 %'],
+      [AdditionalProductTaxEnum.TAX_25_50, 'sv', '25,5 %'],
+      // English locale
+      [AdditionalProductTaxEnum.TAX_10_00, 'en', '10%'],
+      [AdditionalProductTaxEnum.TAX_14_00, 'en', '14%'],
+      [AdditionalProductTaxEnum.TAX_24_00, 'en', '24%'],
+      [AdditionalProductTaxEnum.TAX_25_50, 'en', '25.5%'],
+    ])('getProductTax(%s, "%s") == "%s"', (tax, locale, expectedResult) => {
+      expect(getProductTax(tax, locale)).toBe(expectedResult);
     });
 
     it('should fallback to the actual value from the backend if there is no match during the runtime', () => {

--- a/src/common/utils/format.ts
+++ b/src/common/utils/format.ts
@@ -64,6 +64,7 @@ export const formatPrice = (value: number, locale: string, percentage?: number) 
 export const formatPercentage = (value: number, locale: string) => {
   return new Intl.NumberFormat(locale, {
     style: 'percent',
+    maximumFractionDigits: 2,
   }).format(value / 100);
 };
 

--- a/src/common/utils/translations.ts
+++ b/src/common/utils/translations.ts
@@ -113,8 +113,12 @@ export const getProductTax = (tax: AdditionalProductTaxEnum, locale: string) => 
   switch (tax) {
     case AdditionalProductTaxEnum.TAX_10_00:
       return formatPercentage(10, locale);
+    case AdditionalProductTaxEnum.TAX_14_00:
+      return formatPercentage(14, locale);
     case AdditionalProductTaxEnum.TAX_24_00:
       return formatPercentage(24, locale);
+    case AdditionalProductTaxEnum.TAX_25_50:
+      return formatPercentage(25.5, locale);
 
     default:
       return tax;


### PR DESCRIPTION
## Description :sparkles:

### feat: add 14% and 25.5% VAT%, fix formatting non-integer percentages

refs VEN-1575

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ