### PR TITLE
VEN-1575 | fix: change all "alv 24 %" to "alv 25,5 %" in hardcoded translations

### DIFF
--- a/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
+++ b/src/features/pricing/__tests__/__snapshots__/Pricing.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`PricingPage renders normally 1`] = `
           <section
             class="body"
           >
-            Perushinta. Hinnat sisältävät alv 24 %.
+            Perushinta. Hinnat sisältävät alv 25,5 %.
           </section>
         </article>
         <div>
@@ -312,7 +312,7 @@ exports[`PricingPage renders normally 1`] = `
           <section
             class="body"
           >
-            Perushinta. Hinnat sisältävät alv 24 %.
+            Perushinta. Hinnat sisältävät alv 25,5 %.
           </section>
         </article>
         <div>
@@ -537,7 +537,7 @@ exports[`PricingPage renders normally 1`] = `
           <section
             class="body"
           >
-            Perushinta. Hinnat sisältävät alv 24 %.
+            Perushinta. Hinnat sisältävät alv 25,5 %.
           </section>
         </article>
         <div>
@@ -723,7 +723,7 @@ exports[`PricingPage renders normally 1`] = `
           <section
             class="body"
           >
-            Perushinta. Hinnat sisältävät alv 24 %.
+            Perushinta. Hinnat sisältävät alv 25,5 %.
           </section>
         </article>
         <div>
@@ -1056,7 +1056,7 @@ exports[`PricingPage renders normally 1`] = `
         <section
           class="body"
         >
-          Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.
+          Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 25,5 %.
         </section>
       </article>
       <div>
@@ -1298,7 +1298,7 @@ exports[`PricingPage renders normally 1`] = `
         <section
           class="body"
         >
-          Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.
+          Lisähinnat venepaikoille. Hinnat sisältävät alv 25,5 %.
         </section>
       </article>
       <div>

--- a/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
+++ b/src/features/pricing/berthPricing/__tests__/__snapshots__/BerthPricing.test.tsx.snap
@@ -27,7 +27,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -213,7 +213,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -399,7 +399,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -585,7 +585,7 @@ exports[`BerthPricing renders noData message when there is no data 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -787,7 +787,7 @@ exports[`BerthPricing renders normally 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -1061,7 +1061,7 @@ exports[`BerthPricing renders normally 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -1286,7 +1286,7 @@ exports[`BerthPricing renders normally 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -1472,7 +1472,7 @@ exports[`BerthPricing renders normally 1`] = `
       <section
         class="body"
       >
-        Perushinta. Hinnat sisältävät alv 24 %.
+        Perushinta. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>

--- a/src/features/pricing/harborServicePricing/__tests__/__snapshots__/HarborServicePricing.test.tsx.snap
+++ b/src/features/pricing/harborServicePricing/__tests__/__snapshots__/HarborServicePricing.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`HarborServicePricing renders noData message when there is no data 1`] =
       <section
         class="body"
       >
-        Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.
+        Lisähinnat venepaikoille. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -194,7 +194,7 @@ exports[`HarborServicePricing renders normally 1`] = `
       <section
         class="body"
       >
-        Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.
+        Lisähinnat venepaikoille. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>

--- a/src/features/pricing/winterStoragePricing/__tests__/__snapshots__/WinterStoragePricing.test.tsx.snap
+++ b/src/features/pricing/winterStoragePricing/__tests__/__snapshots__/WinterStoragePricing.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`WinterStoragePricing renders noData message when there is no data 1`] =
       <section
         class="body"
       >
-        Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.
+        Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>
@@ -227,7 +227,7 @@ exports[`WinterStoragePricing renders normally 1`] = `
       <section
         class="body"
       >
-        Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.
+        Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 25,5 %.
       </section>
     </article>
     <div>

--- a/src/locales/fi.json
+++ b/src/locales/fi.json
@@ -765,7 +765,7 @@
     "editModalHeading": "Hinnaston muokkaus",
     "berths": {
       "title": "Venepaikka",
-      "description": "Perushinta. Hinnat sisältävät alv 24 %.",
+      "description": "Perushinta. Hinnat sisältävät alv 25,5 %.",
       "defaultProducts": "Venepaikat",
       "vasikkasaari": "Vasikkasaaren venesatama",
       "dinghy": "Jollapaikat",
@@ -779,7 +779,7 @@
     },
     "winterStorage": {
       "title": "Talvisäilytyspaikka",
-      "description": "Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 24 %.",
+      "description": "Hinta €/m2 sisältäen palvelut. Hinnat sisältävät alv 25,5 %.",
       "area": "Alue",
       "privateCustomer": "Yksityinen",
       "company": "Yritys",
@@ -787,7 +787,7 @@
     },
     "harborServices": {
       "title": "Satamapalvelut",
-      "description": "Lisähinnat venepaikoille. Hinnat sisältävät alv 24 %.",
+      "description": "Lisähinnat venepaikoille. Hinnat sisältävät alv 25,5 %.",
       "service": "Palvelu",
       "price": "Hinta",
       "unit": "Yksikkö",


### PR DESCRIPTION
## Description :sparkles:

### fix: change all "alv 24 %" to "alv 25,5 %" in hardcoded translations

refs VEN-1575

## Issues :bug:

### Closes :no_good_woman:

### Related :handshake:

[VEN-1575](https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575)

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[VEN-1575]: https://helsinkisolutionoffice.atlassian.net/browse/VEN-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ